### PR TITLE
Issues/fix warnings2

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -4098,7 +4098,7 @@ int cgroup_read_value_begin(const char *controller, const char *path,
 {
 	int ret = 0;
 	char *ret_c = NULL;
-	char stat_file[FILENAME_MAX];
+	char stat_file[FILENAME_MAX + sizeof(name)];
 	char stat_path[FILENAME_MAX];
 	FILE *fp;
 

--- a/src/api.c
+++ b/src/api.c
@@ -264,7 +264,7 @@ int cg_chmod_file(FTS *fts, FTSENT *ent, mode_t dir_mode,
  */
 static int cg_chmod_recursive_controller(char *path, mode_t dir_mode,
 		int dirm_change, mode_t file_mode, int filem_change,
-		int owner_is_umask, const char const **ignore_list)
+		int owner_is_umask, const char * const *ignore_list)
 {
 	int ret = 0;
 	int final_ret =0;

--- a/src/api.c
+++ b/src/api.c
@@ -2257,7 +2257,7 @@ static int cg_delete_cgroup_controller_recursive(char *cgroup_name,
 	void *handle;
 	struct cgroup_file_info info;
 	int level, group_len;
-	char child_name[FILENAME_MAX];
+	char child_name[FILENAME_MAX + 1];
 
 	cgroup_dbg("Recursively removing %s:%s\n", controller, cgroup_name);
 

--- a/src/api.c
+++ b/src/api.c
@@ -114,7 +114,7 @@ const char * const cgroup_strerror_codes[] = {
 	"Failed to remove a non-empty group",
 };
 
-static const char const *cgroup_ignored_tasks_files[] = { "tasks", NULL };
+static const char * const cgroup_ignored_tasks_files[] = { "tasks", NULL };
 
 #ifndef UNIT_TEST
 static int cg_get_cgroups_from_proc_cgroups(pid_t pid, char *cgroup_list[],

--- a/src/api.c
+++ b/src/api.c
@@ -3227,6 +3227,7 @@ static int cgroup_create_template_group(char *orig_group_name,
 		ret = ECGOTHER;
 		last_errno = errno;
 		free(template_name);
+		template_name = NULL;
 		goto end;
 	}
 

--- a/src/api.c
+++ b/src/api.c
@@ -81,7 +81,7 @@ __thread char *cg_namespace_table[CG_CONTROLLER_MAX];
 pthread_rwlock_t cg_mount_table_lock = PTHREAD_RWLOCK_INITIALIZER;
 struct cg_mount_table_s cg_mount_table[CG_CONTROLLER_MAX];
 
-const char const *cgroup_strerror_codes[] = {
+const char * const cgroup_strerror_codes[] = {
 	"Cgroup is not compiled in",
 	"Cgroup is not mounted",
 	"Cgroup does not exist",

--- a/src/api.c
+++ b/src/api.c
@@ -4173,7 +4173,7 @@ int cgroup_read_stats_begin(const char *controller, const char *path,
 				void **handle, struct cgroup_stat *cgroup_stat)
 {
 	int ret = 0;
-	char stat_file[FILENAME_MAX];
+	char stat_file[FILENAME_MAX + sizeof(".stat")];
 	char stat_path[FILENAME_MAX];
 	FILE *fp;
 

--- a/src/config.c
+++ b/src/config.c
@@ -1372,7 +1372,7 @@ out_error:
 int cgroup_unload_cgroups(void)
 {
 	int error = 0;
-	void *ctrl_handle;
+	void *ctrl_handle = NULL;
 	int ret = 0;
 	char *curr_path = NULL;
 	struct cgroup_mount_point info;

--- a/src/config.c
+++ b/src/config.c
@@ -652,6 +652,7 @@ static int cgroup_config_ajdust_mount_options(struct cg_mount_table_s *mount,
 				if (controller == NULL)
 					break;
 				strncpy(mount->name, controller, sizeof(mount->name));
+				mount->name[sizeof(mount->name)-1] = '\0';
 			}
 
 			if (strncmp(token, "nodev", strlen("nodev")) == 0) {

--- a/src/daemon/cgrulesengd.c
+++ b/src/daemon/cgrulesengd.c
@@ -1009,11 +1009,11 @@ void cgre_catch_term(int signum)
  */
 static int cgre_parse_syslog_facility(const char *arg)
 {
-    if (arg == NULL)
-	return 0;
+	if (arg == NULL)
+		return 0;
 
-    if (strlen(arg) > 1)
-	return 0;
+	if (strlen(arg) > 1)
+		return 0;
 
 	switch (arg[0]) {
 	case '0':

--- a/src/daemon/cgrulesengd.c
+++ b/src/daemon/cgrulesengd.c
@@ -792,9 +792,9 @@ static int cgre_create_netlink_socket_process_msg(void)
 	}
 
 close_and_exit:
-	if (sk_nl > 0)
+	if (sk_nl >= 0)
 		close(sk_nl);
-	if (sk_unix > 0)
+	if (sk_unix >= 0)
 		close(sk_unix);
 	return rc;
 }

--- a/src/parse.y
+++ b/src/parse.y
@@ -45,9 +45,9 @@ int yywrap(void)
 	int val;
 	struct cgroup_dictionary *values;
 }
-%type <name> ID DEFAULT
+%type <name> ID DEFAULT group_name
 %type <val> mountvalue_conf mount task_namevalue_conf admin_namevalue_conf
-%type <val> admin_conf task_conf task_or_admin group_conf group start group_name
+%type <val> admin_conf task_conf task_or_admin group_conf group start
 %type <val> namespace namespace_conf default default_conf
 %type <values> namevalue_conf
 %type <val> template template_conf

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -196,7 +196,9 @@ int cgroup_add_value_string(struct cgroup_controller *controller,
 		return ECGCONTROLLERCREATEFAILED;
 
 	strncpy(cntl_value->name, name, sizeof(cntl_value->name));
+	cntl_value->name[sizeof(cntl_value->name)-1] = '\0';
 	strncpy(cntl_value->value, value, sizeof(cntl_value->value));
+	cntl_value->value[sizeof(cntl_value->value)-1] = '\0';
 	cntl_value->dirty = true;
 	controller->values[controller->index] = cntl_value;
 	controller->index++;

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -407,6 +407,7 @@ int cgroup_set_value_string(struct cgroup_controller *controller,
 		struct control_value *val = controller->values[i];
 		if (!strcmp(val->name, name)) {
 			strncpy(val->value, value, CG_VALUE_MAX);
+			val->value[sizeof(val->value)-1] = '\0';
 			val->dirty = true;
 			return 0;
 		}


### PR DESCRIPTION
This patchset fixes several compiler warnings in the
v0.42.rc1 libcgroup release candidate.

The first patch also likely fixes a segfault on systems
with a newer version of bison, but I don't have enough
testing in to unequivocally say this.

I really like the recommended solutions outlined in this
whitepaper [1] for dealing with string truncation, but
with the minimal number of tests in place, I don't feel
comfortable making the recommended changes this late in
a release.  Most of the offending lines of code are using
strings with 4096 characters for the path which should
meet the needs of 99%+ of our users.  I would prefer
adding a release note rather than make risky last minute
changes.

Changes from v1 to v2:
* Gave credit to Nikola and Michal on patch #1
* Added six more patches for issues uncovered by Coverity
* Updated the cover letter comment regarding the status of
  truncated strings in libcgroup

The branch is available on github here:
    https://github.com/drakenclimber/libcgroup/tree/issues/fix_warnings2
Code coverage remained unchanged:
    https://coveralls.io/builds/27964992
All automated tests passed:
    https://github.com/drakenclimber/libcgroup/runs/378125130

[1] https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8/