### PR TITLE
Fix small issues with distribution zip files

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,9 +10,9 @@ fi
 
 # configure googletest
 git submodule update --init --recursive
-pushd googletest
-autoreconf -i
-./configure
+pushd googletest/googletest
+git checkout release-1.8.0
+cmake -DBUILD_SHARED_LIBS=ON .
 make
 popd
 

--- a/tests/gunit/004-cgroup_compare_ignore_rule.cpp
+++ b/tests/gunit/004-cgroup_compare_ignore_rule.cpp
@@ -117,7 +117,7 @@ TEST_F(CgroupCompareIgnoreRuleTest, CombinedControllers)
 		"13:cpu,cpuacct:/containercg";
 	char rule_controller[] = "cpuacct";
 	char procname[] = "docker";
-	struct cgroup_rule rule;
+	struct cgroup_rule rule = {0};
 	pid_t pid = 6789;
 	bool ret;
 

--- a/tests/gunit/Makefile.am
+++ b/tests/gunit/Makefile.am
@@ -26,21 +26,13 @@ AM_CPPFLAGS = -I$(top_srcdir)/include \
 	      -std=c++11 \
 	      -DSTATIC= \
 	      -DUNIT_TEST
-LDADD = ../../src/.libs/libcgroupfortesting.la \
-	$(top_srcdir)/googletest/googletest/lib/libgtest.la \
-	$(top_srcdir)/googletest/googletest/lib/libgtest_main.la
+LDADD = $(top_builddir)/src/.libs/libcgroupfortesting.la
 
-EXTRA_DIST = $(top_srcdir)/googletest/googletest/lib/libgtest.la \
-	     $(top_srcdir)/googletest/googletest/lib/libgtest_main.la \
-	     $(top_srcdir)/googletest/googletest/lib/.libs \
-	     $(top_srcdir)/googletest/googletest/include
+EXTRA_DIST = $(top_srcdir)/googletest/googletest/libgtest.so \
+	     $(top_srcdir)/googletest/googletest/libgtest_main.so \
+	     $(top_srcdir)/googletest/googletest/include \
+	     libcgroup_unittest.map
 
-libgtest_la_SOURCES = libcgroup_unittest.map
-libgtest_la_CPPFLAGS = -I$(top_builddir)/googletest/googletest/include \
-		       -I$(top_builddir)/googletest/googletest
-libgtest_la_LDFLAGS = -lpthread
-
-check_LTLIBRARIES = libgtest.la
 check_PROGRAMS = gtest
 TESTS = gtest
 
@@ -50,3 +42,5 @@ gtest_SOURCES = gtest.cpp \
 		003-cg_get_cgroups_from_proc_cgroups.cpp \
 		004-cgroup_compare_ignore_rule.cpp \
 		005-cgroup_compare_wildcard_procname.cpp
+gtest_LDFLAGS = -L$(top_builddir)/googletest/googletest -l:libgtest.so \
+		-rpath $(abs_top_builddir)/googletest/googletest


### PR DESCRIPTION
Googletest is finicky to get properly bundled within the zip.  This commit fixes that.

When testing the zip on Fedora 30, I noticed a small bug in a test and fixed it as well.