### PR TITLE
Paralell build fix #7

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,7 @@
 @CODE_COVERAGE_RULES@
 
+BUILT_SOURCES = parse.c parse.h
+
 if WITH_BINDINGS
 BINDINGS_SUBDIR = bindings
 endif


### PR DESCRIPTION
All source soce files which first needs to be generated needs to be listed in
BUILT_SOURCES.
This patch adds to that automake variable parse.c and parse.h because they are
listed below in libcgroup_la_SOURCES.