### PR TITLE
Add cgroup v2 support to cgcreate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	fetchRecurseSubmodules = true
 [submodule "tests"]
 	path = tests
-	url = https://github.com/libcgroup/libcgroup-tests.git
+	url = https://github.com/drakenclimber/libcgroup-tests.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ script:
 
 after_failure:
   - cat tests/ftests/test-suite.log
+  - cat tests/gunit/test-suite.log
 
 after_success:
   - coveralls --exclude tests --exclude googletest --exclude samples --gcov-options '\-lp'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,7 @@ git submodule update --init --recursive
 
 # configure libcgroup-tests
 pushd tests
-git checkout master
+git checkout issues/cgcreate
 popd
 
 # configure googletest

--- a/src/api.c
+++ b/src/api.c
@@ -5306,4 +5306,23 @@ int cgroup_get_subsys_mount_point_end(void **handle)
 	return 0;
 }
 
+int cgroup_get_controller_version(const char * const controller,
+		enum cg_version_t * const version)
+{
+	int i;
 
+	if (!version)
+		return ECGINVAL;
+
+	*version = CGROUP_UNK;
+
+	for (i = 0; cg_mount_table[i].name[0] != '\0'; i++) {
+		if (strncmp(cg_mount_table[i].name, controller,
+				sizeof(cg_mount_table[i].name)) == 0) {
+			*version = cg_mount_table[i].version;
+			return 0;
+		}
+	}
+
+	return ECGROUPNOTEXIST;
+}

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -340,6 +340,9 @@ int cgroup_set_values_recursive(const char * const base,
 int cgroup_chown_chmod_tasks(const char * const cg_path,
 			     uid_t uid, gid_t gid, mode_t fperm);
 
+int cgroupv2_subtree_control(const char *path, const char *ctrl_name,
+			     bool enable);
+
 #endif /* UNIT_TEST */
 
 __END_DECLS

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -114,6 +114,7 @@ struct cg_mount_point {
 };
 
 enum cg_version_t {
+	CGROUP_UNK = 0,
 	CGROUP_V1,
 	CGROUP_V2,
 };
@@ -297,6 +298,15 @@ extern void cgroup_dictionary_iterator_end(void **handle);
  */
 int cg_chmod_path(const char *path, mode_t mode, int owner_is_umask);
 
+/**
+ * Get the cgroup version of a controller.  Version is set to CGROUP_UNK
+ * if the version cannot be determined.
+ *
+ * @param controller The controller of interest
+ * @param version The version of the controller
+ */
+int cgroup_get_controller_version(const char * const controller,
+		enum cg_version_t * const version);
 /**
  * Functions that are defined as STATIC can be placed within the UNIT_TEST
  * ifdef.  This will allow them to be included in the unit tests while

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -324,6 +324,9 @@ int cgroup_process_v1_mnt(char *controllers[], struct mntent *ent,
 
 int cgroup_process_v2_mnt(struct mntent *ent, int *mnt_tbl_idx);
 
+int cgroup_set_values_recursive(const char * const base,
+	const struct cgroup_controller * const controller);
+
 #endif /* UNIT_TEST */
 
 __END_DECLS

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -327,6 +327,9 @@ int cgroup_process_v2_mnt(struct mntent *ent, int *mnt_tbl_idx);
 int cgroup_set_values_recursive(const char * const base,
 	const struct cgroup_controller * const controller);
 
+int cgroup_chown_chmod_tasks(const char * const cg_path,
+			     uid_t uid, gid_t gid, mode_t fperm);
+
 #endif /* UNIT_TEST */
 
 __END_DECLS


### PR DESCRIPTION
This patchset was sent to the libcg-devel mailing list in July:
https://sourceforge.net/p/libcg/mailman/message/37074048/

This patchset adds cgroup v2 support to cgcreate.

Since the automated tests have been split into a separate git repo,
those patches will come out in a separate patchset.

Note that the functional test suite still does not support cgroup
v2.  I have been able to test the vast majority of the new code via
unit tests, and the code coverage is excellent... But I don't like
the technical debt that is accumulating by not having cgroup v2
functional tests in place.

For the time being, I tested the changes by hand under a variety of
scenarios:
* Create a single cgroup v1 cgroup
* Create a single cgroup v2 cgroup
* Create a hierarchy of v1 cgroups
* Create a hierarchy of v2 cgroups
* Create a v1 and a v2 cgroup at the same time
* Create a v1 and v2 hierarchy at the same time

Code is available on github here:
https://github.com/drakenclimber/libcgroup/tree/issues/cgcreate

Automated test results are passing and are available here:
https://travis-ci.com/github/drakenclimber/libcgroup/builds/177698810

Code coverage increased by 1% and is now at 20.53%:
https://coveralls.io/builds/32409091