### PR TITLE
api.c: Fix erroneous error handling in cgroup_set_values_recursive()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1913,13 +1913,7 @@ STATIC int cgroup_set_values_recursive(const char * const base,
 		free(path);
 		path = NULL;
 
-		/* don't consider error in files directly written by
-		 * the user as fatal */
-		if (ret && !controller->values[j]->dirty) {
-			ret = 0;
-			continue;
-		}
-		if (ret)
+		if (error)
 			goto err;
 
 		controller->values[j]->dirty = false;


### PR DESCRIPTION
Ignore the positive length returned by asprintf() and only act
upon the error code returned from cg_set_control_value().  Previously
cgroup_set_values_recursive() mishandled the error handling when
the value's dirty flag was set.

Reported-by: Github User bharani-viswas
Fixes: 092e4aeb0416f ("api.c: Refactor duplicate logic in cgroup modify and create")
Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>

Fixes Issue #21 