### PR TITLE
Run tests outside of a container

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,7 @@
 #
 # Continuous Integration Workflow for libcgroup
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -67,7 +67,9 @@ jobs:
       run: make check
     - name: Display test logs
       if: ${{ always() }}
-      run: cat tests/ftests/ftests.sh.log
+      run: |
+        cat tests/ftests/ftests.sh.log
+        cat tests/ftests/ftests-nocontainer.sh.log
     - name: Archive test logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v2
@@ -110,7 +112,9 @@ jobs:
       run: make check
     - name: Display test logs
       if: ${{ always() }}
-      run: cat tests/ftests/ftests.sh.log
+      run: |
+        cat tests/ftests/ftests.sh.log
+        cat tests/ftests/ftests-nocontainer.sh.log
     - name: Archive test logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
See the accompanying libcgroup-tests patchset.  This patch
adds logging of the no-container functional test log files.
Note that the no-container tests are automatically invoked
by `make check`, so no changes are required there.

Code is available here:
https://github.com/drakenclimber/libcgroup/tree/issues/nocontainer

Tests are available here:
https://github.com/drakenclimber/libcgroup-tests/tree/issues/nocontainer

Code coverage remained the same at 31.5%:
https://coveralls.io/builds/36846105

Test results are available here:
https://github.com/drakenclimber/libcgroup/runs/1826371745