### PR TITLE
Refactor cgget

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1460,8 +1460,8 @@ static char *cg_concat_path(const char *pref, const char *suf, char *path)
 
 /* Call with cg_mount_table_lock taken */
 /* path value have to have size at least FILENAME_MAX */
-static char *cg_build_path_locked(const char *name, char *path,
-						const char *type)
+char *cg_build_path_locked(const char *name, char *path,
+			   const char *type)
 {
 	int i;
 	for (i = 0; cg_mount_table[i].name[0] != '\0'; i++) {

--- a/src/api.c
+++ b/src/api.c
@@ -2965,8 +2965,8 @@ static int cg_rd_ctrl_file(const char *subsys, const char *cgroup,
 /*
  * Call this function with required locks taken.
  */
-static int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup,
-			struct cgroup_controller *cgc, int cg_index)
+int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup,
+		    struct cgroup_controller *cgc, int cg_index)
 {
 	char *ctrl_name = NULL;
 	char *ctrl_file = NULL;

--- a/src/api.c
+++ b/src/api.c
@@ -384,7 +384,7 @@ static char *cgroup_basename(const char *path)
 	return base;
 }
 
-static int cgroup_test_subsys_mounted(const char *name)
+int cgroup_test_subsys_mounted(const char *name)
 {
 	int i;
 

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -351,6 +351,14 @@ int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup,
 		    struct cgroup_controller *cgc, int cg_index);
 
 /**
+ * Given a controller name, test if it's mounted
+ *
+ * @param ctrl_name Controller name
+ * @return 1 if mounted, 0 if not mounted
+ */
+int cgroup_test_subsys_mounted(const char *ctrl_name);
+
+/**
  * Functions that are defined as STATIC can be placed within the UNIT_TEST
  * ifdef.  This will allow them to be included in the unit tests while
  * remaining static in a normal libcgroup library build.

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -322,6 +322,20 @@ int cgroup_build_tasks_procs_path(char * const path,
 				  const char * const ctrl_name);
 
 /**
+ * Build the full path to the controller/setting
+ *
+ * @param setting Cgroup virtual filename/setting (optional)
+ * @param path Output variable to contain the concatenated path
+ * @param controller Cgroup controller name
+ *
+ * @return If successful, a valid pointer to the concatenated path
+ *
+ * @note The cg_mount_table_lock must be held prior to calling this function
+ */
+char *cg_build_path_locked(const char *setting, char *path,
+			   const char *controller);
+
+/**
  * Functions that are defined as STATIC can be placed within the UNIT_TEST
  * ifdef.  This will allow them to be included in the unit tests while
  * remaining static in a normal libcgroup library build.

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -19,6 +19,7 @@
 __BEGIN_DECLS
 
 #include "config.h"
+#include <dirent.h>
 #include <fts.h>
 #include <libcgroup.h>
 #include <limits.h>
@@ -334,6 +335,20 @@ int cgroup_build_tasks_procs_path(char * const path,
  */
 char *cg_build_path_locked(const char *setting, char *path,
 			   const char *controller);
+
+/**
+ * Given a cgroup controller and a setting within it, populate the setting's
+ * value
+ *
+ * @param ctrl_dir dirent representation of the setting, e.g. memory.stat
+ * @param cgroup current cgroup
+ * @param cgc current cgroup controller
+ * @param cg_index Index into the cg_mount_table of the cgroup
+ *
+ * @note The cg_mount_table_lock must be held prior to calling this function
+ */
+int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup,
+		    struct cgroup_controller *cgc, int cg_index);
 
 /**
  * Functions that are defined as STATIC can be placed within the UNIT_TEST

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -86,6 +86,9 @@ __BEGIN_DECLS
 struct control_value {
 	char name[FILENAME_MAX];
 	char value[CG_CONTROL_VALUE_MAX];
+
+	/* cgget uses this field for values that span multiple lines */
+	char *multiline_value;
 	bool dirty;
 };
 

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -134,4 +134,5 @@ CGROUP_0.43 {
 	cgroup_build_tasks_procs_path;
 	cg_build_path_locked;
 	cgroup_fill_cgc;
+	cgroup_test_subsys_mounted;
 } CGROUP_0.42;

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -135,4 +135,6 @@ CGROUP_0.43 {
 	cg_build_path_locked;
 	cgroup_fill_cgc;
 	cgroup_test_subsys_mounted;
+	cg_mount_table;
+	cg_mount_table_lock;
 } CGROUP_0.42;

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -133,4 +133,5 @@ CGROUP_0.42 {
 CGROUP_0.43 {
 	cgroup_build_tasks_procs_path;
 	cg_build_path_locked;
+	cgroup_fill_cgc;
 } CGROUP_0.42;

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -132,4 +132,5 @@ CGROUP_0.42 {
 
 CGROUP_0.43 {
 	cgroup_build_tasks_procs_path;
+	cg_build_path_locked;
 } CGROUP_0.42;

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -1,7 +1,7 @@
 @CODE_COVERAGE_RULES@
 
 INCLUDES = -I$(top_srcdir)/src -I$(top_srcdir)/include
-LDADD = $(top_builddir)/src/.libs/libcgroup.la
+LDADD = $(top_builddir)/src/.libs/libcgroup.la -lpthread
 
 if WITH_TOOLS
 

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -150,8 +150,12 @@ void cgroup_free_controllers(struct cgroup *cgroup)
 		return;
 
 	for (i = 0; i < cgroup->index; i++) {
-		for (j = 0; j < cgroup->controller[i]->index; j++)
+		for (j = 0; j < cgroup->controller[i]->index; j++) {
+			if (cgroup->controller[i]->values[j]->multiline_value)
+				free(cgroup->controller[i]->values[j]->multiline_value);
+
 			free(cgroup->controller[i]->values[j]);
+		}
 		cgroup->controller[i]->index = 0;
 		free(cgroup->controller[i]);
 	}

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -195,18 +195,22 @@ int cgroup_add_value_string(struct cgroup_controller *controller,
 	if (!cntl_value)
 		return ECGCONTROLLERCREATEFAILED;
 
-	if (strlen(value) >= sizeof(cntl_value->value)) {
-		fprintf(stderr, "value exceeds the maximum of %d characters\n",
-			sizeof(cntl_value->value) - 1);
-		free(cntl_value);
-		return ECGCONFIGPARSEFAIL;
-	}
-
 	strncpy(cntl_value->name, name, sizeof(cntl_value->name));
 	cntl_value->name[sizeof(cntl_value->name)-1] = '\0';
-	strncpy(cntl_value->value, value, sizeof(cntl_value->value));
-	cntl_value->value[sizeof(cntl_value->value)-1] = '\0';
-	cntl_value->dirty = true;
+
+	if (value) {
+		if (strlen(value) >= sizeof(cntl_value->value)) {
+			fprintf(stderr, "value exceeds the maximum of %d characters\n",
+				sizeof(cntl_value->value) - 1);
+			free(cntl_value);
+			return ECGCONFIGPARSEFAIL;
+		}
+
+		strncpy(cntl_value->value, value, sizeof(cntl_value->value));
+		cntl_value->value[sizeof(cntl_value->value)-1] = '\0';
+		cntl_value->dirty = true;
+	}
+
 	controller->values[controller->index] = cntl_value;
 	controller->index++;
 


### PR DESCRIPTION
Unlike the rest of libcgroup, the current implementation of cgget
uses arrays of strings to represent cgroups, controllers, and
settings.  The rest of the library utilizes the cgroup struct to
represent the hierarchy.

In preparation for the development of a cgroup v1/v2 abstraction
layer, this patchset refactors cgget to utilize struct cgroup and
better match the rest of the code base.  Note that patch #5 is a
complete re-write; it will likely be easier to review it as if it
were a new file rather than trying to decipher the git diff.

This patchset is largely intended to be nonfunctional and utilizes
the extensive cgget tests patchset sent out earlier [1].  During the
development of this code and the corresponding tests, I noticed in
a few error cases that the previous cgget would return 0 but still
populate stderr.  The newly refactored cgget does not behave this
way and this is reflected in this automated test [2].  Major
behavior should remain unchanged.

The changes to libcgroup are available here:
https://github.com/drakenclimber/libcgroup/tree/issues/cgget-refactor

The extensive cgget tests are available here:
https://github.com/drakenclimber/libcgroup-tests/tree/issues/cgget-tests

Automated tests results are available here:
https://github.com/drakenclimber/libcgroup/runs/1912708516

Code coverage increased from 45% to 46.2%.  Code coverage in the
newly refactored cgget.c is now at 86.3%:
https://coveralls.io/builds/37176420

[1] https://sourceforge.net/p/libcg/mailman/message/37218156/
[2] https://github.com/drakenclimber/libcgroup-tests/blob/issues/cgget-tests/ftests/016-cgget-invalid_options.py#L100