### PR TITLE
api.c: Don't fail a recursive write if value isn't dirty

### DIFF
--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -389,7 +389,8 @@ int cgroup_process_v1_mnt(char *controllers[], struct mntent *ent,
 int cgroup_process_v2_mnt(struct mntent *ent, int *mnt_tbl_idx);
 
 int cgroup_set_values_recursive(const char * const base,
-	const struct cgroup_controller * const controller);
+	const struct cgroup_controller * const controller,
+	bool ignore_non_dirty_failures);
 
 int cgroup_chown_chmod_tasks(const char * const cg_path,
 			     uid_t uid, gid_t gid, mode_t fperm);


### PR DESCRIPTION
When cgroup_modify_cgroup() invokes cgroup_set_values_recursive(),
some of the settings within the cgroup may not be writable.  Avoid
failing the entire write by ignoring write failures on settings that
do not explicitly have the dirty flag set.

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>