### PR TITLE
build: Remove .libs from Makefile.am files.

### DIFF
--- a/src/bindings/Makefile.am
+++ b/src/bindings/Makefile.am
@@ -5,7 +5,7 @@ lib_LTLIBRARIES = _libcgroup.la
 _libcgroup_la_SOURCES = libcgroup.c
 _libcgroup_la_LDFLAGS = $(shell python-config --ldflags) -module -avoid-version
 _libcgroup_la_CFLAGS = $(shell python-config --cflags)
-_libcgroup_la_LIBADD = $(top_builddir)/src/.libs/libcgroup.la
+_libcgroup_la_LIBADD = $(top_builddir)/src/libcgroup.la
 SWIG=swig
 
 

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -8,7 +8,7 @@ sbin_PROGRAMS = cgrulesengd
 cgrulesengd_SOURCES = cgrulesengd.c cgrulesengd.h ../tools/tools-common.h ../tools/tools-common.c
 cgrulesengd_LIBS = $(CODE_COVERAGE_LIBS)
 cgrulesengd_CFLAGS = $(CODE_COVERAGE_CFLAGS)
-cgrulesengd_LDADD = $(top_builddir)/src/.libs/libcgroup.la -lrt
+cgrulesengd_LDADD = $(top_builddir)/src/libcgroup.la -lrt
 cgrulesengd_LDFLAGS = -L$(top_builddir)/src/.libs
 
 endif

--- a/src/pam/Makefile.am
+++ b/src/pam/Makefile.am
@@ -5,6 +5,6 @@ if WITH_PAM
 pamlib_LTLIBRARIES = pam_cgroup.la
 pam_cgroup_la_SOURCES = pam_cgroup.c
 pam_cgroup_la_LDFLAGS = -module
-pam_cgroup_la_LIBADD = $(top_builddir)/src/.libs/libcgroup.la -lpam
+pam_cgroup_la_LIBADD = $(top_builddir)/src/libcgroup.la -lpam
 
 endif

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -1,7 +1,7 @@
 @CODE_COVERAGE_RULES@
 
 INCLUDES = -I$(top_srcdir)/src -I$(top_srcdir)/include
-LDADD = $(top_builddir)/src/.libs/libcgroup.la -lpthread
+LDADD = $(top_builddir)/src/libcgroup.la -lpthread
 
 if WITH_TOOLS
 


### PR DESCRIPTION
Remove .libs from Makefile.am files.  Suggested by
github user @orbea.

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>