### PR TITLE
cgget: Fix segfault when no flags provided

### DIFF
--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -336,9 +336,25 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 	}
 
 	while (argv[optind] != NULL) {
-		cg = (*cg_list)[(*cg_list_len) - 1];
+		if ((*cg_list_len) > 0)
+			cg = (*cg_list)[(*cg_list_len) - 1];
+		else
+			cg = NULL;
 
-		if (strlen(cg->name) == 0) {
+		if ((*cg_list_len) == 0) {
+			/* The user didn't provide a '-r' or '-g' flag.
+			 * The parse_a_flag() function can be reused here
+			 * because we both have the same use case - gather
+			 * all the data about this particular cgroup.
+			 */
+			ret = parse_a_flag(cg_list, cg_list_len);
+			if (ret)
+				goto out;
+
+			strncpy((*cg_list)[(*cg_list_len) - 1]->name,
+				argv[optind],
+				sizeof((*cg_list)[(*cg_list_len) - 1]->name) - 1);
+		} else if (cg != NULL && strlen(cg->name) == 0) {
 			/* this cgroup was created based upon control/value
 			 * pairs or with a -g <controller> option.  we'll
 			 * populate it with the parameter provided by the


### PR DESCRIPTION
Fix a segmentation fault when cgget is invoked in the
following form:
	cgget CroupName

parse_opt_args() was erroneously expecting a previously
populated struct cgroup in this case, and we were indexing
out of bounds of the cg_list.

Fixes: 1b7d606fa12a ("cgget: Major refactor")
Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>