### PR TITLE
libcgroup.map: Update version number

### DIFF
--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -130,7 +130,7 @@ CGROUP_0.42 {
 	cgroup_add_all_controllers;
 } CGROUP_0.41;
 
-CGROUP_0.43 {
+CGROUP_2.0 {
 	cgroup_build_tasks_procs_path;
 	cg_build_path_locked;
 	cgroup_fill_cgc;


### PR DESCRIPTION
Update the version number for the most recent exported
functions.

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>