### PR TITLE
github: Run apt update before apt install

### DIFF
--- a/.github/actions/setup-libcgroup/action.yml
+++ b/.github/actions/setup-libcgroup/action.yml
@@ -24,6 +24,8 @@ description: "Install dependencies, git clone, bootstrap, configure, and make li
 runs:
   using: "composite"
   steps:
+  - run: sudo apt update
+    shell: bash
   - run: sudo apt-get install libpam-dev lcov
     shell: bash
   - run: ./bootstrap.sh


### PR DESCRIPTION
Run apt update before apt install

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>