### PR TITLE
Replace __BEGIN_DECLS and __END_DECLS with extern "C".

### DIFF
--- a/include/libcgroup/config.h
+++ b/include/libcgroup/config.h
@@ -9,7 +9,9 @@
 #include <features.h>
 #endif
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup group_config 5. Configuration
@@ -128,6 +130,8 @@ int cgroup_config_create_template_group(
  * @}
  * @}
  */
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /*_LIBCGROUP_CONFIG_H*/

--- a/include/libcgroup/error.h
+++ b/include/libcgroup/error.h
@@ -9,7 +9,9 @@
 #include <features.h>
 #endif
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup group_errors 6. Error handling
@@ -99,6 +101,8 @@ int cgroup_get_last_errno(void);
  * @}
  * @}
  */
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _LIBCGROUP_INIT_H */

--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -11,7 +11,9 @@
 #include <stdbool.h>
 #endif
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Flags for cgroup_delete_cgroup_ext().
@@ -587,6 +589,8 @@ char *cgroup_get_cgroup_name(struct cgroup *cgroup);
  */
 
 
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _LIBCGROUP_GROUPS_H */

--- a/include/libcgroup/init.h
+++ b/include/libcgroup/init.h
@@ -9,7 +9,9 @@
 #include <features.h>
 #endif
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup group_init 1. Initialization
@@ -58,6 +60,8 @@ int cgroup_get_subsys_mount_point(const char *controller, char **mount_point);
  * @}
  * @}
  */
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _LIBCGROUP_INIT_H */

--- a/include/libcgroup/iterators.h
+++ b/include/libcgroup/iterators.h
@@ -11,7 +11,9 @@
 #include <features.h>
 #endif
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup group_iterators 3. Iterators
@@ -423,6 +425,8 @@ int cgroup_get_subsys_mount_point_end(void **handle);
  * @}
  */
 
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _LIBCGROUP_ITERATORS_H */

--- a/include/libcgroup/log.h
+++ b/include/libcgroup/log.h
@@ -11,7 +11,9 @@
 
 #include <stdarg.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup group_log 7. Logging
@@ -142,6 +144,8 @@ extern int cgroup_parse_log_level_str(const char *levelstr);
  * @}
  * @}
  */
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _LIBCGROUP_LOG_H */

--- a/include/libcgroup/tasks.h
+++ b/include/libcgroup/tasks.h
@@ -12,7 +12,9 @@
 #include <stdbool.h>
 #endif
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Flags for cgroup_change_cgroup_uid_gid(). */
 enum cgflags {
@@ -204,6 +206,8 @@ int cgroup_register_unchanged_process(pid_t pid, int flags);
  * @}
  * @}
  */
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _LIBCGROUP_TASKS_H */

--- a/src/bindings/libcgroup.p
+++ b/src/bindings/libcgroup.p
@@ -3,14 +3,6 @@
 #include "libcgroup.h"
 %}
 
-#ifdef  __cplusplus
-#define __BEGIN_DECLS   extern "C" {
-#define __END_DECLS     }
-#else
-#define __BEGIN_DECLS
-#define __END_DECLS
-#endif
-
 %include typemaps.i
 %include cpointer.i
 %pointer_functions(int, intp);

--- a/src/daemon/cgrulesengd.h
+++ b/src/daemon/cgrulesengd.h
@@ -17,7 +17,9 @@
 
 #include <features.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "config.h"
 #include "libcgroup.h"
@@ -119,7 +121,9 @@ void cgre_flash_templates(int signum);
  */
 void cgre_catch_term(int signum);
 
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _CGRULESENGD_H */
 

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -16,7 +16,9 @@
 
 #define __LIBCG_INTERNAL
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "config.h"
 #include <dirent.h>
@@ -407,6 +409,8 @@ int cgroupv2_controller_enabled(const char * const cg_name,
 
 #endif /* UNIT_TEST */
 
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/src/tools/tools-common.h
+++ b/src/tools/tools-common.h
@@ -18,7 +18,9 @@
 
 #define __TOOLS_COMMON
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "config.h"
 #include <libcgroup.h>
 #include "../libcgroup-internal.h"
@@ -136,6 +138,8 @@ int parse_r_flag(const char * const program_name,
 
 #endif /* UNIT_TEST */
 
-__END_DECLS
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* TOOLS_COMMON */


### PR DESCRIPTION
The macros __BEGIN_DECLS and __END_DECLS are a GNU-ism found in
glibc and uClibc, but not musl.  We replace them by the more general
extern "C" { ... } block exposed only if we have __cplusplus.

Forward ported from a patch by Anthony G. Basile <blueness@gentoo.org>.

Signed-off-by: Alex Xu (Hello71) <alex_y_xu@yahoo.ca>
Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>