### PR TITLE
github: Delete the tests folder before bootstrap

### DIFF
--- a/.github/actions/setup-libcgroup/action.yml
+++ b/.github/actions/setup-libcgroup/action.yml
@@ -28,6 +28,8 @@ runs:
     shell: bash
   - run: sudo apt-get install libpam-dev lcov
     shell: bash
+  - run: rm -fr tests/
+    shell: bash
   - run: ./bootstrap.sh
     shell: bash
   - run: CFLAGS="$CFLAGS -g -O0 -Werror" ./configure --sysconfdir=/etc --localstatedir=/var --enable-code-coverage --enable-opaque-hierarchy="name=systemd"


### PR DESCRIPTION
On self-hosted github machines, the working directory for
libcgroup is reused from one run to the next.  This is fine
for the root of the directory as the proper git clean/reset
commands are issues.  But this is problematic for the git
submodules like the tests/ folder because clean/reset is not
run there.

For the github continuous integration, remove the tests/
directory entirely and rely on ./bootstrap.sh to recreate and
populate it.

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>