### PR TITLE
github: Improve code coverage collection

### DIFF
--- a/.github/actions/setup-libcgroup/action.yml
+++ b/.github/actions/setup-libcgroup/action.yml
@@ -36,3 +36,5 @@ runs:
     shell: bash
   - run: make
     shell: bash
+  - run: lcov -i -d . -c -o lcov.base
+    shell: bash

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,14 +42,22 @@ jobs:
       if: ${{ always() }}
       run: cat tests/gunit/test-suite.log
     - name: Collate code coverage results
-      run: lcov -d . -c > lcov.info
+      run: |
+        lcov -d . -c -o lcov.tests
+        lcov -a lcov.base -a lcov.tests -o lcov.total
     - name: Upload code coverage results
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./lcov.info
+        path-to-lcov: ./lcov.total
         flag-name: "Unit Tests"
         parallel: True
+    - name: Archive code coverage results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Unit Test Code Coverage
+        path: lcov.*
 
   functionaltestsv1:
     name: Cgroup v1 Functional Tests
@@ -80,14 +88,22 @@ jobs:
         name: Cgroup v1 test logs
         path: tests/ftests/*.log
     - name: Collate code coverage results
-      run: lcov -d . -c > lcov.info
+      run: |
+        lcov -d . -c -o lcov.tests
+        lcov -a lcov.base -a lcov.tests -o lcov.total
     - name: Upload code coverage results
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./lcov.info
+        path-to-lcov: ./lcov.total
         flag-name: "Cgroup v1 Functional Tests"
         parallel: True
+    - name: Archive code coverage results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Cgroup v1 Code Coverage
+        path: lcov.*
 
   functionaltestsv1v2:
     name: Cgroup v1/v2 Functional Tests
@@ -136,6 +152,12 @@ jobs:
         path-to-lcov: ./lcov.info
         flag-name: "Cgroup v1/v2 Functional Tests"
         parallel: True
+    - name: Archive code coverage results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Cgroup v1 Code Coverage
+        path: lcov.*
 
   functionaltestsv2:
     name: Cgroup v2 Functional Tests
@@ -164,14 +186,22 @@ jobs:
         name: Cgroup v2 test logs
         path: tests/ftests/*.log
     - name: Collate code coverage results
-      run: lcov -d . -c > lcov.info
+      run: |
+        lcov -d . -c -o lcov.tests
+        lcov -a lcov.base -a lcov.tests -o lcov.total
     - name: Upload code coverage results
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./lcov.info
+        path-to-lcov: ./lcov.total
         flag-name: "Cgroup v2 Functional Tests"
         parallel: True
+    - name: Archive code coverage results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Cgroup v2 Code Coverage
+        path: lcov.*
 
   finalize:
     name: Finalize the test run


### PR DESCRIPTION
Improve code coverage collection by utilizing the "-i" flag
prior to the run.  This allows coverage on #ifdef'ed code.

Also, archive the code coverage files for later analysis if
desired.

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>