### PR TITLE
README.md: Display status of main branch in build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/libcgroup/libcgroup/workflows/Continuous%20Integration/badge.svg?branch=master)](https://github.com/libcgroup/libcgroup/actions)
+[![Build Status](https://github.com/libcgroup/libcgroup/workflows/Continuous%20Integration/badge.svg?branch=main)](https://github.com/libcgroup/libcgroup/actions)
 [![Coverage Status](https://coveralls.io/repos/github/libcgroup/libcgroup/badge.png)](https://coveralls.io/github/libcgroup/libcgroup)
 
 The entire libcgroup README is available [here](README).


### PR DESCRIPTION
The master branch was renamed to main, but the build status
badge wasn't updated as part of this change.  Display the
build status of the main branch in README.md

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>