### PR TITLE
configure.ac: check for the library containing fts_open

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,10 @@ AC_FUNC_REALLOC
 AC_FUNC_STAT
 AC_CHECK_FUNCS([getmntent hasmntopt memset mkdir rmdir strdup])
 
+AC_SEARCH_LIBS([fts_open], [fts], [], [
+  AC_MSG_ERROR([unable to find the fts_open() function])
+])
+
 if test x$with_pam = xtrue; then
 	AC_CHECK_LIB(
 		[pam],


### PR DESCRIPTION
The musl C library doesn't provide fts.h[1], so libcgroup doesn't
compile with musl. However, there is a standalone implementation of fts
for musl users[2] which can be used.

Use AC_SEARCH_LIBS to search for fts_open, which will check if it is part
of libc, and if not look in libfts, then set LIBS if needed.

[1] https://wiki.musl-libc.org/faq.html
[2] https://github.com/void-linux/musl-fts

Closes #61.

Signed-off-by: Ross Burton <ross.burton@arm.com>