### PR TITLE
github: re-arrange workflow run commands

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -73,8 +73,8 @@ jobs:
       uses: ./.github/actions/setup-libcgroup
     - name: Run functional tests
       run: |
-        make check
         pushd tests/ftests
+        make check
         popd
     - name: Display test logs
       if: ${{ always() }}
@@ -129,8 +129,8 @@ jobs:
       uses: ./.github/actions/setup-libcgroup
     - name: Run functional tests
       run: |
-        make check
         pushd tests/ftests
+        make check
         popd
     - name: Display test logs
       if: ${{ always() }}
@@ -173,8 +173,8 @@ jobs:
       uses: ./.github/actions/setup-libcgroup
     - name: Run functional tests
       run: |
-        make check
         pushd tests/ftests
+        make check
         popd
     - name: Display test logs
       if: ${{ always() }}


### PR DESCRIPTION
The current workflow executes the functional tests from the make check
called at the top-level source directory. Though this runs the tests
case, it also has an unintended side effect of re-running gunit tests
for every functional test combination in the workflow. Fix it, by
re-arranging the function test run commands, to change into
tests/ftests directory before executing make check.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>