### PR TITLE
BUG: Don't install testing libraries

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,3 +26,8 @@ libcgroupfortesting_la_LIBADD = -lpthread $(CODE_COVERAGE_LIBS)
 libcgroupfortesting_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC= -DUNIT_TEST
 libcgroupfortesting_la_LDFLAGS = -Wl,--version-script,$(top_srcdir)/tests/gunit/libcgroup_unittest.map \
 	-version-number $(LIBRARY_VERSION_MAJOR):$(LIBRARY_VERSION_MINOR):$(LIBRARY_VERSION_RELEASE)
+
+install-exec-hook:
+	find $(DESTDIR)$(libdir) -type f -name libcgroupfortesting.\* -delete
+	unlink $(DESTDIR)$(libdir)/libcgroupfortesting.so
+	unlink $(DESTDIR)$(libdir)/libcgroupfortesting.so.$(LIBRARY_VERSION_MAJOR)

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -58,5 +58,8 @@ cgsnapshot_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 
 install-exec-hook:
 	chmod u+s $(DESTDIR)$(bindir)/cgexec
+	find $(DESTDIR)$(libdir) -type f -name libcgset.\* -delete
+	unlink $(DESTDIR)$(libdir)/libcgset.so
+	unlink $(DESTDIR)$(libdir)/libcgset.so.0
 
 endif


### PR DESCRIPTION
libcgset and libcgfortesting are libraries that are used by the
unit test framework and are not intended to be installed when
`make install` is invoked.  Delete them from the install path.

Closes: https://github.com/libcgroup/libcgroup/issues/62
Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>