### PR TITLE
automake: idiomatically mark test libraries as convenience libraries

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,20 +14,17 @@ AM_YFLAGS = -d
 CLEANFILES = lex.c parse.c parse.h
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
-lib_LTLIBRARIES = libcgroup.la libcgroupfortesting.la
+
+lib_LTLIBRARIES = libcgroup.la
 libcgroup_la_SOURCES = parse.h parse.y lex.l api.c config.c libcgroup-internal.h libcgroup.map wrapper.c log.c
 libcgroup_la_LIBADD = -lpthread $(CODE_COVERAGE_LIBS)
 libcgroup_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC=static
 libcgroup_la_LDFLAGS = -Wl,--version-script,$(srcdir)/libcgroup.map \
 	-version-number $(LIBRARY_VERSION_MAJOR):$(LIBRARY_VERSION_MINOR):$(LIBRARY_VERSION_RELEASE)
 
+noinst_LTLIBRARIES = libcgroupfortesting.la
 libcgroupfortesting_la_SOURCES = $(libcgroup_la_SOURCES)
 libcgroupfortesting_la_LIBADD = -lpthread $(CODE_COVERAGE_LIBS)
 libcgroupfortesting_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC= -DUNIT_TEST
 libcgroupfortesting_la_LDFLAGS = -Wl,--version-script,$(top_srcdir)/tests/gunit/libcgroup_unittest.map \
 	-version-number $(LIBRARY_VERSION_MAJOR):$(LIBRARY_VERSION_MINOR):$(LIBRARY_VERSION_RELEASE)
-
-install-exec-hook:
-	find $(DESTDIR)$(libdir) -type f -name libcgroupfortesting.\* -delete
-	unlink $(DESTDIR)$(libdir)/libcgroupfortesting.so
-	unlink $(DESTDIR)$(libdir)/libcgroupfortesting.so.$(LIBRARY_VERSION_MAJOR)

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -10,7 +10,7 @@ bin_PROGRAMS = cgexec cgclassify cgcreate cgset cgget cgdelete lssubsys\
 
 sbin_PROGRAMS = cgconfigparser
 
-lib_LTLIBRARIES = libcgset.la
+noinst_LTLIBRARIES = libcgset.la
 
 cgexec_SOURCES = cgexec.c tools-common.c tools-common.h
 cgexec_LIBS = $(CODE_COVERAGE_LIBS)
@@ -59,8 +59,5 @@ cgsnapshot_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 
 install-exec-hook:
 	chmod u+s $(DESTDIR)$(bindir)/cgexec
-	find $(DESTDIR)$(libdir) -type f -name libcgset.\* -delete
-	unlink $(DESTDIR)$(libdir)/libcgset.so
-	unlink $(DESTDIR)$(libdir)/libcgset.so.0
 
 endif


### PR DESCRIPTION
Instead of installing then deleting, mark the libraries which are only
used at build time and should not be installed as noinst, so they don't
get installed at all.

Signed-off-by: Ross Burton <ross.burton@arm.com>