### PR TITLE
api.c: Allow reading/writing from cgroup.* files in cgroup v2

### DIFF
--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -75,6 +75,8 @@ extern "C" {
 #define CGROUP_RULE_MAXLINE	(FILENAME_MAX + CGROUP_RULE_MAXKEY + \
 	CG_CONTROLLER_MAX + 3)
 
+#define CGROUP_FILE_PREFIX	"cgroup"
+
 #define cgroup_err(x...) cgroup_log(CGROUP_LOG_ERROR, x)
 #define cgroup_warn(x...) cgroup_log(CGROUP_LOG_WARNING, x)
 #define cgroup_info(x...) cgroup_log(CGROUP_LOG_INFO, x)


### PR DESCRIPTION
Allow reading/writing from cgroup.* files (such as cgroup.type
and cgroup.procs) on cgroup v2 filesystems.

Closes: https://github.com/libcgroup/libcgroup/issues/73
Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>