### PR TITLE
Initialize cgroup version for named V1 hierarchy

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1164,6 +1164,7 @@ STATIC int cgroup_process_v1_mnt(char *controllers[], struct mntent *ent,
 			ent->mnt_dir, FILENAME_MAX);
 		cg_mount_table[*mnt_tbl_idx].mount.path[FILENAME_MAX-1] =
 			'\0';
+		cg_mount_table[*mnt_tbl_idx].version = CGROUP_V1;
 		cg_mount_table[*mnt_tbl_idx].mount.next = NULL;
 		cgroup_dbg("Found cgroup option %s, count %d\n",
 			ent->mnt_opts, *mnt_tbl_idx);


### PR DESCRIPTION
Commit 3aac9889 added the 'version' field in cg_mount_table_s and
initializes it in cgroup_process_v1_mnt(). The same initialization is
required in a second place dealing with named hierarchies.