### PR TITLE
configure: set version numbers for releases only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@
 AC_PREREQ([2.69])
 
 # In following section update all occurences of version, including soname
-AC_INIT([libcgroup],[2.0])
+AC_INIT([libcgroup],[0.0.0])
 
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIRS([m4])
@@ -25,9 +25,9 @@ AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # set library version, soname is libcgroup.so.MAJOR
-AC_SUBST(LIBRARY_VERSION_MAJOR, 1)
+AC_SUBST(LIBRARY_VERSION_MAJOR, 0)
 AC_SUBST(LIBRARY_VERSION_MINOR, 0)
-AC_SUBST(LIBRARY_VERSION_RELEASE, 42)
+AC_SUBST(LIBRARY_VERSION_RELEASE, 0)
 
 # we do not want static libraries
 #AC_DISABLE_STATIC


### PR DESCRIPTION
Let's set the version for releases only and set the development/main
branch version to 0.0.0, that differentiate between development and
releases.

Suggested-by: Tom Hromatka <tom.hromatka@oracle.com>
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>