### PR TITLE
Introduce vim modeline for python sources

### DIFF
--- a/src/python/cgroup.pxd
+++ b/src/python/cgroup.pxd
@@ -63,3 +63,5 @@ cdef extern from "libcgroup.h":
 
     int cgroup_cgxset(const cgroup * const cg, cg_version_t version,
                       bint ignore_unmappable)
+
+# vim: set et ts=4 sw=4:

--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -292,3 +292,5 @@ cdef class Cgroup:
 
     def __dealloc__(self):
         cgroup.cgroup_free(&self._cgp);
+
+# vim: set et ts=4 sw=4:

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -43,3 +43,5 @@ setup(
             extra_objects=["../.libs/libcgroup.a"]),
     ])
 )
+
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
Introduce vim modeline to python source files. This sets up the
vim editor to PEP-8 recommend editing style. The vim modeline added:
"# vim: set et ts=4 sw=4:"

'et' converts the tabs to spaces, 'ts' set the tabs indentation/tabstop
to 4 characters and 'sw' sets the shiftwidth to 4 characters.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>