### PR TITLE
python/setup.py: make it PEP8 compliant

### DIFF
--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -23,25 +23,26 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-import os
-
 from setuptools import Extension, setup
 from Cython.Build import cythonize
+import os
 
 setup(
-    name = "libcgroup",
-    version = os.environ["VERSION_RELEASE"],
-    description = "Python bindings for libcgroup",
-    url = "https://github.com/libcgroup/libcgroup",
-    maintainer = "Tom Hromatka",
-    maintainer_email = "tom.hromatka@oracle.com",
-    license = "LGPLv2.1",
-    platforms = "Linux",
-    ext_modules = cythonize([
-        Extension("libcgroup", ["libcgroup.pyx"],
-            # unable to handle libtool libraries directly
-            extra_objects=["../.libs/libcgroup.a"]),
-    ])
+    name='libcgroup',
+    version=os.environ['VERSION_RELEASE'],
+    description='Python bindings for libcgroup',
+    url='https://github.com/libcgroup/libcgroup',
+    maintainer='Tom Hromatka',
+    maintainer_email='tom.hromatka@oracle.com',
+    license='LGPLv2.1',
+    platforms='Linux',
+    ext_modules=cythonize([
+            Extension(
+                      'libcgroup', ['libcgroup.pyx'],
+                      # unable to handle libtool libraries directly
+                      extra_objects=['../.libs/libcgroup.a']
+                     ),
+             ])
 )
 
 # vim: set et ts=4 sw=4:


### PR DESCRIPTION
Make setup.py PEP-8 compliant, it fixes the following two issues
reported by flake8:
- E128 continuation line under-indented for visual indent
- E251 unexpected spaces around keyword/parameter equals

also, adopt single quotes for strings.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>