### PR TITLE
Modernise cgconfig initscript.

### DIFF
--- a/scripts/init.d/cgconfig.in
+++ b/scripts/init.d/cgconfig.in
@@ -30,22 +30,39 @@
 ### END INIT INFO
 
 # get correct location of binaries from configure
-prefix=@prefix@;exec_prefix=@exec_prefix@;sbindir=@sbindir@
+sbindir=@sbindir@
 CGCONFIGPARSER_BIN=$sbindir/cgconfigparser
 CONFIG_FILE=/etc/cgconfig.conf
+CONFIG_DIR=/etc/cgconfig.d
 servicename=cgconfig
-lockfile=/var/lock/subsys/$servicename
 
+
+lockfile=/run/subsys/$servicename
 #
 # Source LSB routines
 #
-. /lib/lsb/init-functions
+SYSLIBFILE=/lib/lsb/init-functions
+OLDSYSLIBFILE=/etc/init.d/functions
+if [[ -x  $SYSLIBFILE ]] ; then
+  source $SYSLIBFILE
+elif  [[ -x $OLDSYSLIBFILE ]] ; then
+  source $OLDSYSLIBFILE
+  log_warning_msg() ( warning $@ ; printf "\n" 1>&2 ; )
+  log_failure_msg() ( failure $@ ; printf "\n" 1>&2 ; )
+  log_success_msg() ( success $@ ; printf "\n" 1>&2 ; )
+else
+  log_warning_msg() ( printf "warning:%s\n" "$@" 1>&2 ;)
+  log_failure_msg() ( printf "failure:%s\n" "$@" 1>&2 ;)
+  log_success_msg() ( printf "success:%s\n" "$@" 1>&2 ;)
+fi
 
 # read the config
 CREATE_DEFAULT=yes
 if [ -e /etc/sysconfig/cgconfig ]; then
-        . /etc/sysconfig/cgconfig
+        source /etc/sysconfig/cgconfig
 fi
+
+lockfiledir=$(dirname "$lockfile")
 
 create_default_groups() {
 	defaultcgroup=
@@ -53,14 +70,14 @@ create_default_groups() {
         if [ -f /etc/cgrules.conf ]; then
 	    read user ctrl defaultcgroup <<< \
 		    $(grep -m1 '^\*[[:space:]]\+' /etc/cgrules.conf)
-            if [ -n "$defaultcgroup" -a "$defaultcgroup" = "*" ]; then
+           if [[ ( -n "$defaultcgroup" ) && ( "$defaultcgroup" = "*" ) ]]; then
                 log_warning_msg "/etc/cgrules.conf incorrect"
                 log_warning_msg "Overriding it"
                 defaultcgroup=
             fi
         fi
 
-        if [ -z $defaultcgroup ]
+        if [[ -z "$defaultcgroup" ]]
         then
             defaultcgroup=sysdefault/
         fi
@@ -69,7 +86,7 @@ create_default_groups() {
         # Find all mounted subsystems and create comma-separated list
         # of controllers.
         #
-        controllers=`lssubsys 2>/dev/null | tr '\n' ',' | sed s/.$//`
+        controllers=$(lssubsys 2>/dev/null | tr '\n' ',' | sed s/.$//)
 
         #
         # Create the default group, ignore errors when the default group
@@ -81,9 +98,9 @@ create_default_groups() {
         # special rule for cpusets
         #
         if echo $controllers | grep -q -w cpuset; then
-                cpus=`cgget -nv -r cpuset.cpus /`
+                cpus=$(cgget -nv -r cpuset.cpus /)
                 cgset -r cpuset.cpus=$cpus $defaultcgroup
-                mems=`cgget -nv -r cpuset.mems /`
+                mems=$(cgget -nv -r cpuset.mems /)
                 cgset -r cpuset.mems=$mems $defaultcgroup
         fi
 
@@ -91,50 +108,52 @@ create_default_groups() {
         # Classify everything to default cgroup. Ignore errors, some processes
         # may exit after ps is run and before cgclassify moves them.
         #
-        cgclassify -g $controllers:$defaultcgroup `ps --no-headers -eL o tid` \
+        cgclassify -g $controllers:$defaultcgroup $(ps --no-headers -eL o tid) \
                  2>/dev/null || :
 }
 
 start() {
-        echo -n "Starting cgconfig service: "
-	if [ -f "$lockfile" ]; then
+        printf "Starting cgconfig service: "
+	if [[ -f "$lockfile" ]]; then
             log_warning_msg "lock file already exists"
             return 0
         fi
 
-        if [ $? -eq 0 ]; then
-                if [ ! -s $CONFIG_FILE ]; then
-                    log_failure_msg $CONFIG_FILE "is not configured"
-                    return 6
-                fi
+        if [[ ! -s "$CONFIG_FILE" ]]; then
+          log_failure_msg $CONFIG_FILE "is not configured"
+          return 6
+        fi
 
-                $CGCONFIGPARSER_BIN -l $CONFIG_FILE
-                retval=$?
-                if [ $retval -ne 0 ]; then
-                    log_failure_msg "Failed to parse " $CONFIG_FILE
-                    return 1
-                fi
+
+        if ! "$CGCONFIGPARSER_BIN" -l "$CONFIG_FILE" -L "$CONFIG_DIR"
+        then
+          log_failure_msg "Failed to parse " "$CONFIG_FILE" "or" "$CONFIG_DIR"'/*'
+          return 1
         fi
 
         if [ $CREATE_DEFAULT = "yes" ]; then
                 create_default_groups
         fi
 
-        touch "$lockfile"
-        retval=$?
-        if [ $retval -ne 0 ]; then
+        if ! mkdir -p "$lockfiledir" ; then
+          log_failure_msg "Failed to mkdir $lockfiledir directory"
+          return 1
+        fi
+
+
+        if ! touch "$lockfile" ; then
             log_failure_msg "Failed to touch $lockfile"
             return 1
         fi
-        log_success_msg
+        log_success_msg "Started $servicename"
         return 0
 }
 
 stop() {
-    echo -n "Stopping cgconfig service: "
-    rm -f "$lockfile"
-    log_success_msg
-    return 0
+    echo -n "Stopping cgconfig service is not supported!: "
+    # rm -f "$lockfile"
+    log_failure_msg "Failed to stop $servicename"
+    return 1
 }
 
 trapped() {
@@ -183,7 +202,7 @@ case $1 in
         RETVAL=$?
         ;;
     'condrestart')
-        if [ -f "$lockfile" ]; then
+        if [[ -f "$lockfile" ]]; then
             restart
             RETVAL=$?
         fi

--- a/scripts/init.d/cgconfig.in
+++ b/scripts/init.d/cgconfig.in
@@ -37,7 +37,7 @@ CONFIG_DIR=/etc/cgconfig.d
 servicename=cgconfig
 
 
-lockfile=/run/subsys/$servicename
+lockfile=/run/lock/subsys/$servicename
 #
 # Source LSB routines
 #
@@ -47,9 +47,9 @@ if [[ -x  $SYSLIBFILE ]] ; then
   source $SYSLIBFILE
 elif  [[ -x $OLDSYSLIBFILE ]] ; then
   source $OLDSYSLIBFILE
-  log_warning_msg() ( warning $@ ; printf "\n" 1>&2 ; )
-  log_failure_msg() ( failure $@ ; printf "\n" 1>&2 ; )
-  log_success_msg() ( success $@ ; printf "\n" 1>&2 ; )
+  log_warning_msg() ( warning "$@" ; printf "\n" 1>&2 ; )
+  log_failure_msg() ( failure "$@" ; printf "\n" 1>&2 ; )
+  log_success_msg() ( success "$@" ; printf "\n" 1>&2 ; )
 else
   log_warning_msg() ( printf "warning:%s\n" "$@" 1>&2 ;)
   log_failure_msg() ( printf "failure:%s\n" "$@" 1>&2 ;)
@@ -113,7 +113,7 @@ create_default_groups() {
 }
 
 start() {
-        printf "Starting cgconfig service: "
+        printf "Starting %s service: " "$servicename"
 	if [[ -f "$lockfile" ]]; then
             log_warning_msg "lock file already exists"
             return 0
@@ -150,8 +150,7 @@ start() {
 }
 
 stop() {
-    echo -n "Stopping cgconfig service is not supported!: "
-    # rm -f "$lockfile"
+    printf "Stopping %s service is not supported!: " "$servicename"
     log_failure_msg "Failed to stop $servicename"
     return 1
 }


### PR DESCRIPTION
1. Remove obsolete constructions from scripts/init/cgconfig.in
2. Add fallback logging functions for non-lsb systems.

Signed-off-by: Vladimir Nikishkin <libcgroup@lockywolf.net>