### PR TITLE
Fixes for GCC warnings

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1202,7 +1202,8 @@ STATIC int cgroup_process_v2_mnt(struct mntent *ent, int *mnt_tbl_idx)
 	 * Save off this mount point.  This may be used later to build
 	 * the cg_path.
 	 */
-	strncpy(cg_cgroup_v2_mount_path, ent->mnt_dir, FILENAME_MAX);
+	strncpy(cg_cgroup_v2_mount_path, ent->mnt_dir, FILENAME_MAX-1);
+	cg_cgroup_v2_mount_path[FILENAME_MAX-1] = '\0';
 
 	/* determine what v2 controllers are available on this mount */
 	snprintf(cgroup_controllers_path, FILENAME_MAX, "%s/%s", ent->mnt_dir,

--- a/src/tools/lssubsys.c
+++ b/src/tools/lssubsys.c
@@ -123,11 +123,9 @@ static int print_all_controllers_in_hierarchy(const char *tname,
 
 		if (first) {
 			/* the first controller in the hierarchy */
-			memset(cont_name, 0, FILENAME_MAX);
 			strncpy(cont_name, info.name, FILENAME_MAX-1);
 			cont_name[sizeof(cont_name) - 1] = '\0';
 
-			memset(cont_names, 0, FILENAME_MAX);
 			strncpy(cont_names, info.name, FILENAME_MAX-1);
 			cont_names[sizeof(cont_names) - 1] = '\0';
 			first = 0;


### PR DESCRIPTION
While compiling on Fedora-34, which ships `GCC-11` as the
default compiler triggers a couple of `strncpy()` related build
warnings.  This patch series attempts to fix those warnings
and keep the GCC happy.