### PR TITLE
[RFC] src/* - introduce coding style

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,15 @@
+# There is no Kernel tree available, run without it.
+--no-tree
+
+# Ignore the SPDX License tag, that's supposed to be the first line in
+# Linux Kernel sources.
+--ignore SPDX_LICENSE_TAG
+
+# We do not follow the negative error numbering, so ignore it.
+--ignore USE_NEGATIVE_ERRNO
+
+# Follow the 80-character limit.
+--max-line-length=80
+
+# Kernel specific kstr* functions recommendation doesn't apply to us.
+--ignore SSCANF_TO_KSTRTO

--- a/src/abstraction-common.c
+++ b/src/abstraction-common.c
@@ -19,20 +19,21 @@
  * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
-#include <libcgroup.h>
-#include <libcgroup-internal.h>
-
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-
 #include "abstraction-common.h"
 #include "abstraction-map.h"
 
+#include <libcgroup.h>
+#include <libcgroup-internal.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+
+
 int cgroup_strtol(const char * const in_str, int base,
-		  long int * const out_value)
+		  long * const out_value)
 {
 	char *endptr = NULL;
 	int ret = 0;
@@ -74,10 +75,10 @@ int cgroup_convert_int(struct cgroup_controller * const dst_cgc,
 {
 #define OUT_VALUE_STR_LEN 20
 
-	long int in_dflt_int = (long int)in_dflt;
-	long int out_dflt_int = (long int)out_dflt;
+	long out_dflt_int = (long)out_dflt;
+	long in_dflt_int = (long)in_dflt;
 	char *out_value_str = NULL;
-	long int out_value;
+	long out_value;
 	int ret;
 
 	if (!in_value)
@@ -144,8 +145,8 @@ static int convert_setting(struct cgroup_controller * const out_cgc,
 			   const struct control_value * const in_ctrl_val)
 {
 	const struct cgroup_abstraction_map *convert_tbl;
-	int tbl_sz = 0;
 	int ret = ECGINVAL;
+	int tbl_sz = 0;
 	int i;
 
 	switch (out_cgc->version) {
@@ -266,9 +267,8 @@ int cgroup_convert_cgroup(struct cgroup * const out_cgroup,
 		}
 
 		/* the user has overridden the version */
-		if (in_version == CGROUP_V1 || in_version == CGROUP_V2) {
+		if (in_version == CGROUP_V1 || in_version == CGROUP_V2)
 			in_cgroup->controller[i]->version = in_version;
-		}
 
 		if (strcmp(CGROUP_FILE_PREFIX, cgc->name) == 0)
 			/*

--- a/src/abstraction-common.h
+++ b/src/abstraction-common.h
@@ -26,6 +26,7 @@ extern "C" {
 #endif
 
 #include "config.h"
+
 #include <libcgroup.h>
 #include "libcgroup-internal.h"
 
@@ -37,11 +38,11 @@ extern "C" {
  * @param out_value Pointer to hold the output long value
  *
  * @return 0 on success,
- * 	   ECGFAIL if the conversion to long failed,
- * 	   ECGINVAL upon an invalid parameter
+ *	   ECGFAIL if the conversion to long failed,
+ *	   ECGINVAL upon an invalid parameter
  */
 int cgroup_strtol(const char * const in_str, int base,
-		  long int * const out_value);
+		  long * const out_value);
 
 /**
  * Convert an integer setting to another integer setting

--- a/src/abstraction-cpu.c
+++ b/src/abstraction-cpu.c
@@ -19,17 +19,17 @@
  * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
+#include "abstraction-common.h"
+#include "abstraction-map.h"
+
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
 
-#include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include "abstraction-common.h"
-#include "abstraction-map.h"
+#include <errno.h>
+#include <stdio.h>
 
 #define LL_MAX 8192
 

--- a/src/abstraction-cpuset.c
+++ b/src/abstraction-cpuset.c
@@ -19,16 +19,16 @@
  * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
+#include "abstraction-common.h"
+
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
 
-#include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include "abstraction-common.h"
+#include <errno.h>
+#include <stdio.h>
 
 static const char * const MEMBER = "member";
 static const char * const ROOT = "root";

--- a/src/abstraction-map.c
+++ b/src/abstraction-map.c
@@ -19,17 +19,17 @@
  * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
+#include "abstraction-common.h"
+#include "abstraction-map.h"
+
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
 
-#include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include "abstraction-common.h"
-#include "abstraction-map.h"
+#include <errno.h>
+#include <stdio.h>
 
 const struct cgroup_abstraction_map cgroup_v1_to_v2_map[] = {
 	/* cpu controller */

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -21,15 +21,18 @@ extern "C" {
 #endif
 
 #include "config.h"
-#include <dirent.h>
-#include <fts.h>
+
 #include <libcgroup.h>
+
+#include <pthread.h>
+#include <dirent.h>
 #include <limits.h>
 #include <mntent.h>
-#include <pthread.h>
+#include <setjmp.h>
+#include <fts.h>
+
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <setjmp.h>
 
 /* Maximum number of mount points/controllers */
 #define MAX_MNT_ELEMENTS	16
@@ -37,19 +40,19 @@ extern "C" {
 #define MAX_GROUP_ELEMENTS	128
 
 /* Maximum length of a value */
-#define CG_CONTROL_VALUE_MAX 4096
+#define CG_CONTROL_VALUE_MAX	4096
 
-#define CG_NV_MAX 100
-#define CG_CONTROLLER_MAX 100
-#define CG_OPTIONS_MAX 100
+#define CG_NV_MAX		100
+#define CG_CONTROLLER_MAX	100
+#define CG_OPTIONS_MAX		100
 /* Max number of mounted hierarchies. Event if one controller is mounted per
  * hier, it can not exceed CG_CONTROLLER_MAX
  */
 #define CG_HIER_MAX  CG_CONTROLLER_MAX
 
 /* Definitions for the uid and gid members of a cgroup_rules */
-#define CGRULE_INVALID ((uid_t) -1)
-#define CGRULE_WILD ((uid_t) -2)
+#define CGRULE_INVALID	((uid_t) -1)
+#define CGRULE_WILD	((uid_t) -2)
 
 #define CGRULE_SUCCESS_STORE_PID	"SUCCESS_STORE_PID"
 
@@ -76,15 +79,15 @@ extern "C" {
 
 #define CGROUP_FILE_PREFIX	"cgroup"
 
-#define cgroup_err(x...) cgroup_log(CGROUP_LOG_ERROR, x)
-#define cgroup_warn(x...) cgroup_log(CGROUP_LOG_WARNING, x)
-#define cgroup_info(x...) cgroup_log(CGROUP_LOG_INFO, x)
-#define cgroup_dbg(x...) cgroup_log(CGROUP_LOG_DEBUG, x)
+#define cgroup_err(x...)	cgroup_log(CGROUP_LOG_ERROR, x)
+#define cgroup_warn(x...)	cgroup_log(CGROUP_LOG_WARNING, x)
+#define cgroup_info(x...)	cgroup_log(CGROUP_LOG_INFO, x)
+#define cgroup_dbg(x...)	cgroup_log(CGROUP_LOG_DEBUG, x)
 
 #define CGROUP_DEFAULT_LOGLEVEL CGROUP_LOG_ERROR
 
-#define max(x,y) ((y)<(x)?(x):(y))
-#define min(x,y) ((y)>(x)?(x):(y))
+#define max(x, y) ((y) < (x)?(x):(y))
+#define min(x, y) ((y) > (x)?(x):(y))
 
 struct control_value {
 	char name[FILENAME_MAX];
@@ -311,7 +314,7 @@ int cg_chmod_path(const char *path, mode_t mode, int owner_is_umask);
  * Build the path to the tasks or cgroup.procs file
  *
  * @param path Output variable that will contain the path.  Must be
-              of size FILENAME_MAX or larger
+ *	       of size FILENAME_MAX or larger
  * @param path_sz Size of the path string
  * @param cg_name Cgroup name
  * @param ctrl_name Controller name
@@ -371,7 +374,7 @@ int cgroup_copy_controller_values(struct cgroup_controller * const dst,
  * Remove a name/value pair from a controller.
  *
  * @param controller
- * @param name Name of the name/value pair to be removed
+ * @param name The name of the name/value pair to be removed
  * @return 0 on success.  ECGROUPNOTEXIST if name does not exist.
  */
 int cgroup_remove_value(struct cgroup_controller * const controller,

--- a/src/log.c
+++ b/src/log.c
@@ -14,11 +14,12 @@
 
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
+
+#include <strings.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <strings.h>
+#include <stdio.h>
 
 static cgroup_logger_callback cgroup_logger;
 static void *cgroup_logger_userdata;
@@ -46,7 +47,7 @@ void cgroup_log(int level, const char *fmt, ...)
 }
 
 void cgroup_set_logger(cgroup_logger_callback logger, int loglevel,
-		void *userdata)
+		       void *userdata)
 {
 	cgroup_logger = logger;
 	cgroup_set_loglevel(loglevel);
@@ -63,6 +64,7 @@ int cgroup_parse_log_level_str(const char *levelstr)
 {
 	char *end;
 	long level;
+
 	errno = 0;
 
 	/* try to parse integer first */
@@ -88,6 +90,7 @@ void cgroup_set_loglevel(int loglevel)
 		cgroup_loglevel = loglevel;
 	else {
 		char *level_str = getenv("CGROUP_LOGLEVEL");
+
 		if (level_str != NULL)
 			cgroup_loglevel = cgroup_parse_log_level_str(level_str);
 		else

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -17,18 +17,20 @@
 
 #define _GNU_SOURCE
 
-#include <errno.h>
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
+
 #include <inttypes.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
 
 static void init_cgroup(struct cgroup *cgroup)
 {
-	cgroup->task_fperm = cgroup->control_fperm = cgroup->control_dperm = NO_PERMS;
+	cgroup->task_fperm = cgroup->control_fperm =
+			cgroup->control_dperm = NO_PERMS;
 	cgroup->control_gid = cgroup->control_uid = cgroup->tasks_gid =
 			cgroup->tasks_uid = NO_UID_GID;
 }
@@ -44,6 +46,7 @@ void init_cgroup_table(struct cgroup *cgroups, size_t count)
 struct cgroup *cgroup_new_cgroup(const char *name)
 {
 	struct cgroup *cgroup = calloc(1, sizeof(struct cgroup));
+
 	if (!cgroup)
 		return NULL;
 
@@ -54,10 +57,10 @@ struct cgroup *cgroup_new_cgroup(const char *name)
 }
 
 struct cgroup_controller *cgroup_add_controller(struct cgroup *cgroup,
-							const char *name)
+						const char *name)
 {
-	int i, ret;
 	struct cgroup_controller *controller;
+	int i, ret;
 
 	if (!cgroup)
 		return NULL;
@@ -73,7 +76,7 @@ struct cgroup_controller *cgroup_add_controller(struct cgroup *cgroup,
 	 */
 	for (i = 0; i < cgroup->index; i++) {
 		if (strncmp(name, cgroup->controller[i]->name,
-				sizeof(cgroup->controller[i]->name)) == 0)
+			    sizeof(cgroup->controller[i]->name)) == 0)
 			return NULL;
 	}
 
@@ -111,10 +114,10 @@ struct cgroup_controller *cgroup_add_controller(struct cgroup *cgroup,
 
 int cgroup_add_all_controllers(struct cgroup *cgroup)
 {
-	int ret;
-	void *handle;
-	struct controller_data info;
 	struct cgroup_controller *cgc;
+	struct controller_data info;
+	void *handle;
+	int ret;
 
 	/* go through the controller list */
 	ret = cgroup_get_all_controller_begin(&handle, &info);
@@ -126,8 +129,10 @@ int cgroup_add_all_controllers(struct cgroup *cgroup)
 
 	while (ret == 0) {
 		if (info.hierarchy == 0) {
-			/* the controller is not attached to any hierarchy
-			   skip it */
+			/*
+			 * the controller is not attached to any hierarchy
+			 * skip it.
+			 */
 			goto next;
 		}
 
@@ -187,9 +192,9 @@ void cgroup_free_controllers(struct cgroup *cgroup)
 	if (!cgroup)
 		return;
 
-	for (i = 0; i < cgroup->index; i++) {
+	for (i = 0; i < cgroup->index; i++)
 		cgroup_free_controller(cgroup->controller[i]);
-	}
+
 	cgroup->index = 0;
 }
 
@@ -209,7 +214,7 @@ void cgroup_free(struct cgroup **cgroup)
 }
 
 int cgroup_add_value_string(struct cgroup_controller *controller,
-					const char *name, const char *value)
+			    const char *name, const char *value)
 {
 	int i;
 	struct control_value *cntl_value;
@@ -235,7 +240,8 @@ int cgroup_add_value_string(struct cgroup_controller *controller,
 
 	if (value) {
 		if (strlen(value) >= sizeof(cntl_value->value)) {
-			fprintf(stderr, "value exceeds the maximum of %ld characters\n",
+			fprintf(stderr,
+				"value exceeds the maximum of %ld characters\n",
 				sizeof(cntl_value->value) - 1);
 			free(cntl_value);
 			return ECGCONFIGPARSEFAIL;
@@ -253,10 +259,10 @@ int cgroup_add_value_string(struct cgroup_controller *controller,
 }
 
 int cgroup_add_value_int64(struct cgroup_controller *controller,
-					const char *name, int64_t value)
+			   const char *name, int64_t value)
 {
-	int ret;
 	char *val;
+	int ret;
 
 	ret = asprintf(&val, "%"PRId64, value);
 	if (ret < 0) {
@@ -271,10 +277,10 @@ int cgroup_add_value_int64(struct cgroup_controller *controller,
 }
 
 int cgroup_add_value_uint64(struct cgroup_controller *controller,
-					const char *name, u_int64_t value)
+			    const char *name, u_int64_t value)
 {
-	int ret;
 	char *val;
+	int ret;
 
 	ret = asprintf(&val, "%" PRIu64, value);
 	if (ret < 0) {
@@ -289,10 +295,10 @@ int cgroup_add_value_uint64(struct cgroup_controller *controller,
 }
 
 int cgroup_add_value_bool(struct cgroup_controller *controller,
-						const char *name, bool value)
+			  const char *name, bool value)
 {
-	int ret;
 	char *val;
+	int ret;
 
 	if (value)
 		val = strdup("1");
@@ -339,7 +345,7 @@ int cgroup_remove_value(struct cgroup_controller * const controller,
 }
 
 int cgroup_compare_controllers(struct cgroup_controller *cgca,
-					struct cgroup_controller *cgcb)
+			       struct cgroup_controller *cgcb)
 {
 	int i;
 
@@ -397,11 +403,12 @@ int cgroup_compare_cgroup(struct cgroup *cgroup_a, struct cgroup *cgroup_b)
 		if (cgroup_compare_controllers(cgca, cgcb))
 			return ECGCONTROLLERNOTEQUAL;
 	}
+
 	return 0;
 }
 
 int cgroup_set_uid_gid(struct cgroup *cgroup, uid_t tasks_uid, gid_t tasks_gid,
-					uid_t control_uid, gid_t control_gid)
+		       uid_t control_uid, gid_t control_gid)
 {
 	if (!cgroup)
 		return ECGINVAL;
@@ -429,7 +436,7 @@ int cgroup_get_uid_gid(struct cgroup *cgroup, uid_t *tasks_uid,
 }
 
 struct cgroup_controller *cgroup_get_controller(struct cgroup *cgroup,
-							const char *name)
+						const char *name)
 {
 	int i;
 	struct cgroup_controller *cgc;
@@ -448,7 +455,7 @@ struct cgroup_controller *cgroup_get_controller(struct cgroup *cgroup,
 }
 
 int cgroup_get_value_string(struct cgroup_controller *controller,
-					const char *name, char **value)
+			    const char *name, char **value)
 {
 	int i;
 
@@ -473,7 +480,7 @@ int cgroup_get_value_string(struct cgroup_controller *controller,
 }
 
 int cgroup_set_value_string(struct cgroup_controller *controller,
-					const char *name, const char *value)
+			    const char *name, const char *value)
 {
 	int i;
 
@@ -482,6 +489,7 @@ int cgroup_set_value_string(struct cgroup_controller *controller,
 
 	for (i = 0; i < controller->index; i++) {
 		struct control_value *val = controller->values[i];
+
 		if (!strcmp(val->name, name)) {
 			strncpy(val->value, value, CG_VALUE_MAX);
 			val->value[sizeof(val->value)-1] = '\0';
@@ -494,7 +502,7 @@ int cgroup_set_value_string(struct cgroup_controller *controller,
 }
 
 int cgroup_get_value_int64(struct cgroup_controller *controller,
-					const char *name, int64_t *value)
+			   const char *name, int64_t *value)
 {
 	int i;
 
@@ -517,10 +525,10 @@ int cgroup_get_value_int64(struct cgroup_controller *controller,
 }
 
 int cgroup_set_value_int64(struct cgroup_controller *controller,
-					const char *name, int64_t value)
+			   const char *name, int64_t value)
 {
-	int i;
 	int ret;
+	int i;
 
 	if (!controller)
 		return ECGINVAL;
@@ -530,7 +538,7 @@ int cgroup_set_value_int64(struct cgroup_controller *controller,
 
 		if (!strcmp(val->name, name)) {
 			ret = snprintf(val->value,
-				sizeof(val->value), "%" PRId64, value);
+				       sizeof(val->value), "%" PRId64, value);
 
 			if (ret >= sizeof(val->value))
 				return ECGINVAL;
@@ -544,7 +552,7 @@ int cgroup_set_value_int64(struct cgroup_controller *controller,
 }
 
 int cgroup_get_value_uint64(struct cgroup_controller *controller,
-					const char *name, u_int64_t *value)
+			    const char *name, u_int64_t *value)
 {
 	int i;
 
@@ -553,8 +561,8 @@ int cgroup_get_value_uint64(struct cgroup_controller *controller,
 
 	for (i = 0; i < controller->index; i++) {
 		struct control_value *val = controller->values[i];
-		if (!strcmp(val->name, name)) {
 
+		if (!strcmp(val->name, name)) {
 			if (sscanf(val->value, "%" SCNu64, value) != 1)
 				return ECGINVAL;
 
@@ -566,10 +574,10 @@ int cgroup_get_value_uint64(struct cgroup_controller *controller,
 }
 
 int cgroup_set_value_uint64(struct cgroup_controller *controller,
-					const char *name, u_int64_t value)
+			    const char *name, u_int64_t value)
 {
-	int i;
 	int ret;
+	int i;
 
 	if (!controller)
 		return ECGINVAL;
@@ -578,8 +586,8 @@ int cgroup_set_value_uint64(struct cgroup_controller *controller,
 		struct control_value *val = controller->values[i];
 
 		if (!strcmp(val->name, name)) {
-			ret = snprintf(val->value,
-				sizeof(val->value), "%" PRIu64, value);
+			ret = snprintf(val->value, sizeof(val->value),
+				       "%" PRIu64, value);
 
 			if (ret >= sizeof(val->value))
 				return ECGINVAL;
@@ -593,7 +601,7 @@ int cgroup_set_value_uint64(struct cgroup_controller *controller,
 }
 
 int cgroup_get_value_bool(struct cgroup_controller *controller,
-						const char *name, bool *value)
+			  const char *name, bool *value)
 {
 	int i;
 
@@ -621,10 +629,10 @@ int cgroup_get_value_bool(struct cgroup_controller *controller,
 }
 
 int cgroup_set_value_bool(struct cgroup_controller *controller,
-						const char *name, bool value)
+			  const char *name, bool value)
 {
-	int i;
 	int ret;
+	int i;
 
 	if (!controller)
 		return ECGINVAL;
@@ -656,8 +664,8 @@ int cgroup_set_value_bool(struct cgroup_controller *controller,
 struct cgroup *create_cgroup_from_name_value_pairs(const char *name,
 		struct control_value *name_value, int nv_number)
 {
-	struct cgroup *src_cgroup;
 	struct cgroup_controller *cgc;
+	struct cgroup *src_cgroup;
 	char con[FILENAME_MAX];
 
 	int ret;
@@ -671,8 +679,10 @@ struct cgroup *create_cgroup_from_name_value_pairs(const char *name,
 		goto scgroup_err;
 	}
 
-	/* add pairs name-value to
-	   relevant controllers of this cgroup */
+	/*
+	 * add pairs name-value to
+	 * relevant controllers of this cgroup.
+	 */
 	for (i = 0; i < nv_number; i++) {
 
 		if ((strchr(name_value[i].name, '.')) == NULL) {
@@ -684,15 +694,17 @@ struct cgroup *create_cgroup_from_name_value_pairs(const char *name,
 		strncpy(con, name_value[i].name, FILENAME_MAX - 1);
 		strtok(con, ".");
 
-		/* find out whether we have to add the controller or
-		   cgroup already contains it */
+		/*
+		 * find out whether we have to add the controller or
+		 * cgroup already contains it.
+		 */
 		cgc = cgroup_get_controller(src_cgroup, con);
 		if (!cgc) {
 			/* add relevant controller */
 			cgc = cgroup_add_controller(src_cgroup, con);
 			if (!cgc) {
 				fprintf(stderr, "controller %s can't be add\n",
-						con);
+					con);
 				goto scgroup_err;
 			}
 		}


### PR DESCRIPTION
This is the patch series is the first attempt to bring up the `src/*.[ch]` files,
close to the coding style recommended by Linux Kernel's `/scripts/checkpatch.pl`.
It also introduces reverse Xmas declaration for local variables and re-orders the
headers files in the following order:
1. Header files that declare the functions, are defined in this file.
2. Other header files from the libcgroup.
3. Standard header file.

not all recommendations from `checkpatch.pl` are applicable to us, so this series
adds `.checkpatch.conf` at the top-level of the source directory, where the following
recommendations are ignored:
1. `--no-tree` - This hints that we are running it over the non-kernel tree.
2. `--ignore SPDX_LICENSE_TAG` - Linux Kernel excepts, the first line of the source
    to have SPDX License tag and it does not apply to us.
3. `--ignore USE_NEGATIVE_ERRNO` - The error code are positive in our source files,
    so ignore this error.
4. `--max-line-length=80` - Stick to 80 column limit for now.
5. `--ignore SSCANF_TO_KSTRTO` - ignore the recommendation of `kstr*` functions,
    those are implemented in the Kernel.




