### PR TITLE
log: add log level string prefix to logging functions

### DIFF
--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -76,9 +76,9 @@ extern "C" {
 
 #define CGROUP_FILE_PREFIX	"cgroup"
 
-#define cgroup_err(x...) cgroup_log(CGROUP_LOG_ERROR, x)
-#define cgroup_warn(x...) cgroup_log(CGROUP_LOG_WARNING, x)
-#define cgroup_info(x...) cgroup_log(CGROUP_LOG_INFO, x)
+#define cgroup_err(x...) cgroup_log(CGROUP_LOG_ERROR, "Error: " x)
+#define cgroup_warn(x...) cgroup_log(CGROUP_LOG_WARNING, "Warning: " x)
+#define cgroup_info(x...) cgroup_log(CGROUP_LOG_INFO, "Info: " x)
 #define cgroup_dbg(x...) cgroup_log(CGROUP_LOG_DEBUG, x)
 
 #define CGROUP_DEFAULT_LOGLEVEL CGROUP_LOG_ERROR

--- a/src/tools/tools-common.h
+++ b/src/tools/tools-common.h
@@ -25,9 +25,9 @@ extern "C" {
 #include <libcgroup.h>
 #include "../libcgroup-internal.h"
 
-#define cgroup_err(x...) cgroup_log(CGROUP_LOG_ERROR, x)
-#define cgroup_warn(x...) cgroup_log(CGROUP_LOG_WARNING, x)
-#define cgroup_info(x...) cgroup_log(CGROUP_LOG_INFO, x)
+#define cgroup_err(x...) cgroup_log(CGROUP_LOG_ERROR, "Error: " x)
+#define cgroup_warn(x...) cgroup_log(CGROUP_LOG_WARNING, "Warning: " x)
+#define cgroup_info(x...) cgroup_log(CGROUP_LOG_INFO, "Info: " x)
 #define cgroup_dbg(x...) cgroup_log(CGROUP_LOG_DEBUG, x)
 
 /**


### PR DESCRIPTION
Usage of cgroup_{err, warn, info} functions, expects the log level to be
prefixed to the message like: cgroup_warn("Warning: ...").  This patch
removes this need to prefix and automatically adds the desired prefix to
the logger function, so the usage becomes cgroup_warn("...").  This
helps in readability and avoiding typos in setting the right log level
string to the message.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>