### PR TITLE
[RFC] Adopt SPDX License tag

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-only
 
 set -ex
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,16 +1,10 @@
 #                                               -*- Autoconf -*-
+# SPDX-License-Identifier: LGPL-2.1-only
 # Process this file with autoconf to produce a configure script.
 #
 #  Copyright International Business Machines Corp. 2008
 #
 #  Authors:	Balbir Singh <balbir@linux.vnet.ibm.com>
-#  This program is free software; you can redistribute it and/or modify it
-#  under the terms of version 2.1 of the GNU Lesser General Public License
-#  as published by the Free Software Foundation.
-#
-#  This program is distributed in the hope that it would be useful, but
-#  WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 AC_PREREQ([2.69])
 

--- a/include/libcgroup.h
+++ b/include/libcgroup.h
@@ -1,16 +1,8 @@
-/*
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
  * Copyright IBM Corporation. 2007
  *
  * Author:	Balbir Singh <balbir@linux.vnet.ibm.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
  */
 
 #ifndef _LIBCGROUP_H

--- a/include/libcgroup/config.h
+++ b/include/libcgroup/config.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 #ifndef _LIBCGROUP_CONFIG_H
 #define _LIBCGROUP_CONFIG_H
 

--- a/include/libcgroup/error.h
+++ b/include/libcgroup/error.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 #ifndef _LIBCGROUP_ERROR_H
 #define _LIBCGROUP_ERROR_H
 

--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 #ifndef _LIBCGROUP_GROUPS_H
 #define _LIBCGROUP_GROUPS_H
 

--- a/include/libcgroup/iterators.h
+++ b/include/libcgroup/iterators.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 #ifndef _LIBCGROUP_ITERATORS_H
 #define _LIBCGROUP_ITERATORS_H
 

--- a/include/libcgroup/log.h
+++ b/include/libcgroup/log.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 #ifndef _LIBCGROUP_LOG_H
 #define _LIBCGROUP_LOG_H
 

--- a/include/libcgroup/tasks.h
+++ b/include/libcgroup/tasks.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 #ifndef _LIBCGROUP_TASKS_H
 #define _LIBCGROUP_TASKS_H
 

--- a/include/libcgroup/tools.h
+++ b/include/libcgroup/tools.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * Libcgroup tools header file
  *
@@ -5,19 +6,6 @@
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
  */
 
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
- */
 #ifndef _LIBCGROUP_TOOLS_H
 #define _LIBCGROUP_TOOLS_H
 

--- a/samples/c/get_all_controller.c
+++ b/samples/c/get_all_controller.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <libcgroup.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/c/get_controller.c
+++ b/samples/c/get_controller.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <libcgroup.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/c/get_mount_point.c
+++ b/samples/c/get_mount_point.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <libcgroup.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/c/get_procs.c
+++ b/samples/c/get_procs.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <stdio.h>
 #include <libcgroup.h>
 #include <stdlib.h>

--- a/samples/c/get_variable_names.c
+++ b/samples/c/get_variable_names.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <libcgroup.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/c/logger.c
+++ b/samples/c/logger.c
@@ -1,15 +1,8 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /*
  * Copyright Red Hat Inc., 2012
  *
  * Author:	Jan Safranek <jsafrane@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
  * Description: This file contains the test code for libcgroup logging.
  */

--- a/samples/c/proctest.c
+++ b/samples/c/proctest.c
@@ -1,15 +1,8 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /*
  * Copyright NEC Soft Ltd. 2009
  *
  * Author:	Ken'ichi Ohmichi <oomichi@mxs.nes.nec.co.jp>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 #include <stdio.h>

--- a/samples/c/read_stats.c
+++ b/samples/c/read_stats.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/samples/c/setuid.c
+++ b/samples/c/setuid.c
@@ -1,16 +1,8 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /*
  * Copyright Red Hat Inc. 2008
  *
  * Author:      Steve Olivieri <sjo@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
  */
 
 #include <stdio.h>

--- a/samples/c/test_functions.c
+++ b/samples/c/test_functions.c
@@ -1,15 +1,8 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /*
  * Copyright IBM Corporation. 2008
  *
  * Author:	Sudhir Kumar <skumar@linux.vnet.ibm.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
  * Description: This file contains the functions for testing libcgroup apis.
  */

--- a/samples/c/test_named_hierarchy.c
+++ b/samples/c/test_named_hierarchy.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/samples/c/walk_task.c
+++ b/samples/c/walk_task.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <stdio.h>
 #include <libcgroup.h>
 #include <stdlib.h>

--- a/samples/c/walk_test.c
+++ b/samples/c/walk_test.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/samples/c/wrapper_test.c
+++ b/samples/c/wrapper_test.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <libcgroup.h>
 #include <stdio.h>
 #include <string.h>

--- a/samples/config/cgconfig.conf
+++ b/samples/config/cgconfig.conf
@@ -1,14 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 #  Copyright IBM Corporation. 2007
 #
 #  Authors:	Balbir Singh <balbir@linux.vnet.ibm.com>
-#  This program is free software; you can redistribute it and/or modify it
-#  under the terms of version 2.1 of the GNU Lesser General Public License
-#  as published by the Free Software Foundation.
-#
-#  This program is distributed in the hope that it would be useful, but
-#  WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 #group daemons/www {
 #	perm {

--- a/samples/config/invalid_namespace_config.conf
+++ b/samples/config/invalid_namespace_config.conf
@@ -1,14 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 #  Copyright IBM Corporation. 2009
 #
 #  Authors:	Dhaval Giani <dhaval@linux.vnet.ibm.com>
-#  This program is free software; you can redistribute it and/or modify it
-#  under the terms of version 2.1 of the GNU Lesser General Public License
-#  as published by the Free Software Foundation.
-#
-#  This program is distributed in the hope that it would be useful, but
-#  WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 group www {
 	perm {

--- a/samples/config/namespace_config.conf
+++ b/samples/config/namespace_config.conf
@@ -1,14 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 #  Copyright IBM Corporation. 2009
 #
 #  Authors:	Dhaval Giani <dhaval@linux.vnet.ibm.com>
-#  This program is free software; you can redistribute it and/or modify it
-#  under the terms of version 2.1 of the GNU Lesser General Public License
-#  as published by the Free Software Foundation.
-#
-#  This program is distributed in the hope that it would be useful, but
-#  WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 group www {
 	perm {

--- a/scripts/init.d/cgconfig.in
+++ b/scripts/init.d/cgconfig.in
@@ -1,17 +1,11 @@
 #!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Start/Stop the workload manager
 #
 # Copyright IBM Corporation. 2008
 #
 # Authors:     Balbir Singh <balbir@linux.vnet.ibm.com>
-# This program is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it would be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 # cgconfig Control Groups Configuration Startup
 # chkconfig: - 5 95

--- a/scripts/init.d/cgred.in
+++ b/scripts/init.d/cgred.in
@@ -1,17 +1,11 @@
 #!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Start/Stop the CGroups Rules Engine Daemon
 #
 # Copyright Red Hat Inc. 2008
 #
 # Authors:	Steve Olivieri <sjo@redhat.com>
-# This program is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License
-# as published by the Free Software Foundation.
-# 
-# This program is distributed in the hope that it would be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 # cgred		CGroups Rules Engine Daemon
 # chkconfig:	- 14 86

--- a/src/abstraction-common.c
+++ b/src/abstraction-common.c
@@ -1,22 +1,9 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /**
  * Libcgroup abstraction layer
  *
  * Copyright (c) 2021-2022 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "abstraction-common.h"

--- a/src/abstraction-common.h
+++ b/src/abstraction-common.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * Libcgroup abstraction layer prototypes and structs
  *
@@ -5,19 +6,6 @@
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
  */
 
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
- */
 #ifndef __ABSTRACTION_COMMON
 #define __ABSTRACTION_COMMON
 

--- a/src/abstraction-cpu.c
+++ b/src/abstraction-cpu.c
@@ -1,22 +1,9 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /**
  * Libcgroup abstraction layer for the cpu controller
  *
  * Copyright (c) 2021-2022 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "abstraction-common.h"

--- a/src/abstraction-cpuset.c
+++ b/src/abstraction-cpuset.c
@@ -1,22 +1,9 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /**
  * Libcgroup abstraction layer for the cpuset controller
  *
  * Copyright (c) 2021-2022 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "abstraction-common.h"

--- a/src/abstraction-map.c
+++ b/src/abstraction-map.c
@@ -1,22 +1,9 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /**
  * Libcgroup abstraction layer mappings
  *
  * Copyright (c) 2021-2022 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "abstraction-common.h"

--- a/src/abstraction-map.h
+++ b/src/abstraction-map.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * Libcgroup abstraction layer mappings
  *
@@ -5,19 +6,6 @@
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
  */
 
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
- */
 #ifndef __ABSTRACTION_MAP
 #define __ABSTRACTION_MAP
 

--- a/src/api.c
+++ b/src/api.c
@@ -1,16 +1,9 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright IBM Corporation. 2007
  *
  * Author:	Dhaval Giani <dhaval@linux.vnet.ibm.com>
  * Author:	Balbir Singh <balbir@linux.vnet.ibm.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
  * TODOs:
  *	1. Add more APIs for the control groups.

--- a/src/config.c
+++ b/src/config.c
@@ -1,16 +1,9 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright IBM Corporation. 2007
  *
  * Authors:	Balbir Singh <balbir@linux.vnet.ibm.com>
  *		Dhaval Giani <dhaval@linux.vnet.ibm.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
  * TODOs:
  *	1. Implement our own hashing scheme

--- a/src/daemon/cgrulesengd.c
+++ b/src/daemon/cgrulesengd.c
@@ -1,4 +1,5 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright Red Hat Inc. 2008
  *
  * Author: Steve Olivieri <sjo@redhat.com>
@@ -19,14 +20,6 @@
  *
  * Copyright (C) 2005 BULL SA.
  * Written by Guillaume Thouvenin <guillaume.thouvenin <at> bull.net>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
  * TODO Stop using netlink for communication (or at least rewrite that part).
  */

--- a/src/daemon/cgrulesengd.h
+++ b/src/daemon/cgrulesengd.h
@@ -1,15 +1,8 @@
-/*
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
  * Copyright Red Hat Inc. 2008
  *
  * Author:      Steve Olivieri <sjo@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 #ifndef _CGRULESENGD_H

--- a/src/lex.l
+++ b/src/lex.l
@@ -1,14 +1,8 @@
-/*
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
  * Copyright IBM Corporation. 2007
  *
  * Authors:	Balbir Singh <balbir@linux.vnet.ibm.com>
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 %{

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -1,17 +1,10 @@
-/*
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
  * Copyright IBM Corporation. 2008
  *
  * Author:	Dhaval Giani <dhaval@linux.vnet.ibm.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
  */
+
 #ifndef __LIBCG_INTERNAL
 
 #define __LIBCG_INTERNAL

--- a/src/log.c
+++ b/src/log.c
@@ -1,15 +1,8 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright Red Hat, Inc. 2012
  *
  * Author:	Jan Safranek <jsafrane@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 #include <libcgroup.h>

--- a/src/pam/pam_cgroup.c
+++ b/src/pam/pam_cgroup.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /*
  * Copyright RedHat Inc. 2008
  *
@@ -40,14 +41,6 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * End of original copyright notice.
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 #include <stdio.h>

--- a/src/parse.y
+++ b/src/parse.y
@@ -1,18 +1,13 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright IBM Corporation. 2007
  *
  * Authors:	Balbir Singh <balbir@linux.vnet.ibm.com>
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
  * NOTE: The grammar has been modified, not to be the most efficient, but
  * to allow easy updation of internal data structures.
  */
+
 %{
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Libcgroup Python Bindings
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 @CODE_COVERAGE_RULES@
 

--- a/src/python/cgroup.pxd
+++ b/src/python/cgroup.pxd
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Libcgroup Python Bindings
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 # cython: language_level = 3str

--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Libcgroup Python Bindings
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 # cython: language_level = 3str

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Libcgroup Python Module Build Script
 #
@@ -7,20 +7,6 @@
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from setuptools import Extension, setup

--- a/src/tools/cgclassify.c
+++ b/src/tools/cgclassify.c
@@ -1,16 +1,8 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright RedHat Inc. 2008
  *
  * Authors:	Vivek Goyal <vgoyal@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
  */
 
 #include <stdio.h>

--- a/src/tools/cgconfig.c
+++ b/src/tools/cgconfig.c
@@ -1,17 +1,9 @@
-
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright IBM Corporation. 2007
  *
  * Authors:	Dhaval Giani <dhaval@linux.vnet.ibm.com>
  * 		Balbir Singh <balbir@linux.vnet.ibm.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
  * Code initiated and designed by Dhaval Giani. All faults are most likely
  * his mistake.

--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -1,16 +1,8 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright Red Hat, Inc. 2009
  *
  * Authors:	Ivana Hutarova Varekova <varekova@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
  */
 
 #include <libcgroup.h>

--- a/src/tools/cgdelete.c
+++ b/src/tools/cgdelete.c
@@ -1,16 +1,8 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright RedHat Inc. 2009
  *
  * Authors:	Jan Safranek <jsafrane@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
  */
 
 #include <libcgroup.h>

--- a/src/tools/cgexec.c
+++ b/src/tools/cgexec.c
@@ -1,16 +1,8 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright RedHat Inc. 2008
  *
  * Authors:	Vivek Goyal <vgoyal@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
  */
 
 #ifndef _GNU_SOURCE

--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
 

--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
 

--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -1,13 +1,7 @@
-/* " Copyright (C) 2010 Red Hat, Inc. All Rights Reserved.
- * " Written by Ivana Hutarova Varekova <varekova@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
+ * Copyright (C) 2010 Red Hat, Inc. All Rights Reserved.
+ * Written by Ivana Hutarova Varekova <varekova@redhat.com>
  */
 
 #include <stdio.h>

--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /**
  * Libcgroup extended cgget.  Works with both cgroup v1 and v2
  *
@@ -5,19 +6,6 @@
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
  */
 
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
- */
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
 

--- a/src/tools/cgxset.c
+++ b/src/tools/cgxset.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-only
 /**
  * Libcgroup extended cgset.  Works with both cgroup v1 and v2
  *
@@ -5,19 +6,6 @@
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
  */
 
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
- */
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
 

--- a/src/tools/lscgroup.c
+++ b/src/tools/lscgroup.c
@@ -1,13 +1,7 @@
-/* Copyright (C) 2009 Red Hat, Inc. All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
+ * Copyright (C) 2009 Red Hat, Inc. All Rights Reserved.
  * Written by Ivana Hutarova Varekova <varekova@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 #include <stdio.h>

--- a/src/tools/lssubsys.c
+++ b/src/tools/lssubsys.c
@@ -1,13 +1,7 @@
-/* " Copyright (C) 2009 Red Hat, Inc. All Rights Reserved.
- * " Written by Ivana Hutarova Varekova <varekova@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
+ * Copyright (C) 2009 Red Hat, Inc. All Rights Reserved.
+ * Written by Ivana Hutarova Varekova <varekova@redhat.com>
  */
 
 #include <stdio.h>

--- a/src/tools/tools-common.c
+++ b/src/tools/tools-common.c
@@ -1,17 +1,9 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright Red Hat, Inc. 2009
  *
  * Author:	Vivek Goyal <vgoyal@redhat.com>
  *		Jan Safranek <jsafrane@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
  */
 
 /* for asprintf */

--- a/src/tools/tools-common.h
+++ b/src/tools/tools-common.h
@@ -1,17 +1,9 @@
-/*
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
  * Copyright Red Hat, Inc. 2009
  *
  * Author:	Vivek Goyal <vgoyal@redhat.com>
  *		Jan Safranek <jsafrane@redhat.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
  */
 
 #ifndef __TOOLS_COMMON

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -1,15 +1,8 @@
-/*
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
  * Copyright IBM Corporation. 2008
  *
  * Author:	Dhaval Giani <dhaval@linux.vnet.ibm.com>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it would be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
  * Code initiated and designed by Dhaval Giani. All faults are most likely
  * his mistake.


### PR DESCRIPTION
Adopt SPDX license tag for all the source files, those already have
LGPL 2.1 bolierplate in them.  Adopting SPDX license helps the
compliance tools to determine the license and also helps in reducing the
repetitive license boilerplate across source files.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>