### PR TITLE
api.c: API to list mount points of a cgroup type

### DIFF
--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -616,6 +616,17 @@ int cgroup_convert_cgroup(struct cgroup * const out_cgroup,
 			  enum cg_version_t in_version);
 
 /**
+ * List the mount paths, that matches the specified version
+ *
+ *	@param cgrp_version The cgroup type/version
+ *	@param mount_paths Holds the list of mount paths
+ *	@return 0 success and list of mounts paths in mount_paths
+ *		ECGOTHER on failure and mount_paths is NULL.
+ */
+int cgroup_list_mount_points(const enum cg_version_t cgrp_version,
+			     char ***mount_paths);
+
+/**
  * Get the cgroup version of a controller.  Version is set to CGROUP_UNK
  * if the version cannot be determined.
  *

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -145,4 +145,5 @@ CGROUP_3.0 {
 	cgroup_cgxget;
 	cgroup_cgxset;
 	cgroup_version;
+	cgroup_list_mount_points;
 } CGROUP_2.0;

--- a/src/python/cgroup.pxd
+++ b/src/python/cgroup.pxd
@@ -51,4 +51,7 @@ cdef extern from "libcgroup.h":
     int cgroup_cgxset(const cgroup * const cg, cg_version_t version,
                       bint ignore_unmappable)
 
+    int cgroup_list_mount_points(const cg_version_t cgrp_version,
+                                 char ***mount_paths)
+
 # vim: set et ts=4 sw=4:

--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -277,6 +277,29 @@ cdef class Cgroup:
         if ret != 0:
             raise RuntimeError("Failed to create cgroup: {}".format(ret))
 
+    def cgroup_list_mount_points(self, version):
+        """List cgroup mount points of the specified version
+
+        Arguments:
+        version - It specifies the cgroup version
+
+        Description:
+        Parse the /proc/mounts and list the cgroup mount points matching the
+        version
+        """
+        cdef char **a
+
+        mount_points = []
+        ret = cgroup.cgroup_list_mount_points(version, &a)
+        if ret is not 0:
+            raise RuntimeError("cgroup_list_mount_points failed: {}".format(ret));
+
+        i = 0
+        while a[i]:
+            mount_points.append(<str>(a[i]).decode("utf-8"))
+            i = i + 1
+        return mount_points
+
     def __dealloc__(self):
         cgroup.cgroup_free(&self._cgp);
 


### PR DESCRIPTION
Currently, there is no easy way for a user to list cgroup mount points,
one way to acquire required information is by manually reading the
`/proc/mounts` and parsing the information they are interested in.

Add a new API:
`cgroup_list_mount_points(cg_version_t version, char ***mnts)`

where the first argument is either CGROUP_V1 or CGROUP_V2, which
specifies the mount point types and the second argument is a char**,
that will hold the mount point paths of the cgroup version specified in
the first argument. Note that the mnts pointers are supposed to free'd.
mnts pointers.

```
$ cat get_mount.c

int main(void)
{
        enum cg_version_t t = CGROUP_V2;
        char **mount_paths;
        int i = 0;
        int ret;

        cgroup_init();

         ret = cgroup_list_mount_points(t, &mount_paths);
         if (ret != 0) {
                 fprintf(stderr, "Failed to get mount points\n");
                 return ret;
        }

        while (mount_paths[i]) {
                fprintf(stderr, "%s\n", mount_paths[i]);
                free(mount_paths[i]);
                i++;
        }

        return 0;
}

$ gcc -o get_mount get_mount.c -lcgroup
```
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>