### PR TITLE
Makefile: fix samples/c build dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS= -I m4
-SUBDIRS = dist doc include samples scripts src tests
+SUBDIRS = dist doc include scripts src tests samples
 
 EXTRA_DIST = README_daemon libcgroup.doxyfile README_systemd CONTRIBUTING.md
 


### PR DESCRIPTION
If the user chooses to build the samples/c programs, it will fail to
build, with the error:

config.status: creating samples/c/Makefile
  CC       setuid.o
make: *** No rule to make target '../../src/.libs/libcgroup.la', needed by 'setuid'.  Stop.

it is due to the dependency on libcgroup.la, which is currently built
after
samples. Fix it by moving the samples directory to be built after src.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>