### PR TITLE
api.c: fix a memory leak in cgroup_init()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1416,8 +1416,6 @@ int cgroup_init(void)
 		}
 	}
 
-	free(temp_ent);
-
 	if (!found_mnt) {
 		cg_mount_table[0].name[0] = '\0';
 		ret = ECGROUPNOTMOUNTED;
@@ -1435,6 +1433,9 @@ unlock_exit:
 
 	if (proc_mount)
 		fclose(proc_mount);
+
+	if (temp_ent)
+		free(temp_ent);
 
 	for (i = 0; controllers[i]; i++) {
 		free(controllers[i]);


### PR DESCRIPTION
temp_ent is not free'ed in the error path if cgroup_process_v1_mnt() or
cgroup_process_v2_mnt() fails.  Move the free'ing of temp_ent to error
path.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>