### PR TITLE
Support simpler cleanup in functions

### DIFF
--- a/include/libcgroup.h
+++ b/include/libcgroup.h
@@ -18,6 +18,7 @@
 #include <libcgroup/config.h>
 #include <libcgroup/log.h>
 #include <libcgroup/tools.h>
+#include <libcgroup/util.h>
 
 #undef _LIBCGROUP_H_INSIDE
 

--- a/include/libcgroup/util.h
+++ b/include/libcgroup/util.h
@@ -1,0 +1,22 @@
+#ifndef _LIBCGROUP_UTIL_H_
+#define _LIBCGROUP_UTIL_H_
+
+/**
+ * \def defer(fn)
+ * \brief When used along with a variable, defers freeing up/cleanup
+ *
+ * When placed next to a variable, calls @param fn. This can be used
+ * to simplify cleanup and avoid a lot of the if-err-else style
+ * cleanup. NOTE: if the variable is a pointer and it's value is
+ * going to be alias'd, please DO NOT use this facility.
+ *
+ * \param fn function to invoke when the variable goes out of scope
+ */
+#define defer(fn)	__attribute__((__cleanup__(fn)))
+
+/*
+ * Some common cleanup functions
+ */
+void common_charptr_free(char **ptr);
+
+#endif /* _LIBCGROUP_UTIL_H_ */

--- a/src/api.c
+++ b/src/api.c
@@ -126,6 +126,16 @@ const char * const cgroup_strerror_codes[] = {
 	"Failed to remove a non-empty group",
 };
 
+/*
+ * common free util, not static for potential reuse across the library. We might
+ * need a better name and location as this evolves
+ */
+void common_charptr_free(char **ptr)
+{
+	if (ptr)
+		free(*ptr);
+}
+
 static const char * const cgroup_ignored_tasks_files[] = { "tasks", NULL };
 
 #ifndef UNIT_TEST
@@ -344,7 +354,7 @@ int cg_chmod_recursive(struct cgroup *cgroup, mode_t dir_mode,
 		       int dirm_change, mode_t file_mode, int filem_change)
 {
 	int final_ret = 0;
-	char *path;
+	char defer(common_charptr_free) *path;
 	int i, ret;
 
 	path = malloc(FILENAME_MAX);
@@ -365,7 +375,6 @@ int cg_chmod_recursive(struct cgroup *cgroup, mode_t dir_mode,
 		if (ret)
 			final_ret = ret;
 	}
-	free(path);
 	return final_ret;
 }
 
@@ -380,7 +389,7 @@ void cgroup_set_permissions(struct cgroup *cgroup,
 
 static char *cgroup_basename(const char *path)
 {
-	char *tmp_string;
+	char defer(common_charptr_free) *tmp_string;
 	char *base;
 
 	tmp_string = strdup(path);
@@ -389,8 +398,6 @@ static char *cgroup_basename(const char *path)
 		return NULL;
 
 	base = strdup(basename(tmp_string));
-
-	free(tmp_string);
 
 	return base;
 }
@@ -772,7 +779,7 @@ static int cgroup_parse_rules_file(char *filename, bool cache, uid_t muid,
 			if (!matched)
 				continue;
 			if (len_procname) {
-				char *mproc_base;
+				char defer(common_charptr_free) *mproc_base;
 				/*
 				 * If there is a rule based on process name,
 				 * it should be matched with mprocname.
@@ -790,10 +797,8 @@ static int cgroup_parse_rules_file(char *filename, bool cache, uid_t muid,
 					uid = CGRULE_INVALID;
 					gid = CGRULE_INVALID;
 					matched = false;
-					free(mproc_base);
 					continue;
 				}
-				free(mproc_base);
 			}
 		}
 
@@ -1313,7 +1318,7 @@ int cgroup_init(void)
 	FILE *proc_cgroup = NULL;
 	FILE *proc_mount = NULL;
 	int found_mnt = 0;
-	char *buf = NULL;
+	char defer(common_charptr_free) *buf = NULL;
 	int ret = 0;
 	int i = 0;
 	int err;
@@ -1358,14 +1363,12 @@ int cgroup_init(void)
 		goto unlock_exit;
 	}
 	if (!fgets(buf, LL_MAX, proc_cgroup)) {
-		free(buf);
 		cgroup_err("Error: cannot read /proc/cgroups: %s\n",
 			   strerror(errno));
 		last_errno = errno;
 		ret = ECGOTHER;
 		goto unlock_exit;
 	}
-	free(buf);
 
 	i = 0;
 	while (!feof(proc_cgroup)) {
@@ -1529,14 +1532,13 @@ char *cg_build_path_locked(const char *name, char *path,
 				   cg_cgroup_v2_mount_path);
 
 		if (name) {
-			char *tmp;
+			char defer(common_charptr_free) *tmp;
 
 			tmp = strdup(path);
 			if (tmp == NULL)
 				return NULL;
 
 			cg_concat_path(tmp, name, path);
-			free(tmp);
 		}
 		return path;
 	}
@@ -1573,14 +1575,13 @@ char *cg_build_path_locked(const char *name, char *path,
 			}
 
 			if (name) {
-				char *tmp;
+				char defer(common_charptr_free) *tmp;
 
 				tmp = strdup(path);
 				if (tmp == NULL)
 					break;
 
 				cg_concat_path(tmp, name, path);
-				free(tmp);
 			}
 			return path;
 		}
@@ -1876,7 +1877,7 @@ int cgroup_attach_task(struct cgroup *cgroup)
  */
 int cg_mkdir_p(const char *path)
 {
-	char *real_path = NULL;
+	char defer(common_charptr_free) *real_path = NULL;
 	int stat_ret, ret = 0;
 	struct stat st;
 	int i = 0;
@@ -1911,7 +1912,7 @@ int cg_mkdir_p(const char *path)
 				break;
 			case EPERM:
 				ret = ECGROUPNOTOWNER;
-				goto done;
+				return ret;
 			default:
 				/* Check if path exists */
 				real_path[i] = '\0';
@@ -1922,13 +1923,11 @@ int cg_mkdir_p(const char *path)
 					break;
 				}
 				ret = ECGROUPNOTALLOWED;
-				goto done;
+				return ret;
 			}
 		}
 	} while (real_path[i]);
 
-done:
-	free(real_path);
 	return ret;
 }
 
@@ -1957,7 +1956,7 @@ static int cg_create_control_group(const char *path)
  */
 static int cg_set_control_value(char *path, const char *val)
 {
-	char *str_val_start;
+	char defer(common_charptr_free) *str_val_start = NULL;
 	char *str_val;
 	int ctl_file;
 	size_t len;
@@ -1979,7 +1978,7 @@ static int cg_set_control_value(char *path, const char *val)
 			 */
 			char *path_dir_end;
 			FILE *control_file;
-			char *tasks_path;
+			char defer(common_charptr_free) *tasks_path = NULL;
 
 			path_dir_end = strrchr(path, '/');
 			if (path_dir_end == NULL)
@@ -1999,14 +1998,12 @@ static int cg_set_control_value(char *path, const char *val)
 			control_file = fopen(tasks_path, "re");
 			if (!control_file) {
 				if (errno == ENOENT) {
-					free(tasks_path);
 					return ECGROUPSUBSYSNOTMOUNTED;
 				}
 			} else {
 				fclose(control_file);
 			}
 
-			free(tasks_path);
 			return ECGROUPNOTALLOWED;
 		}
 		return ECGROUPVALUENOTEXIST;
@@ -2037,7 +2034,6 @@ static int cg_set_control_value(char *path, const char *val)
 		if (len > 0) {
 			if (write(ctl_file, str_val, len) == -1) {
 				last_errno = errno;
-				free(str_val_start);
 				close(ctl_file);
 				return ECGOTHER;
 			}
@@ -2048,11 +2044,9 @@ static int cg_set_control_value(char *path, const char *val)
 
 	if (close(ctl_file)) {
 		last_errno = errno;
-		free(str_val_start);
 		return ECGOTHER;
 	}
 
-	free(str_val_start);
 	return 0;
 }
 
@@ -2067,7 +2061,7 @@ STATIC int cgroup_set_values_recursive(const char * const base,
 	bool ignore_non_dirty_failures)
 {
 	int ret, j, error = 0;
-	char *path = NULL;
+	char defer(common_charptr_free) *path = NULL;
 
 	for (j = 0; j < controller->index; j++) {
 		ret = asprintf(&path, "%s%s", base,
@@ -2082,7 +2076,6 @@ STATIC int cgroup_set_values_recursive(const char * const base,
 
 		error = cg_set_control_value(path,
 					     controller->values[j]->value);
-		free(path);
 		path = NULL;
 
 		if (error && ignore_non_dirty_failures &&
@@ -2102,14 +2095,6 @@ STATIC int cgroup_set_values_recursive(const char * const base,
 	}
 
 err:
-	/*
-	 * As currently written, path should always be null as we are exiting
-	 * this function, but let's check just in case, and free it if it's
-	 * non-null
-	 */
-	if (path)
-		free(path);
-
 	return error;
 }
 
@@ -2124,7 +2109,8 @@ STATIC int cgroupv2_get_subtree_control(const char *path,
 					const char *ctrl_name,
 					bool * const enabled)
 {
-	char *path_copy = NULL, *saveptr = NULL, *token, *ret_c;
+	char defer(common_charptr_free) *path_copy = NULL;
+	char *saveptr = NULL, *token, *ret_c;
 	int ret, error = ECGROUPNOTMOUNTED;
 	char buffer[FILENAME_MAX];
 	FILE *fp = NULL;
@@ -2172,8 +2158,6 @@ STATIC int cgroupv2_get_subtree_control(const char *path,
 	} while ((token = strtok_r(NULL, " ", &saveptr)));
 
 out:
-	if (path_copy)
-		free(path_copy);
 	if (fp)
 		fclose(fp);
 
@@ -2192,7 +2176,7 @@ STATIC int cgroupv2_subtree_control(const char *path, const char *ctrl_name,
 {
 	int ret, error = ECGOTHER;
 	char *path_copy = NULL;
-	char *value = NULL;
+	char defer(common_charptr_free) *value = NULL;
 
 	if (!path || !ctrl_name)
 		return ECGOTHER;
@@ -2222,8 +2206,6 @@ STATIC int cgroupv2_subtree_control(const char *path, const char *ctrl_name,
 		goto out;
 
 out:
-	if (value)
-		free(value);
 	if (path_copy)
 		free(path_copy);
 	return error;
@@ -2460,7 +2442,7 @@ STATIC int cgroup_chown_chmod_tasks(const char * const cg_path,
 				    uid_t uid, gid_t gid, mode_t fperm)
 {
 	int ret, error;
-	char *tasks_path = NULL;
+	char defer(common_charptr_free) *tasks_path = NULL;
 
 	tasks_path = (char *)malloc(FILENAME_MAX);
 	if (tasks_path == NULL)
@@ -2470,7 +2452,7 @@ STATIC int cgroup_chown_chmod_tasks(const char * const cg_path,
 	if (ret < 0 || ret >= FILENAME_MAX) {
 		last_errno = errno;
 		error = ECGOTHER;
-		goto err;
+		return error;
 	}
 
 	error = cg_chown(tasks_path, uid, gid);
@@ -2482,10 +2464,6 @@ STATIC int cgroup_chown_chmod_tasks(const char * const cg_path,
 		error = ECGOTHER;
 	}
 
-err:
-	if (tasks_path)
-		free(tasks_path);
-
 	return error;
 }
 
@@ -2495,8 +2473,8 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 {
 	enum cg_version_t version;
 	char *fts_path[2];
-	char *base = NULL;
-	char *path = NULL;
+	char defer(common_charptr_free) *base = NULL;
+	char defer(common_charptr_free) *path = NULL;
 	int error;
 
 	fts_path[0] = (char *)malloc(FILENAME_MAX);
@@ -2510,13 +2488,13 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 	if (controller) {
 		if (!cg_build_path(cgroup->name, path, controller->name)) {
 			error = ECGOTHER;
-			goto err;
+			return error;
 		}
 
 		error = cgroup_get_controller_version(controller->name,
 						      &version);
 		if (error)
-			goto err;
+			return error;
 
 		if (version == CGROUP_V2) {
 			char *parent, *dname;
@@ -2524,7 +2502,7 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 			parent = strdup(path);
 			if (!parent) {
 				error = ECGOTHER;
-				goto err;
+				return error;
 			}
 
 			dname = dirname(parent);
@@ -2533,25 +2511,25 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 					controller->name, true);
 			free(parent);
 			if (error)
-				goto err;
+				return error;
 		}
 	} else {
 		if (!cg_build_path(cgroup->name, path, NULL)) {
 			error = ECGOTHER;
-			goto err;
+			return error;
 		}
 	}
 
 	error = cg_create_control_group(path);
 	if (error)
-		goto err;
+		return error;
 
 	base = strdup(path);
 
 	if (!base) {
 		last_errno = errno;
 		error = ECGOTHER;
-		goto err;
+		return error;
 	}
 
 	if (!ignore_ownership) {
@@ -2568,12 +2546,12 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 	}
 
 	if (error)
-		goto err;
+		return error;
 
 	if (controller) {
 		error = cgroup_set_values_recursive(base, controller, false);
 		if (error)
-			goto err;
+			return error;
 	}
 
 	if (!ignore_ownership && version == CGROUP_V1) {
@@ -2581,14 +2559,9 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 				cgroup->tasks_uid, cgroup->tasks_gid,
 				cgroup->task_fperm);
 		if (error)
-			goto err;
+			return error;
 	}
 
-err:
-	if (path)
-		free(path);
-	if (base)
-		free(base);
 	return error;
 }
 
@@ -2657,7 +2630,7 @@ int cgroup_create_cgroup(struct cgroup *cgroup, int ignore_ownership)
 static int cgroup_get_parent_name(struct cgroup *cgroup, char **parent)
 {
 	char *pdir = NULL;
-	char *dir = NULL;
+	char defer(common_charptr_free) *dir = NULL;
 	int ret = 0;
 
 	dir = strdup(cgroup->name);
@@ -2682,7 +2655,6 @@ static int cgroup_get_parent_name(struct cgroup *cgroup, char **parent)
 			ret = ECGOTHER;
 		}
 	}
-	free(dir);
 
 	return ret;
 }
@@ -2708,7 +2680,7 @@ static int cgroup_find_parent(struct cgroup *cgroup, char *controller,
 {
 	struct stat stat_child, stat_parent;
 	char child_path[FILENAME_MAX];
-	char *parent_path = NULL;
+	char defer(common_charptr_free) *parent_path = NULL;
 	int ret = 0;
 
 	*parent = NULL;
@@ -2730,13 +2702,13 @@ static int cgroup_find_parent(struct cgroup *cgroup, char *controller,
 	if (stat(child_path, &stat_child) < 0) {
 		last_errno = errno;
 		ret = ECGOTHER;
-		goto free_parent;
+		return ret;
 	}
 
 	if (stat(parent_path, &stat_parent) < 0) {
 		last_errno = errno;
 		ret = ECGOTHER;
-		goto free_parent;
+		return ret;
 	}
 
 	/* Is the specified "name" a mount point? */
@@ -2748,8 +2720,6 @@ static int cgroup_find_parent(struct cgroup *cgroup, char *controller,
 		ret = cgroup_get_parent_name(cgroup, parent);
 	}
 
-free_parent:
-	free(parent_path);
 	return ret;
 }
 
@@ -2765,7 +2735,7 @@ int cgroup_create_cgroup_from_parent(struct cgroup *cgroup,
 				     int ignore_ownership)
 {
 	struct cgroup *parent_cgroup = NULL;
-	char *parent = NULL;
+	char defer(common_charptr_free) *parent = NULL;
 	int ret = ECGFAIL;
 
 	if (!cgroup_initialized)
@@ -2787,7 +2757,7 @@ int cgroup_create_cgroup_from_parent(struct cgroup *cgroup,
 	parent_cgroup = cgroup_new_cgroup(parent);
 	if (!parent_cgroup) {
 		ret = ECGFAIL;
-		goto err_nomem;
+		return ret;
 	}
 
 	if (cgroup_get_cgroup(parent_cgroup)) {
@@ -2806,8 +2776,6 @@ int cgroup_create_cgroup_from_parent(struct cgroup *cgroup,
 
 err_parent:
 	cgroup_free(&parent_cgroup);
-err_nomem:
-	free(parent);
 	return ret;
 }
 
@@ -3213,11 +3181,11 @@ int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup,
 {
 	char path[FILENAME_MAX+1];
 	struct stat stat_buffer;
-	char *ctrl_value = NULL;
+	char defer(common_charptr_free) *ctrl_value = NULL;
 	char *ctrl_name = NULL;
 	char *ctrl_file = NULL;
 	char *tmp_path = NULL;
-	char *d_name = NULL;
+	char defer(common_charptr_free) *d_name = NULL;
 	char *buffer = NULL;
 	int tmp_len = 0;
 	int error = 0;
@@ -3226,7 +3194,7 @@ int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup,
 
 	if (!strcmp(d_name, ".") || !strcmp(d_name, "..")) {
 		error = ECGINVAL;
-		goto fill_error;
+		return error;
 	}
 
 
@@ -3242,7 +3210,7 @@ int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup,
 
 	if (error) {
 		error = ECGFAIL;
-		goto fill_error;
+		return error;
 	}
 
 	/*
@@ -3275,14 +3243,14 @@ int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup,
 
 	if (!ctrl_name) {
 		error = ECGFAIL;
-		goto fill_error;
+		return error;
 	}
 
 	ctrl_file = strtok_r(NULL, ".", &buffer);
 
 	if (!ctrl_file) {
 		error = ECGINVAL;
-		goto fill_error;
+		return error;
 	}
 
 	if (strcmp(ctrl_name, cg_mount_table[cg_index].name) == 0) {
@@ -3290,18 +3258,14 @@ int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup,
 					cgroup->name, ctrl_dir->d_name,
 					&ctrl_value);
 		if (error || !ctrl_value)
-			goto fill_error;
+			return error;
 
 		if (cgroup_add_value_string(cgc, ctrl_dir->d_name,
 					    ctrl_value)) {
 			error = ECGFAIL;
-			goto fill_error;
+			return error;
 		}
 	}
-fill_error:
-	if (ctrl_value)
-		free(ctrl_value);
-	free(d_name);
 	return error;
 }
 
@@ -4493,7 +4457,7 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller,
 				       char **current_path)
 {
 	FILE *pid_cgroup_fd = NULL;
-	char *path = NULL;
+	char defer(common_charptr_free) *path = NULL;
 	int ret;
 
 	if (!controller)
@@ -4514,7 +4478,7 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller,
 	ret = ECGROUPNOTEXIST;
 	pid_cgroup_fd = fopen(path, "re");
 	if (!pid_cgroup_fd)
-		goto cleanup_path;
+		return ret;
 
 	/*
 	 * Why do we grab the cg_mount_table_lock?, the reason is that
@@ -4567,8 +4531,6 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller,
 done:
 	pthread_rwlock_unlock(&cg_mount_table_lock);
 	fclose(pid_cgroup_fd);
-cleanup_path:
-	free(path);
 	return ret;
 }
 
@@ -4775,7 +4737,7 @@ static int cg_read_stat(FILE *fp, struct cgroup_stat *cgroup_stat)
 {
 	char *saveptr = NULL;
 	ssize_t read_bytes;
-	char *line = NULL;
+	char defer(common_charptr_free) *line = NULL;
 	size_t len = 0;
 	char *token;
 	int ret = 0;
@@ -4783,25 +4745,23 @@ static int cg_read_stat(FILE *fp, struct cgroup_stat *cgroup_stat)
 	read_bytes = getline(&line, &len, fp);
 	if (read_bytes == -1) {
 		ret = ECGEOF;
-		goto out_free;
+		return ret;
 	}
 
 	token = strtok_r(line, " ", &saveptr);
 	if (!token) {
 		ret = ECGINVAL;
-		goto out_free;
+		return ret;
 	}
 	strncpy(cgroup_stat->name, token, FILENAME_MAX - 1);
 
 	token = strtok_r(NULL, " ", &saveptr);
 	if (!token) {
 		ret = ECGINVAL;
-		goto out_free;
+		return ret;
 	}
 	strncpy(cgroup_stat->value, token, CG_VALUE_MAX - 1);
 
-out_free:
-	free(line);
 	return ret;
 }
 
@@ -4989,7 +4949,7 @@ int cgroup_get_task_begin(const char *cgroup, const char *controller,
 			  void **handle, pid_t *pid)
 {
 	char path[FILENAME_MAX];
-	char *fullpath = NULL;
+	char defer(common_charptr_free) *fullpath = NULL;
 	int ret = 0;
 
 	if (!cgroup_initialized)
@@ -5006,7 +4966,6 @@ int cgroup_get_task_begin(const char *cgroup, const char *controller,
 	}
 
 	*handle = (void *) fopen(fullpath, "re");
-	free(fullpath);
 
 	if (!*handle) {
 		last_errno = errno;
@@ -5393,7 +5352,7 @@ int cgroup_get_procname_from_procfs(pid_t pid, char **procname)
 	char path[FILENAME_MAX];
 	char buf[FILENAME_MAX];
 	char *pname_cmdline;
-	char *pname_status;
+	char defer(common_charptr_free) *pname_status;
 	int ret;
 
 	ret = cg_get_procname_from_proc_status(pid, &pname_status);
@@ -5419,7 +5378,6 @@ int cgroup_get_procname_from_procfs(pid_t pid, char **procname)
 		 * shortened to 15 characters if it is over. So the
 		 * name should be compared by its length.
 		 */
-		free(pname_status);
 		*procname = strdup(buf);
 		if (*procname == NULL) {
 			last_errno = errno;
@@ -5439,7 +5397,6 @@ int cgroup_get_procname_from_procfs(pid_t pid, char **procname)
 						&pname_cmdline);
 	if (!ret) {
 		*procname = pname_cmdline;
-		free(pname_status);
 		return 0;
 	}
 
@@ -5448,7 +5405,6 @@ int cgroup_get_procname_from_procfs(pid_t pid, char **procname)
 	 * /proc/pid/exe points to real executable name then.
 	 * Return it as the last resort.
 	 */
-	free(pname_status);
 	*procname = strdup(buf);
 	if (*procname == NULL) {
 		last_errno = errno;


### PR DESCRIPTION
Add support for a defer() style function, which cleans up
the memory associated with an auto/local variable when it
goes out of scope. The assumption is that this code is
compiled on a compile with support for the cleanup attribute.

Changes in the patch:
1. Add util.h with support for defer
2. Add common_charptr_cleanup() function to be called for
   freeing char pointers (largely strings in our case containing
   paths)
3. Modify src/api.c to use the new framework

TODO:
1. Support other types of defer functions
2. Support fd closure in cleanup
3. Implement these changes for other files

Testing:
Very light, just compiled and ran simple commands.

Signed-off-by: Balbir singh <bsingharora@gmail.com>