### PR TITLE
tools: Introduce err()/info() helper function to print messages

### DIFF
--- a/src/tools/cgclassify.c
+++ b/src/tools/cgclassify.c
@@ -29,21 +29,20 @@
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr,	" try %s -h' for more information.\n",
-			program_name);
+		err("Wrong input parameters, ");
+		err("try %s '-h' for more information.\n", program_name);
 		return;
 	}
-	printf("Usage: %s [[-g] <controllers>:<path>] ", program_name);
-	printf("[--sticky | --cancel-sticky] <list of pids>\n");
-	printf("Move running task(s) to given cgroups\n");
-	printf("  -h, --help			Display this help\n");
-	printf("  -g <controllers>:<path>	Control group to be used ");
-	printf("as target\n");
-	printf("  --cancel-sticky		cgred daemon change pidlist ");
-	printf("and children tasks\n");
-	printf("  --sticky			cgred daemon does not change ");
-	printf("pidlist and children tasks\n");
+
+	info("Usage: %s [[-g] <controllers>:<path>] ", program_name);
+	info("[--sticky | --cancel-sticky] <list of pids>\n");
+	info("Move running task(s) to given cgroups\n");
+	info("  -h, --help			Display this help\n");
+	info("  -g <controllers>:<path>	Control group to be used as target\n");
+	info("  --cancel-sticky		cgred daemon change pidlist ");
+	info("and children tasks\n");
+	info("  --sticky			cgred daemon does not change ");
+	info("pidlist and children tasks\n");
 }
 
 /*
@@ -61,8 +60,8 @@ static int change_group_path(pid_t pid, struct cgroup_group_spec *cgroup_list[])
 		ret = cgroup_change_cgroup_path(cgroup_list[i]->path, pid,
 						(const char *const*) cgroup_list[i]->controllers);
 		if (ret) {
-			fprintf(stderr, "Error changing group of pid %d: %s\n",
-				pid, cgroup_strerror(ret));
+			err("Error changing group of pid %d: %s\n", pid,
+			    cgroup_strerror(ret));
 			return -1;
 		}
 	}
@@ -82,23 +81,21 @@ static int change_group_based_on_rule(pid_t pid)
 
 	/* Put pid into right cgroup as per rules in /etc/cgrules.conf */
 	if (cgroup_get_uid_gid_from_procfs(pid, &euid, &egid)) {
-		fprintf(stderr, "Error in determining euid/egid of ");
-		fprintf(stderr, "pid %d\n", pid);
+		err("Error in determining euid/egid of pid %d\n", pid);
 		goto out;
 	}
 
 	ret = cgroup_get_procname_from_procfs(pid, &procname);
 	if (ret) {
-		fprintf(stderr, "Error in determining process name of ");
-		fprintf(stderr, "pid %d\n", pid);
+		err("Error in determining process name of pid %d\n", pid);
 		goto out;
 	}
 
 	/* Change the cgroup by determining the rules */
 	ret = cgroup_change_cgroup_flags(euid, egid, procname, pid, 0);
 	if (ret) {
-		fprintf(stderr, "Error: change of cgroup failed for ");
-		fprintf(stderr, "pid %d: %s\n", pid, cgroup_strerror(ret));
+		err("Error: change of cgroup failed for pid %d: %s\n", pid,
+		    cgroup_strerror(ret));
 		goto out;
 	}
 	ret = 0;
@@ -143,8 +140,8 @@ int main(int argc, char *argv[])
 			ret = parse_cgroup_spec(cgroup_list, optarg,
 						CG_HIER_MAX);
 			if (ret) {
-				fprintf(stderr, "cgroup controller and path ");
-				fprintf(stderr,	"parsing failed\n");
+				err("cgroup controller and path parsing ");
+				err("failed\n");
 				return -1;
 			}
 			cg_specified = 1;
@@ -165,8 +162,8 @@ int main(int argc, char *argv[])
 	/* Initialize libcg */
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "%s: libcgroup initialization failed: %s\n",
-			argv[0], cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0],
+		    cgroup_strerror(ret));
 		return ret;
 	}
 
@@ -174,8 +171,7 @@ int main(int argc, char *argv[])
 		pid = (pid_t) strtol(argv[i], &endptr, 10);
 		if (endptr[0] != '\0') {
 			/* the input argument was not a number */
-			fprintf(stderr, "Error: %s is not valid pid.\n",
-				argv[i]);
+			err("Error: %s is not valid pid.\n", argv[i]);
 			exit_code = 2;
 			continue;
 		}

--- a/src/tools/cgconfig.c
+++ b/src/tools/cgconfig.c
@@ -32,29 +32,30 @@ static struct cgroup_string_list cfg_files;
 static void usage(int status, char *progname)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters, ");
-		fprintf(stderr, "try %s -h' for more information.\n", progname);
+		err("Wrong input parameters, ");
+		err("try %s '-h' for more information.\n", progname);
 		return;
 	}
-	printf("Usage: %s [-h] [-f mode] [-d mode] [-s mode] ", progname);
-	printf("[-t <tuid>:<tgid>] [-a <agid>:<auid>] [-l FILE] ");
-	printf("[-L DIR] ...\n");
-	printf("Parse and load the specified cgroups configuration file\n");
-	printf("  -a <tuid>:<tgid>		Default owner of groups ");
-	printf("files and directories\n");
-	printf("  -d, --dperm=mode		Default group directory ");
-	printf("permissions\n");
-	printf("  -f, --fperm=mode		Default group file ");
-	printf("permissions\n");
-	printf("  -h, --help			Display this help\n");
-	printf("  -l, --load=FILE		Parse and load the cgroups ");
-	printf("configuration file\n");
-	printf("  -L, --load-directory=DIR	Parse and load the cgroups ");
-	printf("configuration files from a directory\n");
-	printf("  -s, --tperm=mode		Default tasks file ");
-	printf("permissions\n");
-	printf("  -t <tuid>:<tgid>		Default owner of the tasks ");
-	printf("file\n");
+
+	info("Usage: %s [-h] [-f mode] [-d mode] [-s mode] ", progname);
+	info("[-t <tuid>:<tgid>] [-a <agid>:<auid>] [-l FILE] ");
+	info("[-L DIR] ...\n");
+	info("Parse and load the specified cgroups configuration file\n");
+	info("  -a <tuid>:<tgid>		Default owner of groups ");
+	info("files and directories\n");
+	info("  -d, --dperm=mode		Default group directory ");
+	info("permissions\n");
+	info("  -f, --fperm=mode		Default group file ");
+	info("permissions\n");
+	info("  -h, --help			Display this help\n");
+	info("  -l, --load=FILE		Parse and load the cgroups ");
+	info("configuration file\n");
+	info("  -L, --load-directory=DIR	Parse and load the cgroups ");
+	info("configuration files from a directory\n");
+	info("  -s, --tperm=mode		Default tasks file ");
+	info("permissions\n");
+	info("  -t <tuid>:<tgid>		Default owner of the tasks ");
+	info("file\n");
 }
 
 int main(int argc, char *argv[])
@@ -92,8 +93,8 @@ int main(int argc, char *argv[])
 
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "%s: libcgroup initialization failed: %s\n",
-			argv[0], cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0],
+		    cgroup_strerror(ret));
 		goto err;
 	}
 
@@ -111,8 +112,8 @@ int main(int argc, char *argv[])
 		case 'l':
 			error = cgroup_string_list_add_item(&cfg_files, optarg);
 			if (error) {
-				fprintf(stderr, "%s: cannot add file ", argv[0]);
-				fprintf(stderr, "to list, out of memory?\n");
+				err("%s: cannot add file to list, ", argv[0]);
+				err("out of memory?\n");
 				goto err;
 			}
 			break;
@@ -167,14 +168,14 @@ int main(int argc, char *argv[])
 	default_group = cgroup_new_cgroup("default");
 	if (!default_group) {
 		error = -1;
-		fprintf(stderr, "%s: cannot create default cgroup\n", argv[0]);
+		err("%s: cannot create default cgroup\n", argv[0]);
 		goto err;
 	}
 
 	error = cgroup_set_uid_gid(default_group, tuid, tgid, auid, agid);
 	if (error) {
-		fprintf(stderr, "%s: cannot set default UID and GID: %s\n",
-			argv[0], cgroup_strerror(error));
+		err("%s: cannot set default UID and GID: %s\n", argv[0],
+		    cgroup_strerror(error));
 		goto free_cgroup;
 	}
 
@@ -185,16 +186,16 @@ int main(int argc, char *argv[])
 
 	error = cgroup_config_set_default(default_group);
 	if (error) {
-		fprintf(stderr, "%s: cannot set config parser defaults: %s\n",
-			argv[0], cgroup_strerror(error));
+		err("%s: cannot set config parser defaults: %s\n", argv[0],
+		    cgroup_strerror(error));
 		goto free_cgroup;
 	}
 
 	for (i = 0; i < cfg_files.count; i++) {
 		ret = cgroup_config_load_config(cfg_files.items[i]);
 		if (ret) {
-			fprintf(stderr, "%s; error loading %s: %s\n", argv[0],
-				cfg_files.items[i], cgroup_strerror(ret));
+			err("%s; error loading %s: %s\n", argv[0],
+			    cfg_files.items[i], cgroup_strerror(ret));
 			if (!error)
 				error = ret;
 		}

--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -27,25 +27,23 @@
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters, ");
-		fprintf(stderr, " try %s -h' for more information.\n",
-			program_name);
+		err("Wrong input parameters, ");
+		err(" try %s -h' for more information.\n", program_name);
 		return;
 	}
 
-	printf("Usage: %s [-h] [-f mode] [-d mode] [-s mode] ", program_name);
-	printf("[-t <tuid>:<tgid>] [-a <agid>:<auid>] ");
-	printf("-g <controllers>:<path> [-g ...]\n");
-	printf("Create control group(s)\n");
-	printf("  -a <tuid>:<tgid>		Owner of the group and all ");
-	printf("its files\n");
-	printf("  -d, --dperm=mode		Group directory permissions\n");
-	printf("  -f, --fperm=mode		Group file permissions\n");
-	printf("  -g <controllers>:<path>	Control group which should ");
-	printf("be added\n");
-	printf("  -h, --help			Display this help\n");
-	printf("  -s, --tperm=mode		Tasks file permissions\n");
-	printf("  -t <tuid>:<tgid>		Owner of the tasks file\n");
+	info("Usage: %s [-h] [-f mode] [-d mode] [-s mode] ", program_name);
+	info("[-t <tuid>:<tgid>] [-a <agid>:<auid>] ");
+	info("-g <controllers>:<path> [-g ...]\n");
+	info("Create control group(s)\n");
+	info("  -a <tuid>:<tgid>		Owner of the group and all ");
+	info("its files\n");
+	info("  -d, --dperm=mode		Group directory permissions\n");
+	info("  -f, --fperm=mode		Group file permissions\n");
+	info("  -g <controllers>:<path>	Control group which should be added\n");
+	info("  -h, --help			Display this help\n");
+	info("  -s, --tperm=mode		Tasks file permissions\n");
+	info("  -t <tuid>:<tgid>		Owner of the tasks file\n");
 }
 
 int main(int argc, char *argv[])
@@ -90,7 +88,7 @@ int main(int argc, char *argv[])
 
 	cgroup_list = calloc(capacity, sizeof(struct cgroup_group_spec *));
 	if (cgroup_list == NULL) {
-		fprintf(stderr, "%s: out of memory\n", argv[0]);
+		err("%s: out of memory\n", argv[0]);
 		ret = -1;
 		goto err;
 	}
@@ -116,10 +114,8 @@ int main(int argc, char *argv[])
 		case 'g':
 			ret = parse_cgroup_spec(cgroup_list, optarg, capacity);
 			if (ret) {
-				fprintf(stderr, "%s: ", argv[0]);
-				fprintf(stderr,	"cgroup controller and path");
-				fprintf(stderr, "parsing failed (%s)\n",
-					argv[optind]);
+				err("%s: cgroup controller and path", argv[0]);
+				err("parsing failed (%s)\n", argv[optind]);
 				ret = -1;
 				goto err;
 			}
@@ -151,8 +147,7 @@ int main(int argc, char *argv[])
 
 	/* no cgroup name */
 	if (argv[optind]) {
-		fprintf(stderr, "%s: wrong arguments (%s)\n", argv[0],
-			argv[optind]);
+		err("%s: wrong arguments (%s)\n", argv[0], argv[optind]);
 		ret = -1;
 		goto err;
 	}
@@ -160,8 +155,8 @@ int main(int argc, char *argv[])
 	/* initialize libcg */
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "%s: libcgroup initialization failed: %s\n",
-			argv[0], cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0],
+		    cgroup_strerror(ret));
 		goto err;
 	}
 
@@ -174,8 +169,8 @@ int main(int argc, char *argv[])
 		cgroup = cgroup_new_cgroup(cgroup_list[i]->path);
 		if (!cgroup) {
 			ret = ECGFAIL;
-			fprintf(stderr, "%s: can't add new cgroup: %s\n",
-				argv[0], cgroup_strerror(ret));
+			err("%s: can't add new cgroup: %s\n", argv[0],
+			    cgroup_strerror(ret));
 			goto err;
 		}
 
@@ -192,9 +187,8 @@ int main(int argc, char *argv[])
 				ret = cgroup_add_all_controllers(cgroup);
 				if (ret != 0) {
 					ret = ECGINVAL;
-					fprintf(stderr, "%s: can't add ",
-						argv[0]);
-					fprintf(stderr, "all controllers\n");
+					err("%s: can't add all controllers\n",
+					    argv[0]);
 					cgroup_free(&cgroup);
 					goto err;
 				}
@@ -203,10 +197,9 @@ int main(int argc, char *argv[])
 					cgroup_list[i]->controllers[j]);
 				if (!cgc) {
 					ret = ECGINVAL;
-					fprintf(stderr, "%s: ", argv[0]);
-					fprintf(stderr, "controller %s",
-						cgroup_list[i]->controllers[j]);
-					fprintf(stderr, "can't be add\n");
+					err("%s: controller %s can't be add\n",
+					    argv[0],
+					    cgroup_list[i]->controllers[j]);
 					cgroup_free(&cgroup);
 					goto err;
 				}
@@ -221,8 +214,8 @@ int main(int argc, char *argv[])
 
 		ret = cgroup_create_cgroup(cgroup, 0);
 		if (ret) {
-			fprintf(stderr, "%s: can't create cgroup %s: %s\n",
-				argv[0], cgroup->name, cgroup_strerror(ret));
+			err("%s: can't create cgroup %s: %s\n",
+			    argv[0], cgroup->name, cgroup_strerror(ret));
 			cgroup_free(&cgroup);
 			goto err;
 		}

--- a/src/tools/cgdelete.c
+++ b/src/tools/cgdelete.c
@@ -34,20 +34,18 @@ struct ext_cgroup_record {
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr,	" try %s --help' for more information.\n",
-			program_name);
+		err("Wrong input parameters,");
+		err(" try %s --help' for more information.\n", program_name);
 		return;
 	}
 
-	printf("Usage: %s [-h] [-r] [[-g] <controllers>:<path>] ...\n",
-		program_name);
-	printf("Remove control group(s)\n");
-	printf("  -g <controllers>:<path>	Control group to be removed ");
-	printf("(-g is optional)\n");
-	printf("  -h, --help			Display this help\n");
-	printf("  -r, --recursive		Recursively remove ");
-	printf("all subgroups\n");
+	info("Usage: %s [-h] [-r] [[-g] <controllers>:<path>] ...\n",
+	     program_name);
+	info("Remove control group(s)\n");
+	info("  -g <controllers>:<path>	Control group to be removed ");
+	info("(-g is optional)\n");
+	info("  -h, --help			Display this help\n");
+	info("  -r, --recursive		Recursively remove all subgroups\n");
 }
 
 /*
@@ -81,8 +79,8 @@ static int skip_add_controller(int counter, int *skip,
 	if (ret == ECGEOF)
 		ret = 0;
 	if (ret) {
-		fprintf(stderr, "cgroup_get_controller_begin/next failed(%s)\n",
-			cgroup_strerror(ret));
+		err("cgroup_get_controller_begin/next failed(%s)\n",
+		    cgroup_strerror(ret));
 		return ret;
 	}
 
@@ -133,21 +131,21 @@ int main(int argc, char *argv[])
 	/* initialize libcg */
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "%s: libcgroup initialization failed: %s\n",
-			argv[0], cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0],
+		    cgroup_strerror(ret));
 		goto err;
 	}
 
 	cgroup_list = calloc(argc, sizeof(struct cgroup_group_spec *));
 	if (cgroup_list == NULL) {
-		fprintf(stderr, "%s: out of memory\n", argv[0]);
+		err("%s: out of memory\n", argv[0]);
 		ret = -1;
 		goto err;
 	}
 
 	ecg_list = calloc(argc, sizeof(struct ext_cgroup_record *));
 	if (cgroup_list == NULL) {
-		fprintf(stderr, "%s: out of memory\n", argv[0]);
+		err("%s: out of memory\n", argv[0]);
 		ret = -1;
 		goto err;
 	}
@@ -162,8 +160,8 @@ int main(int argc, char *argv[])
 		case 'g':
 			ret = parse_cgroup_spec(cgroup_list, optarg, argc);
 			if (ret != 0) {
-				fprintf(stderr,	"%s: error parsing ", argv[0]);
-				fprintf(stderr, "cgroup '%s'\n", optarg);
+				err("%s: error parsing cgroup '%s'", argv[0],
+				    optarg);
 				ret = -1;
 				goto err;
 			}
@@ -183,8 +181,8 @@ int main(int argc, char *argv[])
 	for (i = optind; i < argc; i++) {
 		ret = parse_cgroup_spec(cgroup_list, argv[i], argc);
 		if (ret != 0) {
-			fprintf(stderr, "%s: error parsing cgroup '%s'\n",
-				argv[0], argv[i]);
+			err("%s: error parsing cgroup '%s'\n", argv[0],
+			    argv[i]);
 			ret = -1;
 			goto err;
 		}
@@ -199,8 +197,8 @@ int main(int argc, char *argv[])
 		cgroup = cgroup_new_cgroup(cgroup_list[i]->path);
 		if (!cgroup) {
 			ret = ECGFAIL;
-			fprintf(stderr, "%s: can't create new cgroup: %s\n",
-				argv[0], cgroup_strerror(ret));
+			err("%s: can't create new cgroup: %s\n", argv[0],
+			    cgroup_strerror(ret));
 			goto err;
 		}
 
@@ -222,8 +220,7 @@ int main(int argc, char *argv[])
 					realloc(ecg_list,
 						max * sizeof(struct ext_cgroup_record));
 				if (!ecg_list) {
-					fprintf(stderr, "%s: ", argv[0]);
-					fprintf(stderr, "not enough memory\n");
+					err("%s: not enough memory\n", argv[0]);
 					final_ret = -1;
 					goto err;
 				}
@@ -252,9 +249,8 @@ int main(int argc, char *argv[])
 						cgroup_list[i]->controllers[j]);
 			if (!cgc) {
 				ret = ECGFAIL;
-				fprintf(stderr, "%s: ", argv[0]);
-				fprintf(stderr,	"controller %s can't be added\n",
-					cgroup_list[i]->controllers[j]);
+				err("%s: controller %s can't be added\n", argv[0],
+				    cgroup_list[i]->controllers[j]);
 				cgroup_free(&cgroup);
 				goto err;
 			}
@@ -266,8 +262,8 @@ next:
 		ret = cgroup_delete_cgroup_ext(cgroup, flags);
 		/* Remember the errors and continue, try to remove all groups. */
 		if (ret != 0) {
-			fprintf(stderr, "%s: cannot remove group '%s': %s\n",
-				argv[0], cgroup->name, cgroup_strerror(ret));
+			err("%s: cannot remove group '%s': %s\n", argv[0],
+			    cgroup->name, cgroup_strerror(ret));
 			final_ret = ret;
 		}
 		cgroup_free(&cgroup);

--- a/src/tools/cgexec.c
+++ b/src/tools/cgexec.c
@@ -38,21 +38,20 @@ static struct option longopts[] = {
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr, " try %s --help' for more information.\n",
-			program_name);
+		err("Wrong input parameters,");
+		err(" try %s --help' for more information.\n", program_name);
 		return;
 	}
 
-	printf("Usage: %s [-h] [-g <controllers>:<path>] [--sticky] ",
-	       program_name);
-	printf("command [arguments] ...\n");
-	printf("Run the task in given control group(s)\n");
-	printf("  -g <controllers>:<path>	Control group which ");
-	printf("should be added\n");
-	printf("  -h, --help			Display this help\n");
-	printf("  --sticky			cgred daemon does not ");
-	printf("change pidlist and children tasks\n");
+	info("Usage: %s [-h] [-g <controllers>:<path>] [--sticky] ",
+	     program_name);
+	info("command [arguments] ...\n");
+	info("Run the task in given control group(s)\n");
+	info("  -g <controllers>:<path>	Control group which ");
+	info("should be added\n");
+	info("  -h, --help			Display this help\n");
+	info("  --sticky			cgred daemon does not ");
+	info("change pidlist and children tasks\n");
 }
 
 
@@ -75,8 +74,8 @@ int main(int argc, char *argv[])
 			ret = parse_cgroup_spec(cgroup_list, optarg,
 						CG_HIER_MAX);
 			if (ret) {
-				fprintf(stderr, "cgroup controller and path");
-				fprintf(stderr,	"parsing failed\n");
+				err("cgroup controller and path parsing ");
+				err("failed\n");
 				return -1;
 			}
 			cg_specified = 1;
@@ -102,8 +101,8 @@ int main(int argc, char *argv[])
 	/* Initialize libcg */
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "libcgroup initialization failed: %s\n",
-			cgroup_strerror(ret));
+		err("libcgroup initialization failed: %s\n",
+		    cgroup_strerror(ret));
 		return ret;
 	}
 
@@ -118,7 +117,7 @@ int main(int argc, char *argv[])
 
 	ret = cgroup_register_unchanged_process(pid, flag_child);
 	if (ret) {
-		fprintf(stderr, "registration of process failed\n");
+		err("registration of process failed\n");
 		return ret;
 	}
 
@@ -129,12 +128,12 @@ int main(int argc, char *argv[])
 	 * from a root user.
 	 */
 	if (setresuid(uid, uid, uid)) {
-		fprintf(stderr, "%s", strerror(errno));
+		err("%s", strerror(errno));
 		return -1;
 	}
 
 	if (setresgid(gid, gid, gid)) {
-		fprintf(stderr, "%s", strerror(errno));
+		err("%s", strerror(errno));
 		return -1;
 	}
 
@@ -151,8 +150,7 @@ int main(int argc, char *argv[])
 				pid,
 				(const char *const*) cgroup_list[i]->controllers);
 			if (ret) {
-				fprintf(stderr,
-					"cgroup change of group failed\n");
+				err("cgroup change of group failed\n");
 				return ret;
 			}
 		}
@@ -162,7 +160,7 @@ int main(int argc, char *argv[])
 		ret = cgroup_change_cgroup_flags(uid, gid,
 						 argv[optind], pid, 0);
 		if (ret) {
-			fprintf(stderr, "cgroup change of group failed\n");
+			err("cgroup change of group failed\n");
 			return ret;
 		}
 	}
@@ -170,7 +168,7 @@ int main(int argc, char *argv[])
 	/* Now exec the new process */
 	ret = execvp(argv[optind], &argv[optind]);
 	if (ret == -1) {
-		fprintf(stderr, "%s", strerror(errno));
+		err("%s", strerror(errno));
 		return -1;
 	}
 

--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -28,27 +28,26 @@ static const struct option long_options[] = {
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr,	" try %s -h' for more information.\n",
-			program_name);
+		err("Wrong input parameters,");
+		err(" try %s -h' for more information.\n", program_name);
 		return;
 	}
-	printf("Usage: %s [-nv] [-r <name>] [-g <controllers>] ", program_name);
-	printf("[-a] <path> ...\n");
-	printf("   or: %s [-nv] [-r <name>] -g <controllers>:<path> ...\n",
-	       program_name);
-	printf("Print parameter(s) of given group(s).\n");
-	printf("  -a, --all			Print info about all relevant ");
-	printf("controllers\n");
-	printf("  -g <controllers>		Controller which info should ");
-	printf("be displayed\n");
-	printf("  -g <controllers>:<path>	Control group which info ");
-	printf("should be displayed\n");
-	printf("  -h, --help			Display this help\n");
-	printf("  -n				Do not print headers\n");
-	printf("  -r, --variable  <name>	Define parameter to display\n");
-	printf("  -v, --values-only		Print only values, not ");
-	printf("parameter names\n");
+	info("Usage: %s [-nv] [-r <name>] [-g <controllers>] ", program_name);
+	info("[-a] <path> ...\n");
+	info("   or: %s [-nv] [-r <name>] -g <controllers>:<path> ...\n",
+	     program_name);
+	info("Print parameter(s) of given group(s).\n");
+	info("  -a, --all			Print info about all relevant ");
+	info("controllers\n");
+	info("  -g <controllers>		Controller which info should ");
+	info("be displayed\n");
+	info("  -g <controllers>:<path>	Control group which info ");
+	info("should be displayed\n");
+	info("  -h, --help			Display this help\n");
+	info("  -n				Do not print headers\n");
+	info("  -r, --variable <name>		Define parameter to display\n");
+	info("  -v, --values-only		Print only values, not ");
+	info("parameter names\n");
 }
 
 static int get_controller_from_name(const char * const name,
@@ -62,8 +61,8 @@ static int get_controller_from_name(const char * const name,
 
 	dot = strchr(*controller, '.');
 	if (dot == NULL) {
-		fprintf(stderr, "cgget: error parsing parameter name\n");
-		fprintf(stderr,	" '%s'", name);
+		err("cgget: error parsing parameter name\n");
+		err(	" '%s'", name);
 		return ECGINVAL;
 	}
 
@@ -115,8 +114,8 @@ static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
 		if (!cgc) {
 			cgc = cgroup_add_controller(cg, controller.name);
 			if (!cgc) {
-				fprintf(stderr, "cgget: cannot find controller '%s'\n",
-					controller.name);
+				err("cgget: cannot find controller '%s'\n",
+				    controller.name);
 				ret = ECGOTHER;
 				goto out;
 			}
@@ -168,8 +167,8 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 	if (!cgc) {
 		cgc = cgroup_add_controller(cg, cntl_value_controller);
 		if (!cgc) {
-			fprintf(stderr, "cgget: cannot find controller '%s'\n",
-				cntl_value_controller);
+			err("cgget: cannot find controller '%s'\n",
+			    cntl_value_controller);
 			ret = ECGOTHER;
 			goto out;
 		}
@@ -213,8 +212,7 @@ static int parse_g_flag_no_colon(struct cgroup **cg_list[],
 	if (!cgc) {
 		cgc = cgroup_add_controller(cg, ctrl_str);
 		if (!cgc) {
-			fprintf(stderr, "cgget: cannot find controller '%s'\n",
-				ctrl_str);
+			err("cgget: cannot find controller '%s'\n", ctrl_str);
 			ret = ECGOTHER;
 			goto out;
 		}
@@ -308,8 +306,8 @@ static int parse_g_flag_with_colon(struct cgroup **cg_list[],
 		if (!cgc) {
 			cgc = cgroup_add_controller(cg, controllers[i]);
 			if (!cgc) {
-				fprintf(stderr, "cgget: cannot find controller '%s'\n",
-					controllers[i]);
+				err("cgget: cannot find controller '%s'\n",
+				    controllers[i]);
 				ret = ECGOTHER;
 				goto out;
 			}
@@ -499,13 +497,12 @@ static int get_cv_value(struct control_value * const cv,
 			 */
 			tmp_ret = cgroup_test_subsys_mounted(controller_name);
 			if (tmp_ret == 0) {
-				fprintf(stderr, "cgget: cannot find ");
-				fprintf(stderr, "controller '%s' in group ",
-					controller_name);
-				fprintf(stderr, "'%s'\n", cg_name);
+				err("cgget: cannot find controller '%s' ",
+				    controller_name);
+				err("in group '%s'\n", cg_name);
 			} else {
-				fprintf(stderr, "variable file read failed %s\n",
-					cgroup_strerror(ret));
+				err("variable file read failed %s\n",
+				    cgroup_strerror(ret));
 			}
 		}
 
@@ -707,12 +704,12 @@ static int get_values(struct cgroup *cg_list[], int cg_list_len)
 void print_control_values(const struct control_value * const cv, int mode)
 {
 	if (mode & MODE_SHOW_NAMES)
-		printf("%s: ", cv->name);
+		info("%s: ", cv->name);
 
 	if (cv->multiline_value)
-		printf("%s\n", cv->multiline_value);
+		info("%s\n", cv->multiline_value);
 	else
-		printf("%s\n", cv->value);
+		info("%s\n", cv->value);
 }
 
 void print_controller(const struct cgroup_controller * const cgc, int mode)
@@ -728,13 +725,13 @@ static void print_cgroup(const struct cgroup * const cg, int mode)
 	int i;
 
 	if (mode & MODE_SHOW_HEADERS)
-		printf("%s:\n", cg->name);
+		info("%s:\n", cg->name);
 
 	for (i = 0; i < cg->index; i++)
 		print_controller(cg->controller[i], mode);
 
 	if (mode & MODE_SHOW_HEADERS)
-		printf("\n");
+		info("\n");
 }
 
 static void print_cgroups(struct cgroup *cg_list[], int cg_list_len, int mode)
@@ -760,8 +757,8 @@ int main(int argc, char *argv[])
 
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "%s: libcgroup initialization failed: %s\n",
-			argv[0], cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0],
+		    cgroup_strerror(ret));
 		goto err;
 	}
 

--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -35,16 +35,15 @@ static struct cgroup *copy_name_value_from_cgroup(char src_cg_path[FILENAME_MAX]
 	/* create source cgroup */
 	src_cgroup = cgroup_new_cgroup(src_cg_path);
 	if (!src_cgroup) {
-		fprintf(stderr, "can't create cgroup: %s\n",
-			cgroup_strerror(ECGFAIL));
+		err("can't create cgroup: %s\n", cgroup_strerror(ECGFAIL));
 		goto scgroup_err;
 	}
 
 	/* copy the name-version values to the cgroup structure */
 	ret = cgroup_get_cgroup(src_cgroup);
 	if (ret != 0) {
-		fprintf(stderr, "cgroup %s error: %s\n",
-			src_cg_path, cgroup_strerror(ret));
+		err("cgroup %s error: %s\n", src_cg_path,
+		    cgroup_strerror(ret));
 		goto scgroup_err;
 	}
 
@@ -59,21 +58,19 @@ scgroup_err:
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr,	" try %s --help' for more information.\n",
-			program_name);
+		err("Wrong input parameters, ");
+		err("try %s --help' for more information.\n", program_name);
 		return;
 	}
 
-	printf("Usage: %s [-r <name=value>] <cgroup_path> ...\n",
-	       program_name);
-	printf("   or: %s --copy-from <source_cgroup_path> ", program_name);
-	printf("<cgroup_path> ...\n");
-	printf("Set the parameters of given cgroup(s)\n");
-	printf("  -r, --variable <name>			Define parameter ");
-	printf("to set\n");
-	printf("  --copy-from <source_cgroup_path>	Control group whose ");
-	printf("parameters will be copied\n");
+	info("Usage: %s [-r <name=value>] <cgroup_path> ...\n", program_name);
+	info("   or: %s --copy-from <source_cgroup_path> ", program_name);
+	info("<cgroup_path> ...\n");
+	info("Set the parameters of given cgroup(s)\n");
+	info("  -r, --variable <name>			Define parameter ");
+	info("to set\n");
+	info("  --copy-from <source_cgroup_path>	Control group whose ");
+	info("parameters will be copied\n");
 }
 #endif /* !UNIT_TEST */
 
@@ -86,7 +83,7 @@ STATIC int parse_r_flag(const char * const program_name,
 
 	copy = strdup(name_value_str);
 	if (copy == NULL) {
-		fprintf(stderr, "%s: not enough memory\n", program_name);
+		err("%s: not enough memory\n", program_name);
 		ret = -1;
 		goto err;
 	}
@@ -94,8 +91,8 @@ STATIC int parse_r_flag(const char * const program_name,
 	/* parse optarg value */
 	buf = strtok(copy, "=");
 	if (buf == NULL) {
-		fprintf(stderr, "%s: wrong parameter of option -r: %s\n",
-			program_name, optarg);
+		err("%s: wrong parameter of option -r: %s\n", program_name,
+		    optarg);
 		ret = -1;
 		goto err;
 	}
@@ -111,8 +108,8 @@ STATIC int parse_r_flag(const char * const program_name,
 	buf++;
 
 	if (strlen(buf) == 0) {
-		fprintf(stderr, "%s: wrong parameter of option -r: %s\n",
-			program_name, optarg);
+		err("%s: wrong parameter of option -r: %s\n", program_name,
+		    optarg);
 		ret = -1;
 		goto err;
 	}
@@ -143,8 +140,8 @@ int main(int argc, char *argv[])
 
 	/* no parameter on input */
 	if (argc < 2) {
-		fprintf(stderr, "Usage is %s -r <name=value> ", argv[0]);
-		fprintf(stderr,	"<relative path to cgroup>\n");
+		err("Usage is %s -r <name=value> ", argv[0]);
+		err("<relative path to cgroup>\n");
 		return -1;
 	}
 
@@ -175,8 +172,7 @@ int main(int argc, char *argv[])
 					realloc(name_value,
 					nv_max * sizeof(struct control_value));
 				if (!name_value) {
-					fprintf(stderr, "%s: ", argv[0]);
-					fprintf(stderr,	"not enough memory\n");
+					err("%s: not enough memory\n", argv[0]);
 					ret = -1;
 					goto err;
 				}
@@ -208,13 +204,13 @@ int main(int argc, char *argv[])
 
 	/* no cgroup name */
 	if (!argv[optind]) {
-		fprintf(stderr, "%s: no cgroup specified\n", argv[0]);
+		err("%s: no cgroup specified\n", argv[0]);
 		ret = -1;
 		goto err;
 	}
 
 	if (flags == 0) {
-		fprintf(stderr, "%s: no name-value pair was set\n", argv[0]);
+		err("%s: no name-value pair was set\n", argv[0]);
 		ret = -1;
 		goto err;
 	}
@@ -222,8 +218,8 @@ int main(int argc, char *argv[])
 	/* initialize libcgroup */
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "%s: libcgroup initialization failed: %s\n",
-			argv[0], cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0],
+		    cgroup_strerror(ret));
 		goto err;
 	}
 
@@ -247,24 +243,24 @@ int main(int argc, char *argv[])
 		cgroup = cgroup_new_cgroup(argv[optind]);
 		if (!cgroup) {
 			ret = ECGFAIL;
-			fprintf(stderr, "%s: can't add new cgroup: %s\n",
-				argv[0], cgroup_strerror(ret));
+			err("%s: can't add new cgroup: %s\n", argv[0],
+			    cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 
 		/* copy the values from the source cgroup to new one */
 		ret = cgroup_copy_cgroup(cgroup, src_cgroup);
 		if (ret != 0) {
-			fprintf(stderr, "%s: cgroup %s error: %s\n",
-				argv[0], src_cg_path, cgroup_strerror(ret));
+			err("%s: cgroup %s error: %s\n", argv[0], src_cg_path,
+			    cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 
 		/* modify cgroup based on values of the new one */
 		ret = cgroup_modify_cgroup(cgroup);
 		if (ret) {
-			fprintf(stderr, "%s: cgroup modify error: %s\n",
-				argv[0], cgroup_strerror(ret));
+			err("%s: cgroup modify error: %s\n", argv[0],
+			    cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 

--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -4,6 +4,8 @@
  * Written by Ivana Hutarova Varekova <varekova@redhat.com>
  */
 
+#include "tools-common.h"
+
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
 
@@ -51,25 +53,25 @@ FILE *output_f;
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr,	" try %s -h' for more information.\n",
-			program_name);
+		err("Wrong input parameters, ");
+		err("try %s -h' for more information.\n", program_name);
 		return;
 	}
-	printf("Usage: %s [-h] [-s] [-b FILE] [-w FILE] [-f FILE] ",
-	       program_name);
-	printf("[controller] [...]\n");
-	printf("Generate the configuration file for given controllers\n");
-	printf("  -b, --blacklist=FILE		Set the blacklist");
-	printf(" configuration file (default %s)\n", BLACKLIST_CONF);
-	printf("  -f, --file=FILE		Redirect the output");
-	printf(" to output_file\n");
-	printf("  -h, --help			Display this help\n");
-	printf("  -s, --silent			Ignore all warnings\n");
-	printf("  -t, --strict			Don't show variables ");
-	printf("which are not on the whitelist\n");
-	printf("  -w, --whitelist=FILE		Set the whitelist");
-	printf(" configuration file (don't used by default)\n");
+
+	info("Usage: %s [-h] [-s] [-b FILE] [-w FILE] [-f FILE] ",
+	     program_name);
+	info("[controller] [...]\n");
+	info("Generate the configuration file for given controllers\n");
+	info("  -b, --blacklist=FILE		Set the blacklist");
+	info(" configuration file (default %s)\n", BLACKLIST_CONF);
+	info("  -f, --file=FILE		Redirect the output ");
+	info("to output_file\n");
+	info("  -h, --help			Display this help\n");
+	info("  -s, --silent			Ignore all warnings\n");
+	info("  -t, --strict			Don't show variables ");
+	info("which are not on the whitelist\n");
+	info("  -w, --whitelist=FILE		Set the whitelist ");
+	info("configuration file (don't used by default)\n");
 }
 
 /* cache values from blacklist file to the list structure */
@@ -87,8 +89,8 @@ int load_list(char *filename, struct black_list_type **p_list)
 
 	fw = fopen(filename, "r");
 	if (fw == NULL) {
-		fprintf(stderr, "ERROR: Failed to open file %s: %s\n",
-			filename, strerror(errno));
+		err("ERROR: Failed to open file %s: %s\n", filename,
+		    strerror(errno));
 		*p_list = NULL;
 		return 1;
 	}
@@ -112,16 +114,16 @@ int load_list(char *filename, struct black_list_type **p_list)
 		new = (struct black_list_type *)
 			malloc(sizeof(struct black_list_type));
 		if (new == NULL) {
-			fprintf(stderr, "ERROR: Memory allocation problem ");
-			fprintf(stderr,	"(%s)\n", strerror(errno));
+			err("ERROR: Memory allocation problem (%s)\n",
+			    strerror(errno));
 			ret = 1;
 			goto err;
 		}
 
 		new->name = strdup(name);
 		if (new->name == NULL) {
-			fprintf(stderr, "ERROR: Memory allocation problem ");
-			fprintf(stderr,	"(%s)\n", strerror(errno));
+			err("ERROR: Memory allocation problem (%s)\n",
+			    strerror(errno));
 			ret = 1;
 			free(new);
 			goto err;
@@ -216,8 +218,7 @@ static int display_permissions(const char *path, const char * const cg_name,
 	/* get the directory statistic */
 	ret = stat(path, &sba);
 	if (ret) {
-		fprintf(stderr, "ERROR: can't read statistics about %s\n",
-			path);
+		err("ERROR: can't read statistics about %s\n", path);
 		return -1;
 	}
 
@@ -226,15 +227,13 @@ static int display_permissions(const char *path, const char * const cg_name,
 	ret = cgroup_build_tasks_procs_path(tasks_path, sizeof(tasks_path),
 					    cg_name, ctrl_name);
 	if (ret) {
-		fprintf(stderr, "ERROR: can't build tasks/procs path: %d\n",
-			ret);
+		err("ERROR: can't build tasks/procs path: %d\n", ret);
 		return -1;
 	}
 
 	ret = stat(tasks_path, &sbt);
 	if (ret) {
-		fprintf(stderr, "ERROR: can't read statistics about %s\n",
-			tasks_path);
+		err("ERROR: can't read statistics about %s\n", tasks_path);
 		return -1;
 	}
 
@@ -251,15 +250,13 @@ static int display_permissions(const char *path, const char * const cg_name,
 		/* find out the user and group name */
 		pw = getpwuid(sba.st_uid);
 		if (pw == NULL) {
-			fprintf(stderr, "ERROR: can't get %d user name\n",
-				sba.st_uid);
+			err("ERROR: can't get %d user name\n", sba.st_uid);
 			return -1;
 		}
 
 		gr = getgrgid(sba.st_gid);
 		if (gr == NULL) {
-			fprintf(stderr, "ERROR: can't get %d group name\n",
-				sba.st_gid);
+			err("ERROR: can't get %d group name\n", sba.st_gid);
 			return -1;
 		}
 
@@ -272,15 +269,13 @@ static int display_permissions(const char *path, const char * const cg_name,
 		/* find out the user and group name */
 		pw = getpwuid(sbt.st_uid);
 		if (pw == NULL) {
-			fprintf(stderr, "ERROR: can't get %d user name\n",
-				sbt.st_uid);
+			err("ERROR: can't get %d user name\n", sbt.st_uid);
 			return -1;
 		}
 
 		gr = getgrgid(sbt.st_gid);
 		if (gr == NULL) {
-			fprintf(stderr, "ERROR: can't get %d group name\n",
-				sbt.st_gid);
+			err("ERROR: can't get %d group name\n", sbt.st_gid);
 			return -1;
 		}
 
@@ -332,8 +327,8 @@ static int display_cgroup_data(struct cgroup *group,
 
 		group_controller = cgroup_get_controller(group, controller[i]);
 		if (group_controller == NULL) {
-			printf("cannot find controller '%s' in group '%s'\n",
-				controller[i], group->name);
+			info("cannot find controller '%s' in group '%s'\n",
+			     controller[i], group->name);
 			i++;
 			ret = -1;
 			continue;
@@ -409,10 +404,8 @@ static int display_cgroup_data(struct cgroup *group,
 			 * used write an warning
 			 */
 			if ((!wl) && !(flags &  FL_SILENT) && (first)) {
-				fprintf(stderr, "WARNING: variable %s is ",
-					name);
-				fprintf(stderr,	"neither blacklisted nor ");
-				fprintf(stderr,	"whitelisted\n");
+				err("WARNING: variable %s is neither ", name);
+				err("blacklisted nor whitelisted\n");
 			}
 
 			output_name = name;
@@ -440,9 +433,8 @@ static int display_cgroup_data(struct cgroup *group,
 			/* variable can not be read */
 			if (ret != 0) {
 				ret = 0;
-				fprintf(stderr, "ERROR: Value of ");
-				fprintf(stderr,	"variable %s can be read\n",
-					name);
+				err("ERROR: Value of variable %s can be read\n",
+				    name);
 				goto err;
 			}
 			fprintf(output_f, "\t\t%s=\"%s\";\n", output_name, value);
@@ -498,7 +490,7 @@ static int display_controller_data(
 			/* start to grab data about the new group */
 			group = cgroup_new_cgroup(cgroup_name);
 			if (group == NULL) {
-				printf("cannot create group '%s'\n",
+				info("cannot create group '%s'\n",
 					cgroup_name);
 				ret = ECGFAIL;
 				goto err;
@@ -506,7 +498,7 @@ static int display_controller_data(
 
 			ret = cgroup_get_cgroup(group);
 			if (ret != 0) {
-				printf("cannot read group '%s': %s\n",
+				info("cannot read group '%s': %s\n",
 					cgroup_name, cgroup_strerror(ret));
 				goto err;
 			}
@@ -651,10 +643,8 @@ static void parse_mountpoint(cont_name_t cont_names[CG_CONTROLLER_MAX],
 	if (!(flags & FL_LIST)) {
 		if (show_mountpoints(name)) {
 			/* the controller is not mounted */
-			if ((flags & FL_SILENT) == 0) {
-				fprintf(stderr, "ERROR: %s hierarchy ", name);
-				fprintf(stderr,	"not mounted\n");
-			}
+			if ((flags & FL_SILENT) == 0)
+				err("ERROR: %s hierarchy not mounted\n", name);
 		}
 		return;
 	}
@@ -666,9 +656,8 @@ static void parse_mountpoint(cont_name_t cont_names[CG_CONTROLLER_MAX],
 			if (show_mountpoints(name)) {
 				/* the controller is not mounted */
 				if ((flags & FL_SILENT) == 0) {
-					fprintf(stderr, "ERROR: %s ", name);
-					fprintf(stderr, "hierarchy not ");
-					fprintf(stderr, "mounted\n");
+					err("ERROR: %s hierarchy not mounted\n",
+					    name);
 				}
 			break;
 			}
@@ -703,9 +692,8 @@ static int parse_mountpoints(cont_name_t cont_names[CG_CONTROLLER_MAX],
 
 	if (ret != ECGEOF) {
 		if ((flags &  FL_SILENT) != 0) {
-			fprintf(stderr,
-				"E: in get next controller %s\n",
-				cgroup_strerror(ret));
+			err("E: in get next controller %s\n",
+			    cgroup_strerror(ret));
 		}
 		final_ret = ret;
 	}
@@ -722,9 +710,8 @@ static int parse_mountpoints(cont_name_t cont_names[CG_CONTROLLER_MAX],
 
 	if (ret != ECGEOF) {
 		if ((flags &  FL_SILENT) != 0) {
-			fprintf(stderr,
-				"E: in get next controller %s\n",
-				cgroup_strerror(ret));
+			err("E: in get next controller %s\n",
+			    cgroup_strerror(ret));
 		}
 		final_ret = ret;
 	}
@@ -789,8 +776,8 @@ int main(int argc, char *argv[])
 			flags |= FL_OUTPUT;
 			output_f = fopen(optarg, "w");
 			if (output_f == NULL) {
-				fprintf(stderr, "%s: Failed to open file %s\n",
-					argv[0], optarg);
+				err("%s: Failed to open file %s\n", argv[0],
+				    optarg);
 				return ECGOTHER;
 			}
 			break;
@@ -808,7 +795,7 @@ int main(int argc, char *argv[])
 		c_number++;
 		optind++;
 		if (optind == CG_CONTROLLER_MAX-1) {
-			fprintf(stderr, "too many parameters\n");
+			err("too many parameters\n");
 			break;
 		}
 	}

--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -40,35 +40,34 @@ static const struct option long_options[] = {
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr,	" try %s -h' for more information.\n",
-			program_name);
+		err("Wrong input parameters, ");
+		err("try %s -h' for more information.\n", program_name);
 		return;
 	}
 
-	printf("Usage: %s [-nv] [-r <name>] [-g <controllers>] ",
-	       program_name);
-	printf("[-a] <path> ...\n");
-	printf("   or: %s [-nv] [-r <name>] -g <controllers>:<path> ...\n",
-	       program_name);
-	printf("Print parameter(s) of given group(s).\n");
-	printf("  -1, --v1			Provided parameters are in ");
-	printf("v1 format\n");
-	printf("  -2, --v2			Provided parameters are in ");
-	printf("v2 format\n");
-	printf("  -i, --ignore-unmappable       Do not return an error for settings ");
-	printf("that cannot be converted\n");
-	printf("  -a, --all			Print info about all relevant ");
-	printf("controllers\n");
-	printf("  -g <controllers>		Controller which info should ");
-	printf("be displayed\n");
-	printf("  -g <controllers>:<path>	Control group which info ");
-	printf("should be displayed\n");
-	printf("  -h, --help			Display this help\n");
-	printf("  -n				Do not print headers\n");
-	printf("  -r, --variable  <name>	Define parameter to display\n");
-	printf("  -v, --values-only		Print only values, not ");
-	printf("parameter names\n");
+	info("Usage: %s [-nv] [-r <name>] [-g <controllers>] ",
+	     program_name);
+	info("[-a] <path> ...\n");
+	info("   or: %s [-nv] [-r <name>] -g <controllers>:<path> ...\n",
+	     program_name);
+	info("Print parameter(s) of given group(s).\n");
+	info("  -1, --v1			Provided parameters are in ");
+	info("v1 format\n");
+	info("  -2, --v2			Provided parameters are in ");
+	info("v2 format\n");
+	info("  -i, --ignore-unmappable       Do not return an error for ");
+	info("settings that cannot be converted\n");
+	info("  -a, --all			Print info about all relevant");
+	info(" controllers\n");
+	info("  -g <controllers>		Controller which info should");
+	info(" be displayed\n");
+	info("  -g <controllers>:<path>	Control group which info");
+	info(" should be displayed\n");
+	info("  -h, --help			Display this help\n");
+	info("  -n				Do not print headers\n");
+	info("  -r, --variable  <name>	Define parameter to display\n");
+	info("  -v, --values-only		Print only values, not ");
+	info("parameter names\n");
 }
 
 static int get_controller_from_name(const char * const name,
@@ -82,8 +81,7 @@ static int get_controller_from_name(const char * const name,
 
 	dot = strchr(*controller, '.');
 	if (dot == NULL) {
-		fprintf(stderr, "cgget: error parsing parameter name\n '%s'",
-			name);
+		err("cgget: error parsing parameter name\n '%s'", name);
 		return ECGINVAL;
 	}
 	*dot = '\0';
@@ -189,8 +187,8 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 	if (!cgc) {
 		cgc = cgroup_add_controller(cg, cntl_value_controller);
 		if (!cgc) {
-			fprintf(stderr, "cgget: cannot find controller '%s'\n",
-				cntl_value_controller);
+			err("cgget: cannot find controller '%s'\n",
+			    cntl_value_controller);
 			ret = ECGOTHER;
 			goto out;
 		}
@@ -531,12 +529,12 @@ static int get_cv_value(struct control_value * const cv,
 			 */
 			tmp_ret = cgroup_test_subsys_mounted(controller_name);
 			if (tmp_ret == 0) {
-				fprintf(stderr, "cgget: cannot find controller ");
-				fprintf(stderr,	"'%s' in group '%s'\n", controller_name,
-					cg_name);
+				err("cgget: cannot find controller '%s' in ",
+				    controller_name);
+				err("in group '%s'\n", cg_name);
 			} else {
-				fprintf(stderr, "variable file read failed %s\n",
-					cgroup_strerror(ret));
+				err("variable file read failed %s\n",
+				    cgroup_strerror(ret));
 			}
 		}
 
@@ -741,12 +739,12 @@ static void print_control_values(const struct control_value * const cv,
 				 int mode)
 {
 	if (mode & MODE_SHOW_NAMES)
-		printf("%s: ", cv->name);
+		info("%s: ", cv->name);
 
 	if (cv->multiline_value)
-		printf("%s\n", cv->multiline_value);
+		info("%s\n", cv->multiline_value);
 	else
-		printf("%s\n", cv->value);
+		info("%s\n", cv->value);
 }
 
 static void print_controller(const struct cgroup_controller * const cgc,
@@ -763,13 +761,13 @@ static void print_cgroup(const struct cgroup * const cg, int mode)
 	int i;
 
 	if (mode & MODE_SHOW_HEADERS)
-		printf("%s:\n", cg->name);
+		info("%s:\n", cg->name);
 
 	for (i = 0; i < cg->index; i++)
 		print_controller(cg->controller[i], mode);
 
 	if (mode & MODE_SHOW_HEADERS)
-		printf("\n");
+		info("\n");
 }
 
 static void print_cgroups(struct cgroup *cg_list[], int cg_list_len, int mode)
@@ -840,8 +838,8 @@ int main(int argc, char *argv[])
 
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "%s: libcgroup initialization failed: %s\n",
-			argv[0], cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0],
+		    cgroup_strerror(ret));
 		goto err;
 	}
 

--- a/src/tools/cgxset.c
+++ b/src/tools/cgxset.c
@@ -45,16 +45,14 @@ static struct cgroup *copy_name_value_from_cgroup(char src_cg_path[FILENAME_MAX]
 	/* create source cgroup */
 	src_cgroup = cgroup_new_cgroup(src_cg_path);
 	if (!src_cgroup) {
-		fprintf(stderr, "can't create cgroup: %s\n",
-			cgroup_strerror(ECGFAIL));
+		err("can't create cgroup: %s\n", cgroup_strerror(ECGFAIL));
 		goto scgroup_err;
 	}
 
 	/* copy the name-version values to the cgroup structure */
 	ret = cgroup_get_cgroup(src_cgroup);
 	if (ret != 0) {
-		fprintf(stderr, "cgroup %s error: %s\n",
-			src_cg_path, cgroup_strerror(ret));
+		err("cgroup %s error: %s\n", src_cg_path, cgroup_strerror(ret));
 		goto scgroup_err;
 	}
 
@@ -69,27 +67,26 @@ scgroup_err:
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr, " try %s --help' for more information.\n",
-			program_name);
+		err("Wrong input parameters, ");
+		err("try %s --help' for more information.\n", program_name);
 		return;
 	}
 
-	printf("Usage: %s [-r <name=value>] <cgroup_path> ...\n",
-	       program_name);
-	printf("   or: %s --copy-from <source_cgroup_path> ", program_name);
-	printf("<cgroup_path> ...\n");
-	printf("Set the parameters of given cgroup(s)\n");
-	printf("  -1, --v1                      Provided parameters are in ");
-	printf("v1 format\n");
-	printf("  -2, --v2                      Provided parameters are in ");
-	printf("v2 format\n");
-	printf("  -i, --ignore-unmappable       Do not return an error for settings ");
-	printf("that cannot be converted\n");
-	printf("  -r, --variable <name>			Define parameter ");
-	printf("to set\n");
-	printf("  --copy-from <source_cgroup_path>	Control group whose ");
-	printf("parameters will be copied\n");
+	info("Usage: %s [-r <name=value>] <cgroup_path> ...\n",
+	     program_name);
+	info("   or: %s --copy-from <source_cgroup_path> ", program_name);
+	info("<cgroup_path> ...\n");
+	info("Set the parameters of given cgroup(s)\n");
+	info("  -1, --v1                      Provided parameters are in ");
+	info("v1 format\n");
+	info("  -2, --v2                      Provided parameters are in ");
+	info("v2 format\n");
+	info("  -i, --ignore-unmappable       Do not return an error for ");
+	info("settings that cannot be converted\n");
+	info("  -r, --variable <name>			Define parameter ");
+	info("to set\n");
+	info("  --copy-from <source_cgroup_path>	Control group whose ");
+	info("parameters will be copied\n");
 }
 #endif /* !UNIT_TEST */
 
@@ -102,7 +99,7 @@ STATIC int parse_r_flag(const char * const program_name,
 
 	copy = strdup(name_value_str);
 	if (copy == NULL) {
-		fprintf(stderr, "%s: not enough memory\n", program_name);
+		err("%s: not enough memory\n", program_name);
 		ret = -1;
 		goto err;
 	}
@@ -110,8 +107,8 @@ STATIC int parse_r_flag(const char * const program_name,
 	/* parse optarg value */
 	buf = strtok(copy, "=");
 	if (buf == NULL) {
-		fprintf(stderr, "%s: wrong parameter of option -r: %s\n",
-			program_name, optarg);
+		err("%s: wrong parameter of option -r: %s\n", program_name,
+		    optarg);
 		ret = -1;
 		goto err;
 	}
@@ -127,8 +124,8 @@ STATIC int parse_r_flag(const char * const program_name,
 	buf++;
 
 	if (strlen(buf) == 0) {
-		fprintf(stderr, "%s: wrong parameter of option -r: %s\n",
-			program_name, optarg);
+		err("%s: wrong parameter of option -r: %s\n", program_name,
+		    optarg);
 		ret = -1;
 		goto err;
 	}
@@ -162,8 +159,8 @@ int main(int argc, char *argv[])
 
 	/* no parametr on input */
 	if (argc < 2) {
-		fprintf(stderr, "Usage is %s -r <name=value> ", argv[0]);
-		fprintf(stderr, "<relative path to cgroup>\n");
+		err("Usage is %s -r <name=value> <relative path to cgroup>\n",
+		    argv[0]);
 		return -1;
 	}
 
@@ -193,8 +190,8 @@ int main(int argc, char *argv[])
 					realloc(name_value,
 					nv_max * sizeof(struct control_value));
 				if (!name_value) {
-					fprintf(stderr, "%s: ", argv[0]);
-					fprintf(stderr,	"not enough memory\n");
+					err("%s: not enough memory\n",
+					    argv[0]);
 					ret = -1;
 					goto err;
 				}
@@ -235,13 +232,13 @@ int main(int argc, char *argv[])
 
 	/* no cgroup name */
 	if (!argv[optind]) {
-		fprintf(stderr, "%s: no cgroup specified\n", argv[0]);
+		err("%s: no cgroup specified\n", argv[0]);
 		ret = -1;
 		goto err;
 	}
 
 	if (flags == 0) {
-		fprintf(stderr, "%s: no name-value pair was set\n", argv[0]);
+		err("%s: no name-value pair was set\n", argv[0]);
 		ret = -1;
 		goto err;
 	}
@@ -249,8 +246,8 @@ int main(int argc, char *argv[])
 	/* initialize libcgroup */
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "%s: libcgroup initialization failed: %s\n",
-			argv[0], cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0],
+		    cgroup_strerror(ret));
 		goto err;
 	}
 
@@ -274,16 +271,16 @@ int main(int argc, char *argv[])
 		cgroup = cgroup_new_cgroup(argv[optind]);
 		if (!cgroup) {
 			ret = ECGFAIL;
-			fprintf(stderr, "%s: can't add new cgroup: %s\n",
-				argv[0], cgroup_strerror(ret));
+			err("%s: can't add new cgroup: %s\n", argv[0],
+			    cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 
 		/* copy the values from the source cgroup to new one */
 		ret = cgroup_copy_cgroup(cgroup, src_cgroup);
 		if (ret != 0) {
-			fprintf(stderr, "%s: cgroup %s error: %s\n",
-				argv[0], src_cg_path, cgroup_strerror(ret));
+			err("%s: cgroup %s error: %s\n", argv[0], src_cg_path,
+			    cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 
@@ -311,8 +308,8 @@ int main(int argc, char *argv[])
 		/* modify cgroup based on values of the new one */
 		ret = cgroup_modify_cgroup(cgroup);
 		if (ret) {
-			fprintf(stderr, "%s: cgroup modify error: %s\n",
-				argv[0], cgroup_strerror(ret));
+			err("%s: cgroup modify error: %s\n", argv[0],
+			    cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 

--- a/src/tools/lscgroup.c
+++ b/src/tools/lscgroup.c
@@ -37,17 +37,17 @@ static inline void trim_filepath(char *path)
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr, " try %s -h' for more information.\n",
-			program_name);
+		err("Wrong input parameters, ");
+		err("try %s -h' for more information.\n", program_name);
 		return;
 	}
-	printf("Usage: %s [-h] [[-g] <controllers>:<path>] [...]\n",
-		program_name);
-	printf("List all cgroups\n");
-	printf("  -g <controllers>:<path>	Control group to be ");
-	printf("displayed (-g is optional)\n");
-	printf("  -h, --help			Display this help\n");
+
+	info("Usage: %s [-h] [[-g] <controllers>:<path>] [...]\n",
+	     program_name);
+	info("List all cgroups\n");
+	info("  -g <controllers>:<path>	Control group to be ");
+	info("displayed (-g is optional)\n");
+	info("  -h, --help			Display this help\n");
 }
 
 /*
@@ -70,9 +70,9 @@ static void print_info(struct cgroup_file_info *info, char *name, int pref)
 {
 	if (info->type == CGROUP_FILE_TYPE_DIR) {
 		if (info->full_path[pref] ==  '/')
-			printf("%s:%s\n", name, &info->full_path[pref]);
+			info("%s:%s\n", name, &info->full_path[pref]);
 		else
-			printf("%s:/%s\n", name, &info->full_path[pref]);
+			info("%s:/%s\n", name, &info->full_path[pref]);
 	}
 }
 
@@ -203,8 +203,7 @@ static int cgroup_list_cgroups(char *tname,
 	/* initialize libcgroup */
 	ret = cgroup_init();
 	if (ret) {
-		fprintf(stderr, "cgroups can't be listed: %s\n",
-			cgroup_strerror(ret));
+		err("cgroups can't be listed: %s\n", cgroup_strerror(ret));
 		return ret;
 	}
 
@@ -219,8 +218,8 @@ static int cgroup_list_cgroups(char *tname,
 			final_ret = 0;
 		} else {
 			final_ret = ret;
-			fprintf(stderr, "cgroups can't be listed: %s\n",
-				cgroup_strerror(ret));
+			err("cgroups can't be listed: %s\n",
+			    cgroup_strerror(ret));
 		}
 	} else {
 		/* we have he list of controllers which should be print */
@@ -236,11 +235,10 @@ static int cgroup_list_cgroups(char *tname,
 					/* other problem */
 					final_ret = ret;
 				}
-				fprintf(stderr,
-					"%s: cannot find group %s..:%s: %s\n",
-					tname, cgroup_list[i]->controllers[0],
-					cgroup_list[i]->path,
-					cgroup_strerror(final_ret));
+				err("%s: cannot find group %s..:%s: %s\n",
+				    tname, cgroup_list[i]->controllers[0],
+				    cgroup_list[i]->path,
+				    cgroup_strerror(final_ret));
 			}
 			i++;
 		}
@@ -276,10 +274,8 @@ int main(int argc, char *argv[])
 			ret = parse_cgroup_spec(cgroup_list, optarg,
 				CG_HIER_MAX);
 			if (ret) {
-				fprintf(stderr, "%s: cgroup controller and ",
-					argv[0]);
-				fprintf(stderr,	"path parsing failed (%s)\n",
-					optarg);
+				err("%s: cgroup controller and path", argv[0]);
+				err(" path parsing failed (%s)\n", optarg);
 				return ret;
 			}
 			break;
@@ -295,9 +291,8 @@ int main(int argc, char *argv[])
 		ret = parse_cgroup_spec(cgroup_list, argv[optind],
 				CG_HIER_MAX);
 		if (ret) {
-			fprintf(stderr, "%s: cgroup controller", argv[0]);
-			fprintf(stderr,	" and path parsing failed (%s)\n",
-				argv[optind]);
+			err("%s: cgroup controller an path parsing ", argv[0]);
+			err("failed (%s)\n", argv[optind]);
 			return -1;
 		}
 		optind++;

--- a/src/tools/lssubsys.c
+++ b/src/tools/lssubsys.c
@@ -4,6 +4,8 @@
  * Written by Ivana Hutarova Varekova <varekova@redhat.com>
  */
 
+#include "tools-common.h"
+
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
 
@@ -27,23 +29,22 @@ typedef char cont_name_t[FILENAME_MAX];
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		fprintf(stderr, "Wrong input parameters,");
-		fprintf(stderr,	" try %s -h' for more information.\n",
-			program_name);
+		err("Wrong input parameters, ");
+		err("try %s -h' for more information.\n", program_name);
 		return;
 	}
 
-	printf("Usage: %s [-i] [-m] [-M] [controller] [...]\n", program_name);
-	printf("   or: %s [-a] [-i] [-m] [-M]\n", program_name);
-	printf("List information about given controller(s) If no controller ");
-	printf("is set list information about all mounted controllers.\n");
-	printf("  -a, --all			Display information ");
-	printf("about all controllers (including not mounted ones)\n");
-	printf("  -h, --help			Display this help\n");
-	printf("  -i, --hierarchies		Display information about ");
-	printf("hierarchies\n");
-	printf("  -m, --mount-points		Display mount points\n");
-	printf("  -M, --all-mount-points	Display all mount points\n");
+	info("Usage: %s [-i] [-m] [-M] [controller] [...]\n", program_name);
+	info("   or: %s [-a] [-i] [-m] [-M]\n", program_name);
+	info("List information about given controller(s) If no controller ");
+	info("is set list information about all mounted controllers.\n");
+	info("  -a, --all			Display information ");
+	info("about all controllers (including not mounted ones)\n");
+	info("  -h, --help			Display this help\n");
+	info("  -i, --hierarchies		Display information about ");
+	info("hierarchies\n");
+	info("  -m, --mount-points		Display mount points\n");
+	info("  -M, --all-mount-points	Display all mount points\n");
 }
 
 static int print_controller_mount(const char *controller, int flags,
@@ -55,11 +56,11 @@ static int print_controller_mount(const char *controller, int flags,
 
 	if (!(flags & FL_MOUNT) && !(flags & FL_HIERARCHY)) {
 		/* print only hierarchy name */
-		printf("%s\n", cont_names);
+		info("%s\n", cont_names);
 	}
 	if (!(flags & FL_MOUNT) && (flags & FL_HIERARCHY)) {
 		/* print only hierarchy name and number*/
-		printf("%s %d\n", cont_names, hierarchy);
+		info("%s %d\n", cont_names, hierarchy);
 	}
 	if (flags & FL_MOUNT) {
 		/* print hierarchy name and mount point(s) */
@@ -67,7 +68,7 @@ static int print_controller_mount(const char *controller, int flags,
 							  path);
 		/* intentionally ignore error from above call */
 		while (ret == 0) {
-			printf("%s %s\n", cont_names, path);
+			info("%s %s\n", cont_names, path);
 			if (!(flags & FL_MOUNT_ALL))
 				/* first mount record is enough */
 				goto stop;
@@ -101,8 +102,7 @@ static int print_all_controllers_in_hierarchy(const char *tname,
 
 	ret = cgroup_get_all_controller_begin(&handle, &info);
 	if ((ret != 0) && (ret != ECGEOF)) {
-		fprintf(stderr, "cannot read controller data: %s\n",
-			cgroup_strerror(ret));
+		err("cannot read controller data: %s\n", cgroup_strerror(ret));
 		return ret;
 	}
 
@@ -172,7 +172,7 @@ static int cgroup_list_all_controllers(const char *tname,
 			/* the controller is not attached to any hierachy */
 			if (flags & FL_ALL)
 				/* display only if -a flag is set */
-				printf("%s\n", info.name);
+				info("%s\n", info.name);
 		}
 		is_on_list = 0;
 		j = 0;
@@ -213,9 +213,8 @@ static int cgroup_list_all_controllers(const char *tname,
 	if (ret == ECGEOF)
 		ret = 0;
 	if (ret) {
-		fprintf(stderr,
-			"cgroup_get_controller_begin/next failed (%s)\n",
-			cgroup_strerror(ret));
+		err("cgroup_get_controller_begin/next failed (%s)\n",
+		    cgroup_strerror(ret));
 		return ret;
 	}
 
@@ -280,7 +279,7 @@ int main(int argc, char *argv[])
 		c_number++;
 		optind++;
 		if (optind == CG_CONTROLLER_MAX) {
-			fprintf(stderr, "Warning: too many parameters\n");
+			err("Warning: too many parameters\n");
 			break;
 		}
 	}

--- a/src/tools/tools-common.h
+++ b/src/tools/tools-common.h
@@ -24,6 +24,9 @@ extern "C" {
 #define cgroup_info(x...) cgroup_log(CGROUP_LOG_INFO, "Info: " x)
 #define cgroup_dbg(x...) cgroup_log(CGROUP_LOG_DEBUG, x)
 
+#define err(x...)	fprintf(stderr, x)
+#define info(x...)	fprintf(stdout, x)
+
 /**
  * Auxiliary specifier of group, used to store parsed command line options.
  */


### PR DESCRIPTION
This patch series introduces `err()` and `info()` helpers for tools.  These
helpers replace the usages of `fprintf(stderr, ...)` and `printf(...)` across
the sources of the tools.  This helps in improving the code readability.
