### PR TITLE
make bash scripts shellcheck complaint

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@
 
 set -ex
 
-if [ -f .git/hooks/pre-commit.sample -a ! -f .git/hooks/pre-commit ] ; then
+if [ -f .git/hooks/pre-commit.sample ] && [ ! -f .git/hooks/pre-commit ] ; then
 	cp -p .git/hooks/pre-commit.sample .git/hooks/pre-commit && \
 	chmod +x .git/hooks/pre-commit && \
 	echo "Activated pre-commit hook."

--- a/scripts/init.d/cgconfig.in
+++ b/scripts/init.d/cgconfig.in
@@ -38,8 +38,10 @@ lockfile=/run/lock/subsys/$servicename
 SYSLIBFILE=/lib/lsb/init-functions
 OLDSYSLIBFILE=/etc/init.d/functions
 if [[ -x  $SYSLIBFILE ]] ; then
+  # shellcheck disable=SC1090
   source $SYSLIBFILE
 elif  [[ -x $OLDSYSLIBFILE ]] ; then
+  # shellcheck disable=SC1090
   source $OLDSYSLIBFILE
   log_warning_msg() ( warning "$@" ; printf "\n" 1>&2 ; )
   log_failure_msg() ( failure "$@" ; printf "\n" 1>&2 ; )
@@ -53,6 +55,7 @@ fi
 # read the config
 CREATE_DEFAULT=yes
 if [ -e /etc/sysconfig/cgconfig ]; then
+	# shellcheck disable=SC1091
         source /etc/sysconfig/cgconfig
 fi
 
@@ -62,8 +65,9 @@ create_default_groups() {
 	defaultcgroup=
 
         if [ -f /etc/cgrules.conf ]; then
-	    read user ctrl defaultcgroup <<< \
-		    $(grep -m1 '^\*[[:space:]]\+' /etc/cgrules.conf)
+	    # shellcheck disable=SC2034
+	    read -r user ctrl defaultcgroup <<< \
+		    "$(grep -m1 '^\*[[:space:]]\+' /etc/cgrules.conf)"
            if [[ ( -n "$defaultcgroup" ) && ( "$defaultcgroup" = "*" ) ]]; then
                 log_warning_msg "/etc/cgrules.conf incorrect"
                 log_warning_msg "Overriding it"
@@ -86,23 +90,23 @@ create_default_groups() {
         # Create the default group, ignore errors when the default group
         # already exists.
         #
-        cgcreate -f 664 -d 775 -g $controllers:$defaultcgroup 2>/dev/null
+        cgcreate -f 664 -d 775 -g "$controllers":"$defaultcgroup" 2>/dev/null
 
         #
         # special rule for cpusets
         #
-        if echo $controllers | grep -q -w cpuset; then
+        if echo "$controllers" | grep -q -w cpuset; then
                 cpus=$(cgget -nv -r cpuset.cpus /)
-                cgset -r cpuset.cpus=$cpus $defaultcgroup
+                cgset -r cpuset.cpus="$cpus $defaultcgroup"
                 mems=$(cgget -nv -r cpuset.mems /)
-                cgset -r cpuset.mems=$mems $defaultcgroup
+                cgset -r cpuset.mems="$mems $defaultcgroup"
         fi
 
         #
         # Classify everything to default cgroup. Ignore errors, some processes
         # may exit after ps is run and before cgclassify moves them.
         #
-        cgclassify -g $controllers:$defaultcgroup $(ps --no-headers -eL o tid) \
+        cgclassify -g "$controllers:$defaultcgroup $(ps --no-headers -eL o tid)" \
                  2>/dev/null || :
 }
 

--- a/scripts/init.d/cgred.in
+++ b/scripts/init.d/cgred.in
@@ -32,11 +32,25 @@ CGRED_BIN=$sbindir/cgrulesengd
 # Sanity checks
 [[ -x $CGRED_BIN ]] || exit 1
 
-# Source function library & LSB routines
-# shellcheck disable=SC1091
-source /etc/rc.d/init.d/functions
-# shellcheck disable=SC1091
-source /lib/lsb/init-functions
+#
+# Source LSB routines
+#
+SYSLIBFILE=/lib/lsb/init-functions
+OLDSYSLIBFILE=/etc/init.d/functions
+if [[ -x  $SYSLIBFILE ]] ; then
+  # shellcheck disable=SC1090
+  source $SYSLIBFILE
+elif  [[ -x $OLDSYSLIBFILE ]] ; then
+  # shellcheck disable=SC1090
+  source $OLDSYSLIBFILE
+  log_warning_msg() ( warning "$@" ; printf "\n" 1>&2 ; )
+  log_failure_msg() ( failure "$@" ; printf "\n" 1>&2 ; )
+  log_success_msg() ( success "$@" ; printf "\n" 1>&2 ; )
+else
+  log_warning_msg() ( printf "warning:%s\n" "$@" 1>&2 ;)
+  log_failure_msg() ( printf "failure:%s\n" "$@" 1>&2 ;)
+  log_success_msg() ( printf "success:%s\n" "$@" 1>&2 ;)
+fi
 
 # Read in configuration options.
 if [[ -f "/etc/sysconfig/cgred.conf" ]] ; then
@@ -139,9 +153,9 @@ case "$1" in
 			kill -s 12 "$(cat ${pidfile})"
 			RETVAL=$?
 			if [[ $RETVAL -eq 0 ]] ; then
-				log_success_msg
+				log_success_msg ""
 			else
-				log_failure_msg
+				log_failure_msg ""
 			fi
 		else
 			log_failure_msg "$servicename is not running."

--- a/scripts/init.d/cgred.in
+++ b/scripts/init.d/cgred.in
@@ -26,28 +26,30 @@
 #			cgroups to classify processes
 ### END INIT INFO
 
-prefix=@prefix@;exec_prefix=@exec_prefix@;sbindir=@sbindir@
+sbindir=@sbindir@
 CGRED_BIN=$sbindir/cgrulesengd
-CGRED_CONF=/etc/cgrules.conf
 
 # Sanity checks
-[ -x $CGRED_BIN ] || exit 1
+[[ -x $CGRED_BIN ]] || exit 1
 
 # Source function library & LSB routines
-. /etc/rc.d/init.d/functions
-. /lib/lsb/init-functions
+# shellcheck disable=SC1091
+source /etc/rc.d/init.d/functions
+# shellcheck disable=SC1091
+source /lib/lsb/init-functions
 
 # Read in configuration options.
-if [ -f "/etc/sysconfig/cgred.conf" ] ; then
-	. /etc/sysconfig/cgred.conf
+if [[ -f "/etc/sysconfig/cgred.conf" ]] ; then
+	# shellcheck disable=SC1091
+	source /etc/sysconfig/cgred.conf
 	OPTIONS="$NODAEMON $LOG"
-	if [ -n "$LOG_FILE" ]; then
+	if [[ -n "$LOG_FILE" ]]; then
 		OPTIONS="$OPTIONS --logfile=$LOG_FILE"
 	fi
-	if [ -n "$SOCKET_USER" ]; then
+	if [[ -n "$SOCKET_USER" ]]; then
 		OPTIONS="$OPTIONS -u $SOCKET_USER"
 	fi
-	if [ -n "$SOCKET_GROUP" ]; then
+	if [[ -n "$SOCKET_GROUP" ]]; then
 		OPTIONS="$OPTIONS -g $SOCKET_GROUP"
 	fi
 else
@@ -63,12 +65,12 @@ pidfile=/var/run/cgred.pid
 start()
 {
 	echo -n $"Starting CGroup Rules Engine Daemon: "
-	if [ -f "$lockfile" ]; then
-		log_failure_msg "$servicename is already running with PID `cat ${pidfile}`"
+	if [[ -f "$lockfile" ]]; then
+		log_failure_msg "$servicename is already running with PID $(cat ${pidfile})"
 		return 0
 	fi
-	num=`grep "cgroup" /proc/mounts | awk '$3=="cgroup"' | wc -l`
-	if [ $num -eq 0 ]; then
+	num=$(grep "cgroup" /proc/mounts | awk '$3=="cgroup"' | wc -l)
+	if [[ "$num" -eq 0 ]]; then
 		echo
 		log_failure_msg $"Cannot find cgroups, is cgconfig service running?"
 		return 1
@@ -76,28 +78,27 @@ start()
 	daemon --check $servicename --pidfile $pidfile $CGRED_BIN $OPTIONS
 	retval=$?
 	echo
-	if [ $retval -ne 0 ]; then
+	if [[ $retval -ne 0 ]]; then
 		return 7
 	fi
-	touch "$lockfile"
-	if [ $? -ne 0 ]; then
+	if ! touch "$lockfile"; then
 		return 1
 	fi
-	echo "`pidof $processname`" > $pidfile
+	pidof "$processname" > $pidfile
 	return 0
 }
 
 stop()
 {
 	echo -n $"Stopping CGroup Rules Engine Daemon..."
-	if [ ! -f $pidfile ]; then
+	if [[ ! -f $pidfile ]]; then
 		log_success_msg
 		return 0
 	fi
 	killproc -p $pidfile -TERM "$processname"
 	retval=$?
 	echo
-	if [ $retval -ne 0 ]; then
+	if [[ $retval -ne 0 ]]; then
 		return 1
 	fi
 	rm -f "$lockfile" "$pidfile"
@@ -126,18 +127,18 @@ case "$1" in
 		RETVAL=$?
 		;;
 	condrestart)
-		if [ -f "$lockfile" ]; then
+		if [[ -f "$lockfile" ]]; then
 			stop
 			start
 			RETVAL=$?
 		fi
 		;;
 	reload|flash)
-		if [ -f "$lockfile" ]; then
+		if [[ -f "$lockfile" ]]; then
 			echo $"Reloading rules configuration..."
-			kill -s 12 `cat ${pidfile}`
+			kill -s 12 "$(cat ${pidfile})"
 			RETVAL=$?
-			if [ $RETVAL -eq 0 ] ; then
+			if [[ $RETVAL -eq 0 ]] ; then
 				log_success_msg
 			else
 				log_failure_msg


### PR DESCRIPTION
This patch series fixes the bash scripts shell check complaints.  It allows
exceptions at a couple of sites for rules `SC1090`  and  `SC2034`.
