### PR TITLE
Add a sample code to create empty cgroup v2

### DIFF
--- a/samples/c/Makefile.am
+++ b/samples/c/Makefile.am
@@ -5,7 +5,7 @@ LDADD = $(top_builddir)/src/.libs/libcgroup.la
 #noinst_PROGRAMS = setuid walk_test read_stats walk_task get_controller	\
 #		  get_mount_point proctest get_all_controller		\
 #		  get_variable_names test_named_hierarchy		\
-#		  get_procs wrapper_test logger
+#		  get_procs wrapper_test logger empty_cgroup_v2
 
 setuid_SOURCES=setuid.c
 walk_test_SOURCES=walk_test.c
@@ -20,3 +20,4 @@ test_named_hierarchy_SOURCES=test_named_hierarchy.c
 get_procs_SOURCES=get_procs.c
 wrapper_test_SOURCES=wrapper_test.c
 logger_SOURCES=logger.c
+empty_cgroup_v2_SOURCES=empty_cgroup_v2.c

--- a/samples/c/empty_cgroup_v2.c
+++ b/samples/c/empty_cgroup_v2.c
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
+ * Simple program to add empty cgroup v2
+ *
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Author: Kamalesh babulal <kamalesh.baulal@oracle.com>
+ */
+
+#include <libcgroup.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#define CGRP_NAME "empty_cgrp"
+
+int main(int argc, char **argv)
+{
+	struct cgroup *cgroup = NULL;
+	int ret = 0;
+
+	ret = cgroup_init();
+	if (ret) {
+		fprintf(stderr, "cgroup_init failed\n");
+		exit(1);
+	}
+
+	cgroup = cgroup_new_cgroup(CGRP_NAME);
+	if (!cgroup) {
+		fprintf(stderr, "Failed to allocate cgroup %s\n", CGRP_NAME);
+		exit(1);
+	}
+
+	ret = cgroup_create_cgroup(cgroup, 0);
+	if (ret)
+		fprintf(stderr, "Failed to create cgroup %s\n", CGRP_NAME);
+
+	cgroup_free(&cgroup);
+
+	return ret;
+}


### PR DESCRIPTION
This patchset adds sample code on how to create an empty cgroup
on cgroup v2.