### PR TITLE
[RFC] api.c: fix deleting cgroup created on shared mnt point

### DIFF
--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -132,6 +132,7 @@ struct cg_mount_table_s {
 	 */
 	struct cg_mount_point mount;
 	int index;
+	int shared_mnt;
 	enum cg_version_t version;
 };
 


### PR DESCRIPTION
cgroup v1 allows mounting of two or more controllers on a single
mount point.  This fails currently when trying to delete the cgroup
recursively for all the mounted controllers because the cgroup is
already deleted by the first controller of the share mount point and
the controllers then on complaint about missing cgroup path.

Fix this issue by checking if the cgroup controllers share mount point
and ignore the error if the file doesn't exist, similar to ignoring if
the file exists during creation.

Fixes: https://github.com/libcgroup/libcgroup/issues/127

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>