### PR TITLE
[RFC] add support to attach tid to an empty cgroup v2

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1770,6 +1770,10 @@ STATIC int cgroupv2_controller_enabled(const char * const cg_name,
 	if (version != CGROUP_V2)
 		return 0;
 
+	if (ctrl_name == NULL)
+		/* cgroup v2 supports cgroups with no controllers. */
+		return 0;
+
 	if (strncmp(cg_name, "/", strlen(cg_name)) == 0)
 		/*
 		 * The root cgroup has been requested.  All version 2


### PR DESCRIPTION
Currently, `cgroup_attach_task_pid()` checks for enabled controllers
before attaching the given tid to it, but in the case of empty cgroup,
it simply ignores the attaching due to no controllers available, a.k.a.
`cgroup->index` is 0.  Add support to recognize the empty controller
cgroups.   Also, always return true in `cgroupv2_controller_enabled()`
for cgroups with no controllers attached.
