### PR TITLE
api.c: fix build warnings

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1333,9 +1333,9 @@ static int cgroup_populate_controllers(char *controllers[CG_CONTROLLER_MAX])
 	int hierarchy, num_cgroups, enabled;
 	char subsys_name[FILENAME_MAX];
 	FILE *proc_cgroup;
+	char *buf = NULL;
 	int ret = 0;
 	int i, err;
-	char *buf;
 
 	proc_cgroup = fopen("/proc/cgroups", "re");
 	if (!proc_cgroup) {
@@ -1404,7 +1404,7 @@ err:
 static int cgroup_populate_mount_points(char *controllers[CG_CONTROLLER_MAX])
 {
 	char mntent_buffer[4 * FILENAME_MAX];
-	struct mntent *temp_ent, *ent;
+	struct mntent *ent, *temp_ent = NULL;
 	int found_mnt = 0;
 	FILE *proc_mount;
 	int ret = 0;


### PR DESCRIPTION
Fix the use before initialization build warnings:

api.c: In function ‘cgroup_populate_controllers.constprop’:
api.c:1386:5: warning: ‘buf’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1386 |  if (buf)
      |     ^
api.c: In function ‘cgroup_populate_mount_points.constprop’:
api.c:1461:5: warning: ‘temp_ent’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1461 |  if (temp_ent)
      |     ^

this patch, initializes them to NULL.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>