### PR TITLE
python: Make Cgroup.mount_points() more pythonic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	fetchRecurseSubmodules = true
 [submodule "tests"]
 	path = tests
-	url = https://github.com/libcgroup/libcgroup-tests.git
+	url = https://github.com/drakenclimber/libcgroup-tests.git

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,7 +14,7 @@ git submodule update --init --recursive
 
 # configure libcgroup-tests
 pushd tests
-git checkout main
+git checkout issues/mount-pybindings
 popd
 
 # configure googletest

--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -51,10 +51,14 @@ cdef class Cgroup:
     cdef public:
         object name, controllers, version
 
-    def __cinit__(self, name, version):
+    @staticmethod
+    def cgroup_init():
         ret = cgroup.cgroup_init()
         if ret != 0:
             raise RuntimeError("Failed to initialize libcgroup: {}".format(ret))
+
+    def __cinit__(self, name, version):
+        Cgroup.cgroup_init()
 
         self._cgp = cgroup.cgroup_new_cgroup(c_str(name))
         if self._cgp == NULL:
@@ -277,17 +281,23 @@ cdef class Cgroup:
         if ret != 0:
             raise RuntimeError("Failed to create cgroup: {}".format(ret))
 
-    def cgroup_list_mount_points(self, version):
+    @staticmethod
+    def mount_points(version):
         """List cgroup mount points of the specified version
 
         Arguments:
         version - It specifies the cgroup version
+
+        Return:
+        The cgroup mount points in a list
 
         Description:
         Parse the /proc/mounts and list the cgroup mount points matching the
         version
         """
         cdef char **a
+
+        Cgroup.cgroup_init()
 
         mount_points = []
         ret = cgroup.cgroup_list_mount_points(version, &a)


### PR DESCRIPTION
Rename `cgroup_list_mount_points()` to `mount_points()` and
convert it to an @staticmethod.

`Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>`
