### PR TITLE
api.c: fix segfault while processing cgroup mount points

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1116,6 +1116,9 @@ STATIC int cgroup_process_v1_mnt(char *controllers[], struct mntent *ent,
 		cgroup_dbg("Found cgroup option %s, count %d\n",
 			ent->mnt_opts, *mnt_tbl_idx);
 		(*mnt_tbl_idx)++;
+
+		if (*mnt_tbl_idx >= CG_CONTROLLER_MAX)
+			goto out;
 	}
 
 	/*
@@ -1172,6 +1175,11 @@ STATIC int cgroup_process_v1_mnt(char *controllers[], struct mntent *ent,
 	}
 
 out:
+	if (*mnt_tbl_idx >= CG_CONTROLLER_MAX) {
+		cgroup_err("Error: Mount points exceeds CG_CONTROLLER_MAX\n");
+		ret = ECGMAXVALUESEXCEEDED;
+	}
+
 	return ret;
 }
 
@@ -1251,11 +1259,20 @@ STATIC int cgroup_process_v2_mnt(struct mntent *ent, int *mnt_tbl_idx)
 		cgroup_dbg("Found cgroup option %s, count %d\n",
 			controller, *mnt_tbl_idx);
 		(*mnt_tbl_idx)++;
+
+		if (*mnt_tbl_idx >= CG_CONTROLLER_MAX)
+			break;
+
 	} while ((controller = strtok_r(NULL, " ", &stok_buff)));
 
 out:
 	if (fp)
 		fclose(fp);
+
+	if (*mnt_tbl_idx >= CG_CONTROLLER_MAX) {
+		cgroup_err("Error: Mount points exceeds CG_CONTROLLER_MAX\n");
+		ret = ECGMAXVALUESEXCEEDED;
+	}
 
 	return ret;
 }


### PR DESCRIPTION
The cgroup v1 and cgroup v2 mount points get read from /proc/mounts in
cgroup_process_v1_mnt()/cgroup_process_v2_mnt() respectively and gets
populated into cg_mount_table[].  The size of cg_mount_table[] is set
to CG_CONTROLLER_MAX, that's defined as 100 and if the system has more
than CG_CONTROLLER_MAX, unique mount points, it will segfault while
processing them.  Fix this by checking, the mount point count after
processing every mount entry and bailout in case it reaches
CG_CONTROLLER_MAX.

The issue can be reproduced using, following simple bash commands on
cgroup v1:
1. sudo for i in $(seq 0 100); do sudo mkdir /name$i; done
2. sudo for i in $(seq 0 100); do sudo mount -t cgroup -o
   none,name=named$i none /name$i; done
3. sudo cgget -g <controller>:<existing cgroup name>

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>