### PR TITLE
configure: fix the extra spaces in --enable-bindings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ AC_ARG_ENABLE([bindings],
 			with_bindings=true
 		fi
 	],
-	[with_bindings = false])
+	[with_bindings=false])
 AM_CONDITIONAL([WITH_BINDINGS], [test x$with_bindings = xtrue])
 
 # Process command line options


### PR DESCRIPTION
Extra spaces between the default action assignment for the feature
--enable-bindings feature, fails with:
./configure: line 12510: with_bindings: command not found
    
fix the issue by removing the extra spaces in the assignment.
    
Fixes: https://github.com/libcgroup/libcgroup/issues/133
    
Reported-by: @jeffmacdonald (github username)
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>
