### PR TITLE
lssubsys, lscgroup - support status update in help/man page

### DIFF
--- a/doc/man/lscgroup.1
+++ b/doc/man/lscgroup.1
@@ -40,6 +40,9 @@ in subgroup student
 .B lscgroup
 list all cgroups which in all hierarchies
 
+.SH NOTES
+.TP
+lscgroup is currently supported on cgroups v1 only.
 
 .SH SEE ALSO
 lssubsys (1), cgcreate (1), cgdelete (1),

--- a/doc/man/lssubsys.1
+++ b/doc/man/lssubsys.1
@@ -85,6 +85,10 @@ freezer /cgroup/freezer
 net_cls /cgroup/net_cls
 .fi
 
+.SH NOTES
+.TP
+lssubsys is currently supported on cgroups v1 only.
+
 .SH ENVIRONMENT VARIABLES
 .TP
 .B CGROUP_LOGLEVEL

--- a/src/tools/lscgroup.c
+++ b/src/tools/lscgroup.c
@@ -48,6 +48,7 @@ static void usage(int status, const char *program_name)
 	info("  -g <controllers>:<path>	Control group to be ");
 	info("displayed (-g is optional)\n");
 	info("  -h, --help			Display this help\n");
+	info("(Note: currently supported on cgroups v1 only)\n");
 }
 
 /*

--- a/src/tools/lssubsys.c
+++ b/src/tools/lssubsys.c
@@ -45,6 +45,7 @@ static void usage(int status, const char *program_name)
 	info("hierarchies\n");
 	info("  -m, --mount-points		Display mount points\n");
 	info("  -M, --all-mount-points	Display all mount points\n");
+	info("(Note: currently supported on cgroups v1 only)\n");
 }
 
 static int print_controller_mount(const char *controller, int flags,


### PR DESCRIPTION
lssubsys and lscgroup tools need major rework to support the
cgroups v2.  For now add the support status as notes to both
the help option and the man page of the tools, stating it's supported\
on cgroups v1 only.