### PR TITLE
tools/cgget: fix coverity warning about resource leak

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -4974,6 +4974,7 @@ int cgroup_read_value_end(void **handle)
 
 	fp = (FILE *)*handle;
 	fclose(fp);
+	*handle = NULL;
 
 	return 0;
 }

--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -547,6 +547,9 @@ end:
 		cv->multiline_value = NULL;
 	}
 
+	if ((FILE *)handle)
+		fclose((FILE *)handle);
+
 	return ret;
 }
 
@@ -643,9 +646,10 @@ static int fill_empty_controller(struct cgroup * const cg,
 		}
 	}
 
-	closedir(dir);
-
 out:
+	if (dir)
+		closedir(dir);
+
 	pthread_rwlock_unlock(&cg_mount_table_lock);
 	return ret;
 }


### PR DESCRIPTION
Fix two resource leaks reported by Coverity tool:

CID 1488718 (#1 of 1): Resource leak (RESOURCE_LEAK) leaked_storage:
Variable handle going out of scope leaks the storage it points to.

CID 1488723 (#1 of 1): Resource leak (RESOURCE_LEAK) leaked_storage:
Variable dir going out of scope leaks the storage it points to.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>