### PR TITLE
workflows/CI: upgrade CodeQL actions used to v2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,13 +42,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: false
-    - uses: github/codeql-action/init@v1
+    - uses: github/codeql-action/init@v2
       with:
         languages: cpp, python
     - name: Initialize the directory
       uses: ./.github/actions/setup-libcgroup
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 
   doxygen:
     name: Doxygen


### PR DESCRIPTION
CodeQL warns about deprecating v1 by Dec 2022.  Upgrade the CodeQL
actions, as per the recommendation made in the upgrade guide at:
https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>