### PR TITLE
tools/cgdelete: fix coverity wrong argument size warning

### DIFF
--- a/src/tools/cgdelete.c
+++ b/src/tools/cgdelete.c
@@ -143,8 +143,8 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	ecg_list = calloc(argc, sizeof(struct ext_cgroup_record *));
-	if (cgroup_list == NULL) {
+	ecg_list = calloc(argc, sizeof(struct ext_cgroup_record));
+	if (ecg_list == NULL) {
 		err("%s: out of memory\n", argv[0]);
 		ret = -1;
 		goto err;


### PR DESCRIPTION
Fix a wrong argument size, reported by Coverity tool:

CID 1412122 (#1 of 1): Wrong sizeof argument (SIZEOF_MISMATCH)
suspicious_sizeof: Passing argument 8UL
/* sizeof (struct ext_cgroup_record *) */ to function calloc and then
casting the return value to struct ext_cgroup_record * is suspicious.

Also, fix the typo in the variable name, that's being allocated memory.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>