### PR TITLE
src/config: fix coverity warning about add missing unlock() [v2.0]

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -976,8 +976,10 @@ static int config_order_namespace_table(void)
 				}
 			}
 		}
-		if (!flag)
-			return ECGNAMESPACECONTROLLER;
+		if (!flag) {
+			error = ECGNAMESPACECONTROLLER;
+			break;
+		}
 	}
 error_out:
 	pthread_rwlock_unlock(&cg_mount_table_lock);


### PR DESCRIPTION
Add missing unlock() of cg_mount_table_lock, reported by Coverity tool:

CID 1412126 (#1 of 1): Missing unlock (LOCK). missing_unlock:
Returning without unlocking cg_mount_table_lock.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>