### PR TITLE
configure: introduce --enable-tests/--disable-tests [v2.0]

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,9 @@
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS= -I m4
-SUBDIRS = dist doc include samples scripts src tests
+SUBDIRS = dist doc include samples scripts src
+if WITH_TESTS
+SUBDIRS += tests
+endif
 
 EXTRA_DIST = README_daemon libcgroup.doxyfile README_systemd
 

--- a/configure.ac
+++ b/configure.ac
@@ -137,6 +137,18 @@ AC_ARG_ENABLE([opaque-hierarchy],
 		fi
 	], [])
 
+AC_ARG_ENABLE([tests],
+	[AS_HELP_STRING([--enable-tests],[compile libcgroup tests [default=yes]])],
+	[
+		if test "x$enableval" == xno; then
+			with_tests=false
+		else
+			with_tests=true
+		fi
+	],
+	[with_tests=true])
+AM_CONDITIONAL([WITH_TESTS], [test x$with_tests = xtrue])
+
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC
@@ -201,15 +213,6 @@ fi
 AX_CODE_COVERAGE
 
 AC_CONFIG_FILES([Makefile
-	tests/Makefile
-	tests/ftests/Makefile
-	tests/gunit/Makefile
-	tests/tools/testenv.sh
-	tests/tools/Makefile
-	tests/tools/cgconfigparser/Makefile
-	tests/tools/cgclassify/Makefile
-	tests/tools/multimount/Makefile
-	tests/runlibcgrouptest.sh
 	src/Makefile
 	src/daemon/Makefile
 	src/tools/Makefile
@@ -225,5 +228,15 @@ AC_CONFIG_FILES([Makefile
 	dist/Makefile
 	libcgroup.pc])
 AC_CONFIG_FILES([dist/libcgroup.spec:dist/libcgroup.spec.in])
+AM_COND_IF([WITH_TESTS],
+	[AC_CONFIG_FILES([tests/Makefile
+		tests/ftests/Makefile
+		tests/gunit/Makefile
+		tests/tools/testenv.sh
+		tests/tools/Makefile
+		tests/tools/cgconfigparser/Makefile
+		tests/tools/cgclassify/Makefile
+		tests/tools/multimount/Makefile
+		tests/runlibcgrouptest.sh])])
 CFLAGS="$CFLAGS -Wall"
 AC_OUTPUT


### PR DESCRIPTION
There are scenarios where running tests as part of the make check is
not desirable, like rpmbuild.  The build systems might not have the
environment to run the tests and might fail to build the packages.

This patch introduces, --enable-tests as a configure option, which
is set by default and can be disabled using the --disable-tests flag.
When disabled, the configure will skip creating the Makefiles for the
tests/* directories and in the top-level Makefile the SUBDIRS omits
tests. For example, consider the rpmbuild case to build rpm with
--disable-tests passed:
1. ./bootstrap.sh
2. ./configure ./configure --enable-opaque-hierarchy="name=systemd"
   --disable-tests
3. make check
4. make dist
5. cp libcgroup-2.0.2.tar.gz ~/rpmbuild/SOURCES
6. append --disable-tests to configure in libcgroup.spec
7. rpmbuild -ba libcgroup.spec

this will skip running the test/*, during the build, avoiding unexpected
failures

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>