### PR TITLE
Fix uninitialized variable warnings reported by Coverity

### DIFF
--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
 	int nv_number = 0;
 	int nv_max = 0;
 
-	char src_cg_path[FILENAME_MAX];
+	char src_cg_path[FILENAME_MAX] = "\0";
 	struct cgroup *src_cgroup;
 	struct cgroup *cgroup;
 

--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -542,7 +542,7 @@ static int is_ctlr_on_list(char controllers[CG_CONTROLLER_MAX][FILENAME_MAX],
 static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX],
 			     const char *program_name)
 {
-	char controllers[CG_CONTROLLER_MAX][FILENAME_MAX];
+	char controllers[CG_CONTROLLER_MAX][FILENAME_MAX] = {"\0"};
 	struct cgroup_mount_point controller;
 	char path[FILENAME_MAX];
 	void *handle;

--- a/src/tools/cgxset.c
+++ b/src/tools/cgxset.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 	int nv_max = 0;
 
 	struct cgroup *converted_src_cgroup;
-	char src_cg_path[FILENAME_MAX];
+	char src_cg_path[FILENAME_MAX] = "\0";
 	struct cgroup *src_cgroup;
 	struct cgroup *cgroup;
 

--- a/src/tools/lssubsys.c
+++ b/src/tools/lssubsys.c
@@ -89,7 +89,7 @@ static int print_all_controllers_in_hierarchy(const char *tname,
 {
 	struct controller_data info;
 	enum cg_version_t version;
-	cont_name_t cont_names;
+	cont_name_t cont_names = "\0";
 	cont_name_t cont_name;
 	int first = 1;
 	void *handle;


### PR DESCRIPTION
This patch series fixes the uninitialized variable warnings reported
by Coverity  across: `tools/cgset, tools/lssubsys, tools/cgsnapshot`
and `tools/cgxset`. 