### PR TITLE
Fix uninitialized variable warnings reported by Coverity [v2.0]

### DIFF
--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
 	int nv_number = 0;
 	int nv_max = 0;
 
-	char src_cg_path[FILENAME_MAX];
+	char src_cg_path[FILENAME_MAX] = "\0";
 	struct cgroup *src_cgroup;
 	struct cgroup *cgroup;
 

--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -544,7 +544,7 @@ static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX],
 	char path[FILENAME_MAX];
 	struct cgroup_mount_point controller;
 
-	char controllers[CG_CONTROLLER_MAX][FILENAME_MAX];
+	char controllers[CG_CONTROLLER_MAX][FILENAME_MAX] = {"\0"};
 	int max = 0;
 
 	path[0] = '\0';

--- a/src/tools/lssubsys.c
+++ b/src/tools/lssubsys.c
@@ -93,7 +93,7 @@ static int print_all_controllers_in_hierarchy(const char *tname,
 	void *handle;
 	struct controller_data info;
 	int first = 1;
-	cont_name_t cont_names;
+	cont_name_t cont_names = "\0";
 	cont_name_t cont_name;
 	enum cg_version_t version;
 


### PR DESCRIPTION
This patch series fixes the uninitialized variable warnings reported
by Coverity across: `tools/cgset, tools/lssubsys` and `tools/cgsnapshot`.