### PR TITLE
configure: introduce --enable-tests/--disable-tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,9 @@
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS= -I m4
-SUBDIRS = dist doc include scripts src tests samples
+SUBDIRS = dist doc include samples scripts src
+if WITH_TESTS
+SUBDIRS += tests
+endif
 
 EXTRA_DIST = README_daemon libcgroup.doxyfile README_systemd CONTRIBUTING.md
 

--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,18 @@ AC_ARG_ENABLE([opaque-hierarchy],
 		fi
 	], [])
 
+AC_ARG_ENABLE([tests],
+      [AS_HELP_STRING([--enable-tests],[compile libcgroup tests [default=yes]])],
+      [
+		if test "x$enableval" == xno; then
+			with_tests=false
+		else
+			with_tests=true
+		fi
+       ],
+       [with_tests=true])
+AM_CONDITIONAL([WITH_TESTS], [test x$with_tests = xtrue])
+
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC
@@ -198,9 +210,6 @@ fi
 AX_CODE_COVERAGE
 
 AC_CONFIG_FILES([Makefile
-	tests/Makefile
-	tests/ftests/Makefile
-	tests/gunit/Makefile
 	src/Makefile
 	src/daemon/Makefile
 	src/tools/Makefile
@@ -218,6 +227,10 @@ AC_CONFIG_FILES([Makefile
 	doc/man/Makefile
 	dist/Makefile
 	libcgroup.pc])
+AM_COND_IF([WITH_TESTS],
+	[AC_CONFIG_FILES([tests/Makefile
+		tests/ftests/Makefile
+		tests/gunit/Makefile])])
 AC_CONFIG_FILES([dist/libcgroup.spec:dist/libcgroup.spec.in])
 CFLAGS="$CFLAGS -Wall"
 AC_OUTPUT


### PR DESCRIPTION
There are scenarios where running tests as part of the make check is
not desirable, like rpmbuild.  The build systems might not have the
environment to run the tests and might fail to build the packages.

This patch introduces, --enable-tests as a configure option, which
is set by default and can be disabled using the --disable-tests flag.
When disabled, the configure will skip creating the Makefiles for the
tests/* directories and in the top-level Makefile the SUBDIRS omits
tests. For example, consider the rpmbuild case to build rpm with
--disable-tests passed:
1. ./bootstrap.sh
2. ./configure ./configure --enable-opaque-hierarchy="name=systemd"
   --disable-tests
3. make check
4. make dist
5. cp libcgroup-3.0.0.tar.gz ~/rpmbuild/SOURCES
6. append --disable-tests to configure in libcgroup.spec
7. rpmbuild -ba libcgroup.spec

this will skip running the test/*, during the build, avoiding unexpected
failures

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>