### PR TITLE
api.c: fix coverity out of bounds read warning [v2.0]

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -111,6 +111,7 @@ const char * const cgroup_strerror_codes[] = {
 	"Cgroup parsing failed",
 	"Cgroup, rules file does not exist",
 	"Cgroup mounting failed",
+	"",			/* 50022 is reserved for future errors */
 	"End of File or iterator",
 	"Failed to parse config file",
 	"Have multiple paths for the same namespace",


### PR DESCRIPTION
Fix out of bounds read, reported by Coverity tool:

CID 1412156 (#1 of 1): Out-of-bounds read (OVERRUN).
overrun-local: Overrunning array cgroup_strerror_codes of 30 8-byte
elements at element index 49999 (byte offset 399999) using index
code % ECGROUPNOTCOMPILED (which evaluates to 49999).
```
Reproducer:
-----------
$ cat cgrp-strerr.c

int main(void)
{
        int err = ECGNONEMPTY;

        fprintf(stderr, "%s\n", cgroup_strerror(err));

        return 0;
}

without the patch:
-----------------
$ ./cgrp-stderr
(null)

with the patch:
---------------
$ ./cgrp-stderr
Failed to remove a non-empty group
```
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>