### PR TITLE
tools/cgget: fix coverity warning about double free

### DIFF
--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -625,10 +625,8 @@ static int fill_empty_controller(struct cgroup * const cg,
 			continue;
 
 		ret = cgroup_fill_cgc(ctrl_dir, cg, cgc, i);
-		if (ret == ECGFAIL) {
-			closedir(dir);
+		if (ret == ECGFAIL)
 			goto out;
-		}
 
 		if (cgc->index > 0) {
 			cgc->values[cgc->index - 1]->dirty = false;


### PR DESCRIPTION
Fix double free warning, reported by Coverity tool:

CID 258297 (#1 of 1): Double free (USE_AFTER_FREE). double_free:
Calling closedir frees pointer dir which has already been freed.

As per the man page, the closedir(), closes the directory stream
associated with the dirp, but is ambiguous about if dirp is set to NULL
or not. Coverity answers that with the above report, that dirp is not
NULL and hence the double free.

Fixes: fea1ab8b45d7 ("tools/cgget: fix coverity warning about resource leak")
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>