### PR TITLE
tools/cgxget: fix coverity warning about resource leak

### DIFF
--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -654,10 +654,8 @@ static int fill_empty_controller(struct cgroup * const cg,
 			continue;
 
 		ret = cgroup_fill_cgc(ctrl_dir, cg, cgc, i);
-		if (ret == ECGFAIL) {
-			closedir(dir);
+		if (ret == ECGFAIL)
 			goto out;
-		}
 
 		if (cgc->index > 0) {
 			cgc->values[cgc->index - 1]->dirty = false;
@@ -675,9 +673,10 @@ static int fill_empty_controller(struct cgroup * const cg,
 		}
 	}
 
-	closedir(dir);
-
 out:
+	if (dir)
+		closedir(dir);
+
 	pthread_rwlock_unlock(&cg_mount_table_lock);
 
 	return ret;


### PR DESCRIPTION
Fix a resource leaks reported by Coverity tool:

CID 258302 (#1 of 1): Resource leak (RESOURCE_LEAK). leaked_storage:
Variable dir going out of scope leaks the storage it points to

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>