### PR TITLE
api.c: add cgroup error string for ECGNOVERSIONCONVERT

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -128,6 +128,7 @@ const char * const cgroup_strerror_codes[] = {
 	"This kernel does not support this feature",
 	"Value setting does not succeed",
 	"Failed to remove a non-empty group",
+	"Failed to convert from cgroup v1 to/from cgroup v2",
 };
 
 static const char * const cgroup_ignored_tasks_files[] = { "tasks", NULL };


### PR DESCRIPTION
Add the missing error string for the error code `ECGNOVERSIONCONVERT` to
cgroup_strerror_codes[], that is looked upon to print string version of
the error encountered.
```
Reproducer:
-----------
$ cat cgrp-strerr.c

int main(void)
{
        int err = ECGNOVERSIONCONVERT;

        fprintf(stderr, "%s\n", cgroup_strerror(err));

        return 0;
}

without the patch:
-----------------
$ ./cgrp-stderr
(null)

with the patch:
---------------
$ ./cgrp-stderr
Failed to convert from cgroup v1 to/from cgroup v2
```

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>