### PR TITLE
api: fix coverity warning about uninitialized variable

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -2611,7 +2611,7 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 				 const struct cgroup_controller * const controller,
 				 int ignore_ownership)
 {
-	enum cg_version_t version;
+	enum cg_version_t version = CGROUP_UNK;
 	char *fts_path[2];
 	char *base = NULL;
 	char *path = NULL;


### PR DESCRIPTION
Fix Uninitialized scalar variable, reported by Coverity tool:

CID 258269 (#1 of 1): Uninitialized scalar variable (UNINIT).
uninit_use: Using uninitialized value version.

In _cgroup_create_cgroup(), the (cg_version_t)version is uninitialized
and might be read the version in false path. It worked until now
because the version is assigned in the true path and given that its enum
the checks are not bounded by range, but rather specific.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>