### PR TITLE
api: null terminated string in cgroup_get_controller_next()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -5215,8 +5215,10 @@ int cgroup_get_controller_next(void **handle, struct cgroup_mount_point *info)
 	}
 
 	strncpy(info->name, cg_mount_table[*pos].name, FILENAME_MAX - 1);
+	info->name[FILENAME_MAX - 1] = '\0';
 
 	strncpy(info->path, cg_mount_table[*pos].mount.path, FILENAME_MAX - 1);
+	info->path[FILENAME_MAX - 1] = '\0';
 
 	(*pos)++;
 	*handle = pos;


### PR DESCRIPTION
Fix non-terminated string warnings, reported by Coverity tool:

CID 258299 (#1-2 of 2): String not null terminated (STRING_NULL).
string_null: Passing unterminated string controller.path to strcmp,
which expects a null-terminated string

This issue was reported following the path src/tools/cgsnapshot.c:
- parse_controllers()
  - cgroup_get_controller_begin()
    - cgroup_get_controller_next()

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>