### PR TITLE
config: add missing ret value check from getgrnam_r() [v2.0]

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -370,10 +370,8 @@ int config_group_task_perm(char *perm_type, char *value, int flag)
 			if (!group)
 				goto group_task_error;
 
-			getgrnam_r(value, group, buffer,
-					CGROUP_BUFFER_LEN, &group_buffer);
-
-			if (group_buffer == NULL) {
+			if (getgrnam_r(value, group, buffer,
+				       CGROUP_BUFFER_LEN, &group_buffer) != 0) {
 				free(group);
 				goto group_task_error;
 			}
@@ -482,10 +480,8 @@ int config_group_admin_perm(char *perm_type, char *value, int flag)
 			if (!group)
 				goto admin_error;
 
-			getgrnam_r(value, group, buffer,
-					CGROUP_BUFFER_LEN, &group_buffer);
-
-			if (group_buffer == NULL) {
+			if (getgrnam_r(value, group, buffer,
+				       CGROUP_BUFFER_LEN, &group_buffer) != 0) {
 				free(group);
 				goto admin_error;
 			}


### PR DESCRIPTION
Fix Unchecked return values from library, reported by Coverity tool:

CID 258287 (#1 of 1): Unchecked return value from library
(CHECKED_RETURN).
check_return: Calling getgrnam_r(value, group, buffer, 20480UL,
&group_buffer) without checking return value. This library function may
fail and return an error code.

CID 258303 (#1 of 1): Unchecked return value from library
(CHECKED_RETURN).
check_return: Calling getgrnam_r(value, group, buffer, 20480UL,
&group_buffer) without checking return value. This library function may
fail and return an error code.

Coverity expects us to check for return value from getgrnam_r(), instead
of the current for group_buffer != NULL.  Which is right, let's make
Coverity happy by moving the check to return value.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>