### PR TITLE
wrapper: null terminated string in cgroup_add_controller() [v2.0]

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -83,6 +83,8 @@ struct cgroup_controller *cgroup_add_controller(struct cgroup *cgroup,
 		return NULL;
 
 	strncpy(controller->name, name, sizeof(controller->name) - 1);
+	controller->name[sizeof(controller->name) - 1] = '\0';
+
 	controller->cgroup = cgroup;
 	controller->index = 0;
 


### PR DESCRIPTION
Fix non-terminated string warning, reported by Coverity tool:

CID 258271 (#1 of 1): String not null terminated (STRING_NULL).
string_null: Passing unterminated string cgc->name to strcmp, which
expects a null-terminated string.

This issue was reported following the path src/abstraction-common.c:
- cgroup_convert_cgroup()
  - cgroup_add_controller()

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>