### PR TITLE
api.c: search_and_append_mnt_path() use strncpy()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -6085,7 +6085,9 @@ static int search_and_append_mnt_path(struct cg_mount_point **mount_point,
 		return ECGOTHER;
 	}
 
-	strcpy(mnt_point->path, path);
+	strncpy(mnt_point->path, path, FILENAME_MAX - 1);
+	mnt_point->path[FILENAME_MAX - 1] = '\0';
+
 	mnt_point->next = NULL;
 
 	if (*mount_point == NULL)


### PR DESCRIPTION
Fix copy into fixed size buffer warning, reported by Coverity tool:

CID 258279 (#1 of 1): Copy into fixed size buffer (STRING_OVERFLOW).
fixed_size_dest: You might overrun the 4096-character fixed-size string
mnt_point->path by copying path without checking the length.
10. parameter_as_source: Note: This defect has an elevated risk
because the source argument is a parameter of the current function.

fix this issue by using strnpy(), in place of strcpy().

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>