### PR TITLE
config: cgroup_config_insert_into_mount_table() use strncpy() [v2.0.2]

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -569,8 +569,15 @@ int cgroup_config_insert_into_mount_table(char *name, char *mount_point)
 		}
 	}
 
-	strcpy(config_mount_table[config_table_index].name, name);
-	strcpy(config_mount_table[config_table_index].mount.path, mount_point);
+	strncpy(config_mount_table[config_table_index].name, name,
+		FILENAME_MAX  - 1);
+	config_mount_table[config_table_index].name[FILENAME_MAX - 1] = '\0';
+
+	strncpy(config_mount_table[config_table_index].mount.path, mount_point,
+	       FILENAME_MAX - 1);
+	config_mount_table[config_table_index].mount.path[FILENAME_MAX -1] =
+									'\0';
+
 	config_mount_table[config_table_index].mount.next = NULL;
 	config_table_index++;
 done:


### PR DESCRIPTION
Fix copy into fixed size buffer warning, reported by Coverity tool:

CID 258282 (#2 of 2): Copy into fixed size buffer (STRING_OVERFLOW)9.
fixed_size_dest: You might overrun the 4096-character fixed-size string
config_mount_table[config_table_index].mount.path by copying mount_point
without checking the length.
parameter_as_source: Note: This defect has an elevated risk because the
source argument is a parameter of the current function

Also, convert config_mount_table[config_table_index].name strcpy to
strncpy.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>