### PR TITLE
api.c: avoid ambiguous controller name matches

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1135,11 +1135,17 @@ STATIC int cgroup_process_v1_mnt(char *controllers[], struct mntent *ent,
 	char *strtok_buffer = NULL, *mntopt = NULL;
 	int shared_mnt, duplicate;
 	int i, j, ret = 0;
+	char c = 0;
 
 	for (i = 0; controllers[i] != NULL; i++) {
 		mntopt = hasmntopt(ent, controllers[i]);
 
 		if (!mntopt)
+			continue;
+
+		c = mntopt[strlen(controllers[i])];
+
+		if (c != '\0' && c != ',')
 			continue;
 
 		cgroup_dbg("found %s in %s\n", controllers[i], ent->mnt_opts);


### PR DESCRIPTION
calling "hasmntopt" to determine if the controller name exists in "mntopt", may cause errors because of "hasmntopt" only match substring.

cpu controller may incorrectly match to cpuset when cpuset mount info appeared before cpu,cpuacct in "/proc/mounts", so we need to validate the last character to make sure the controller name matches exactly.

Signed-off-by: Hackerl <490021209@qq.com>