### PR TITLE
wrapper.c: fix string non-termination warning [v2.0.2]

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -622,6 +622,8 @@ struct cgroup *create_cgroup_from_name_value_pairs(const char *name,
 		}
 
 		strncpy(con, name_value[i].name, FILENAME_MAX - 1);
+		con[FILENAME_MAX - 1] = '\0';
+
 		strtok(con, ".");
 
 		/* find out whether we have to add the controller or


### PR DESCRIPTION
Fix non-terminated string warning, reported by Coverity tool:

CID 258266 (#1 of 1): String not null-terminated (STRING_NULL).
string_null: Passing unterminated string con to strtok, which expects a
null-terminated string.

Fix the warning in create_cgroup_from_name_value_pairs(), by adding
'\0'.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>