### PR TITLE
Increase the sources column width to 100 [Part 3]

### DIFF
--- a/src/tools/cgclassify.c
+++ b/src/tools/cgclassify.c
@@ -29,8 +29,7 @@
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		err("Wrong input parameters, ");
-		err("try %s '-h' for more information.\n", program_name);
+		err("Wrong input parameters, try %s '-h' for more information.\n", program_name);
 		return;
 	}
 
@@ -39,8 +38,7 @@ static void usage(int status, const char *program_name)
 	info("Move running task(s) to given cgroups\n");
 	info("  -h, --help			Display this help\n");
 	info("  -g <controllers>:<path>	Control group to be used as target\n");
-	info("  --cancel-sticky		cgred daemon change pidlist ");
-	info("and children tasks\n");
+	info("  --cancel-sticky		cgred daemon change pidlist and children tasks\n");
 	info("  --sticky			cgred daemon does not change ");
 	info("pidlist and children tasks\n");
 }
@@ -60,8 +58,7 @@ static int change_group_path(pid_t pid, struct cgroup_group_spec *cgroup_list[])
 		ret = cgroup_change_cgroup_path(cgroup_list[i]->path, pid,
 						(const char *const*) cgroup_list[i]->controllers);
 		if (ret) {
-			err("Error changing group of pid %d: %s\n", pid,
-			    cgroup_strerror(ret));
+			err("Error changing group of pid %d: %s\n", pid, cgroup_strerror(ret));
 			return -1;
 		}
 	}
@@ -94,8 +91,7 @@ static int change_group_based_on_rule(pid_t pid)
 	/* Change the cgroup by determining the rules */
 	ret = cgroup_change_cgroup_flags(euid, egid, procname, pid, 0);
 	if (ret) {
-		err("Error: change of cgroup failed for pid %d: %s\n", pid,
-		    cgroup_strerror(ret));
+		err("Error: change of cgroup failed for pid %d: %s\n", pid, cgroup_strerror(ret));
 		goto out;
 	}
 	ret = 0;
@@ -137,11 +133,9 @@ int main(int argc, char *argv[])
 			exit(0);
 			break;
 		case 'g':
-			ret = parse_cgroup_spec(cgroup_list, optarg,
-						CG_HIER_MAX);
+			ret = parse_cgroup_spec(cgroup_list, optarg, CG_HIER_MAX);
 			if (ret) {
-				err("cgroup controller and path parsing ");
-				err("failed\n");
+				err("cgroup controller and path parsing failed\n");
 				return -1;
 			}
 			cg_specified = 1;
@@ -162,8 +156,7 @@ int main(int argc, char *argv[])
 	/* Initialize libcg */
 	ret = cgroup_init();
 	if (ret) {
-		err("%s: libcgroup initialization failed: %s\n", argv[0],
-		    cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		return ret;
 	}
 

--- a/src/tools/cgconfig.c
+++ b/src/tools/cgconfig.c
@@ -32,30 +32,23 @@ static struct cgroup_string_list cfg_files;
 static void usage(int status, char *progname)
 {
 	if (status != 0) {
-		err("Wrong input parameters, ");
-		err("try %s '-h' for more information.\n", progname);
+		err("Wrong input parameters, try %s '-h' for more information.\n", progname);
 		return;
 	}
 
 	info("Usage: %s [-h] [-f mode] [-d mode] [-s mode] ", progname);
-	info("[-t <tuid>:<tgid>] [-a <agid>:<auid>] [-l FILE] ");
-	info("[-L DIR] ...\n");
+	info("[-t <tuid>:<tgid>] [-a <agid>:<auid>] [-l FILE] [-L DIR] ...\n");
 	info("Parse and load the specified cgroups configuration file\n");
 	info("  -a <tuid>:<tgid>		Default owner of groups ");
 	info("files and directories\n");
-	info("  -d, --dperm=mode		Default group directory ");
-	info("permissions\n");
-	info("  -f, --fperm=mode		Default group file ");
-	info("permissions\n");
+	info("  -d, --dperm=mode		Default group directory permissions\n");
+	info("  -f, --fperm=mode		Default group file permissions\n");
 	info("  -h, --help			Display this help\n");
-	info("  -l, --load=FILE		Parse and load the cgroups ");
-	info("configuration file\n");
+	info("  -l, --load=FILE		Parse and load the cgroups configuration file\n");
 	info("  -L, --load-directory=DIR	Parse and load the cgroups ");
 	info("configuration files from a directory\n");
-	info("  -s, --tperm=mode		Default tasks file ");
-	info("permissions\n");
-	info("  -t <tuid>:<tgid>		Default owner of the tasks ");
-	info("file\n");
+	info("  -s, --tperm=mode		Default tasks file permissions\n");
+	info("  -t <tuid>:<tgid>		Default owner of the tasks file\n");
 }
 
 int main(int argc, char *argv[])
@@ -85,7 +78,6 @@ int main(int argc, char *argv[])
 	int c, i;
 
 	cgroup_set_default_logger(-1);
-
 	if (argc < 2) {
 		usage(1, argv[0]);
 		return -1;
@@ -93,8 +85,7 @@ int main(int argc, char *argv[])
 
 	ret = cgroup_init();
 	if (ret) {
-		err("%s: libcgroup initialization failed: %s\n", argv[0],
-		    cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		goto err;
 	}
 
@@ -102,8 +93,7 @@ int main(int argc, char *argv[])
 	if (error)
 		goto err;
 
-	while ((c = getopt_long(argc, argv, "hl:L:t:a:d:f:s:", options,
-				NULL)) > 0) {
+	while ((c = getopt_long(argc, argv, "hl:L:t:a:d:f:s:", options, NULL)) > 0) {
 		switch (c) {
 		case 'h':
 			usage(0, argv[0]);
@@ -112,14 +102,12 @@ int main(int argc, char *argv[])
 		case 'l':
 			error = cgroup_string_list_add_item(&cfg_files, optarg);
 			if (error) {
-				err("%s: cannot add file to list, ", argv[0]);
-				err("out of memory?\n");
+				err("%s: cannot add file to list, out of memory?\n", argv[0]);
 				goto err;
 			}
 			break;
 		case 'L':
-			cgroup_string_list_add_directory(&cfg_files, optarg,
-							 argv[0]);
+			cgroup_string_list_add_directory(&cfg_files, optarg, argv[0]);
 			break;
 		case 'a':
 			/* set admin uid/gid */
@@ -174,14 +162,12 @@ int main(int argc, char *argv[])
 
 	error = cgroup_set_uid_gid(default_group, tuid, tgid, auid, agid);
 	if (error) {
-		err("%s: cannot set default UID and GID: %s\n", argv[0],
-		    cgroup_strerror(error));
+		err("%s: cannot set default UID and GID: %s\n", argv[0], cgroup_strerror(error));
 		goto free_cgroup;
 	}
 
 	if (dirm_change | filem_change) {
-		cgroup_set_permissions(default_group, dir_mode, file_mode,
-				       tasks_mode);
+		cgroup_set_permissions(default_group, dir_mode, file_mode, tasks_mode);
 	}
 
 	error = cgroup_config_set_default(default_group);
@@ -194,8 +180,8 @@ int main(int argc, char *argv[])
 	for (i = 0; i < cfg_files.count; i++) {
 		ret = cgroup_config_load_config(cfg_files.items[i]);
 		if (ret) {
-			err("%s; error loading %s: %s\n", argv[0],
-			    cfg_files.items[i], cgroup_strerror(ret));
+			err("%s; error loading %s: %s\n", argv[0], cfg_files.items[i],
+			    cgroup_strerror(ret));
 			if (!error)
 				error = ret;
 		}

--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -27,17 +27,14 @@
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		err("Wrong input parameters, ");
-		err(" try %s -h' for more information.\n", program_name);
+		err("Wrong input parameters, try %s -h for more information.\n", program_name);
 		return;
 	}
 
 	info("Usage: %s [-h] [-f mode] [-d mode] [-s mode] ", program_name);
-	info("[-t <tuid>:<tgid>] [-a <agid>:<auid>] ");
-	info("-g <controllers>:<path> [-g ...]\n");
+	info("[-t <tuid>:<tgid>] [-a <agid>:<auid>] -g <controllers>:<path> [-g ...]\n");
 	info("Create control group(s)\n");
-	info("  -a <tuid>:<tgid>		Owner of the group and all ");
-	info("its files\n");
+	info("  -a <tuid>:<tgid>		Owner of the group and all its files\n");
 	info("  -d, --dperm=mode		Group directory permissions\n");
 	info("  -f, --fperm=mode		Group file permissions\n");
 	info("  -g <controllers>:<path>	Control group which should be added\n");
@@ -94,8 +91,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* parse arguments */
-	while ((c = getopt_long(argc, argv, "a:t:g:hd:f:s:", long_opts,
-				NULL)) > 0) {
+	while ((c = getopt_long(argc, argv, "a:t:g:hd:f:s:", long_opts, NULL)) > 0) {
 		switch (c) {
 		case 'h':
 			usage(0, argv[0]);
@@ -114,8 +110,8 @@ int main(int argc, char *argv[])
 		case 'g':
 			ret = parse_cgroup_spec(cgroup_list, optarg, capacity);
 			if (ret) {
-				err("%s: cgroup controller and path", argv[0]);
-				err("parsing failed (%s)\n", argv[optind]);
+				err("%s: cgroup controller and path parsing failed (%s)\n",
+				    argv[0], argv[optind]);
 				ret = -1;
 				goto err;
 			}
@@ -155,8 +151,7 @@ int main(int argc, char *argv[])
 	/* initialize libcg */
 	ret = cgroup_init();
 	if (ret) {
-		err("%s: libcgroup initialization failed: %s\n", argv[0],
-		    cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		goto err;
 	}
 
@@ -169,8 +164,7 @@ int main(int argc, char *argv[])
 		cgroup = cgroup_new_cgroup(cgroup_list[i]->path);
 		if (!cgroup) {
 			ret = ECGFAIL;
-			err("%s: can't add new cgroup: %s\n", argv[0],
-			    cgroup_strerror(ret));
+			err("%s: can't add new cgroup: %s\n", argv[0], cgroup_strerror(ret));
 			goto err;
 		}
 
@@ -187,8 +181,7 @@ int main(int argc, char *argv[])
 				ret = cgroup_add_all_controllers(cgroup);
 				if (ret != 0) {
 					ret = ECGINVAL;
-					err("%s: can't add all controllers\n",
-					    argv[0]);
+					err("%s: can't add all controllers\n", argv[0]);
 					cgroup_free(&cgroup);
 					goto err;
 				}
@@ -197,8 +190,7 @@ int main(int argc, char *argv[])
 					cgroup_list[i]->controllers[j]);
 				if (!cgc) {
 					ret = ECGINVAL;
-					err("%s: controller %s can't be add\n",
-					    argv[0],
+					err("%s: controller %s can't be add\n", argv[0],
 					    cgroup_list[i]->controllers[j]);
 					cgroup_free(&cgroup);
 					goto err;
@@ -209,13 +201,12 @@ int main(int argc, char *argv[])
 
 		/* all variables set so create cgroup */
 		if (dirm_change | filem_change)
-			cgroup_set_permissions(cgroup, dir_mode, file_mode,
-					       tasks_mode);
+			cgroup_set_permissions(cgroup, dir_mode, file_mode, tasks_mode);
 
 		ret = cgroup_create_cgroup(cgroup, 0);
 		if (ret) {
-			err("%s: can't create cgroup %s: %s\n",
-			    argv[0], cgroup->name, cgroup_strerror(ret));
+			err("%s: can't create cgroup %s: %s\n", argv[0], cgroup->name,
+			    cgroup_strerror(ret));
 			cgroup_free(&cgroup);
 			goto err;
 		}

--- a/src/tools/cgdelete.c
+++ b/src/tools/cgdelete.c
@@ -39,11 +39,9 @@ static void usage(int status, const char *program_name)
 		return;
 	}
 
-	info("Usage: %s [-h] [-r] [[-g] <controllers>:<path>] ...\n",
-	     program_name);
+	info("Usage: %s [-h] [-r] [[-g] <controllers>:<path>] ...\n", program_name);
 	info("Remove control group(s)\n");
-	info("  -g <controllers>:<path>	Control group to be removed ");
-	info("(-g is optional)\n");
+	info("  -g <controllers>:<path>	Control group to be removed (-g is optional)\n");
 	info("  -h, --help			Display this help\n");
 	info("  -r, --recursive		Recursively remove all subgroups\n");
 }
@@ -53,8 +51,7 @@ static void usage(int status, const char *program_name)
  * cgroup with specifying multi controllers. Just skip controller which
  * cgroup and hierarchy number is same
  */
-static int skip_add_controller(int counter, int *skip,
-			       struct ext_cgroup_record *ecg_list)
+static int skip_add_controller(int counter, int *skip, struct ext_cgroup_record *ecg_list)
 {
 	struct controller_data info;
 	void *handle;
@@ -79,8 +76,7 @@ static int skip_add_controller(int counter, int *skip,
 	if (ret == ECGEOF)
 		ret = 0;
 	if (ret) {
-		err("cgroup_get_controller_begin/next failed(%s)\n",
-		    cgroup_strerror(ret));
+		err("cgroup_get_controller_begin/next failed(%s)\n", cgroup_strerror(ret));
 		return ret;
 	}
 
@@ -90,18 +86,17 @@ static int skip_add_controller(int counter, int *skip,
 		if ((!strcmp(ecg_list[k].name, ecg_list[counter].name)) &&
 		    (ecg_list[k].h_number == ecg_list[counter].h_number)) {
 			/* we found a control group in the same hierarchy */
-			if (strcmp(ecg_list[k].controller,
-				   ecg_list[counter].controller)) {
+			if (strcmp(ecg_list[k].controller, ecg_list[counter].controller)) {
 				/*
-				 * it is a different controller ->
-				 * if there is not one cgroup for the same
-				 * controller, skip it
+				 * it is a different controller -> if there
+				 * is not one cgroup for the same controller,
+				 * skip it
 				 */
 				*skip = 1;
 			} else {
 				/*
-				 * there is the identical group,controller pair
-				 * don't skip it
+				 * there is the identical group,controller
+				 * pair don't skip it
 				 */
 				*skip = 0;
 				return ret;
@@ -131,8 +126,7 @@ int main(int argc, char *argv[])
 	/* initialize libcg */
 	ret = cgroup_init();
 	if (ret) {
-		err("%s: libcgroup initialization failed: %s\n", argv[0],
-		    cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		goto err;
 	}
 
@@ -160,8 +154,7 @@ int main(int argc, char *argv[])
 		case 'g':
 			ret = parse_cgroup_spec(cgroup_list, optarg, argc);
 			if (ret != 0) {
-				err("%s: error parsing cgroup '%s'", argv[0],
-				    optarg);
+				err("%s: error parsing cgroup '%s'", argv[0], optarg);
 				ret = -1;
 				goto err;
 			}
@@ -181,8 +174,7 @@ int main(int argc, char *argv[])
 	for (i = optind; i < argc; i++) {
 		ret = parse_cgroup_spec(cgroup_list, argv[i], argc);
 		if (ret != 0) {
-			err("%s: error parsing cgroup '%s'\n", argv[0],
-			    argv[i]);
+			err("%s: error parsing cgroup '%s'\n", argv[0], argv[i]);
 			ret = -1;
 			goto err;
 		}
@@ -197,8 +189,7 @@ int main(int argc, char *argv[])
 		cgroup = cgroup_new_cgroup(cgroup_list[i]->path);
 		if (!cgroup) {
 			ret = ECGFAIL;
-			err("%s: can't create new cgroup: %s\n", argv[0],
-			    cgroup_strerror(ret));
+			err("%s: can't create new cgroup: %s\n", argv[0], cgroup_strerror(ret));
 			goto err;
 		}
 
@@ -207,18 +198,18 @@ int main(int argc, char *argv[])
 		while (cgroup_list[i]->controllers[j]) {
 			skip = 0;
 			/*
-			 * save controller name, cg name and hierarchy number
-			 * to determine whether we should skip adding controller
+			 * save controller name, cg name and hierarchy
+			 * number to determine whether we should skip
+			 * adding controller
 			 */
 			if (counter == max) {
 				/*
-				 * there is not enough space to store them,
-				 * create it
+				 * there is not enough space to store
+				 * them, create it
 				 */
 				max = max + argc;
 				ecg_list = (struct ext_cgroup_record *)
-					realloc(ecg_list,
-						max * sizeof(struct ext_cgroup_record));
+					realloc(ecg_list, max * sizeof(struct ext_cgroup_record));
 				if (!ecg_list) {
 					err("%s: not enough memory\n", argv[0]);
 					final_ret = -1;
@@ -228,12 +219,10 @@ int main(int argc, char *argv[])
 
 			strncpy(ecg_list[counter].controller,
 				cgroup_list[i]->controllers[j], FILENAME_MAX);
-
 			ecg_list[counter].controller[FILENAME_MAX - 1] = '\0';
 
 			strncpy(ecg_list[counter].name,
 				cgroup_list[i]->path, FILENAME_MAX);
-
 			ecg_list[counter].name[FILENAME_MAX - 1] = '\0';
 
 			ret = skip_add_controller(counter, &skip, ecg_list);
@@ -245,8 +234,7 @@ int main(int argc, char *argv[])
 				goto next;
 			}
 
-			cgc = cgroup_add_controller(cgroup,
-						cgroup_list[i]->controllers[j]);
+			cgc = cgroup_add_controller(cgroup, cgroup_list[i]->controllers[j]);
 			if (!cgc) {
 				ret = ECGFAIL;
 				err("%s: controller %s can't be added\n", argv[0],
@@ -262,8 +250,8 @@ next:
 		ret = cgroup_delete_cgroup_ext(cgroup, flags);
 		/* Remember the errors and continue, try to remove all groups. */
 		if (ret != 0) {
-			err("%s: cannot remove group '%s': %s\n", argv[0],
-			    cgroup->name, cgroup_strerror(ret));
+			err("%s: cannot remove group '%s': %s\n", argv[0], cgroup->name,
+			    cgroup_strerror(ret));
 			final_ret = ret;
 		}
 		cgroup_free(&cgroup);

--- a/src/tools/cgexec.c
+++ b/src/tools/cgexec.c
@@ -38,22 +38,18 @@ static struct option longopts[] = {
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		err("Wrong input parameters,");
-		err(" try %s --help' for more information.\n", program_name);
+		err("Wrong input parameters, try %s --help for more information.\n", program_name);
 		return;
 	}
 
-	info("Usage: %s [-h] [-g <controllers>:<path>] [--sticky] ",
-	     program_name);
+	info("Usage: %s [-h] [-g <controllers>:<path>] [--sticky] ", program_name);
 	info("command [arguments] ...\n");
 	info("Run the task in given control group(s)\n");
-	info("  -g <controllers>:<path>	Control group which ");
-	info("should be added\n");
+	info("  -g <controllers>:<path>	Control group which should be added\n");
 	info("  -h, --help			Display this help\n");
 	info("  --sticky			cgred daemon does not ");
 	info("change pidlist and children tasks\n");
 }
-
 
 int main(int argc, char *argv[])
 {
@@ -71,11 +67,9 @@ int main(int argc, char *argv[])
 	while ((c = getopt_long(argc, argv, "+g:sh", longopts, NULL)) > 0) {
 		switch (c) {
 		case 'g':
-			ret = parse_cgroup_spec(cgroup_list, optarg,
-						CG_HIER_MAX);
+			ret = parse_cgroup_spec(cgroup_list, optarg, CG_HIER_MAX);
 			if (ret) {
-				err("cgroup controller and path parsing ");
-				err("failed\n");
+				err("cgroup controller and path parsing failed\n");
 				return -1;
 			}
 			cg_specified = 1;
@@ -101,8 +95,7 @@ int main(int argc, char *argv[])
 	/* Initialize libcg */
 	ret = cgroup_init();
 	if (ret) {
-		err("libcgroup initialization failed: %s\n",
-		    cgroup_strerror(ret));
+		err("libcgroup initialization failed: %s\n", cgroup_strerror(ret));
 		return ret;
 	}
 
@@ -122,10 +115,10 @@ int main(int argc, char *argv[])
 	}
 
 	/*
-	 * 'cgexec' command file needs the root privilege for executing
-	 * a cgroup_register_unchanged_process() by using unix domain
-	 * socket, and an euid/egid should be changed to the executing user
-	 * from a root user.
+	 * 'cgexec' command file needs the root privilege for executing a
+	 * cgroup_register_unchanged_process() by using unix domain socket,
+	 * and an euid/egid should be changed to the executing user from a
+	 * root user.
 	 */
 	if (setresuid(uid, uid, uid)) {
 		err("%s", strerror(errno));
@@ -139,15 +132,14 @@ int main(int argc, char *argv[])
 
 	if (cg_specified) {
 		/*
-		 * User has specified the list of control group and
-		 * controllers
+		 * User has specified the list of control group
+		 * and controllers
 		 */
 		for (i = 0; i < CG_HIER_MAX; i++) {
 			if (!cgroup_list[i])
 				break;
 
-			ret = cgroup_change_cgroup_path(cgroup_list[i]->path,
-				pid,
+			ret = cgroup_change_cgroup_path(cgroup_list[i]->path, pid,
 				(const char *const*) cgroup_list[i]->controllers);
 			if (ret) {
 				err("cgroup change of group failed\n");
@@ -157,8 +149,7 @@ int main(int argc, char *argv[])
 	} else {
 
 		/* Change the cgroup by determining the rules based on uid */
-		ret = cgroup_change_cgroup_flags(uid, gid,
-						 argv[optind], pid, 0);
+		ret = cgroup_change_cgroup_flags(uid, gid, argv[optind], pid, 0);
 		if (ret) {
 			err("cgroup change of group failed\n");
 			return ret;

--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -12,10 +12,10 @@
 #include <unistd.h>
 #include <stdio.h>
 
-#define MODE_SHOW_HEADERS		1
-#define MODE_SHOW_NAMES			2
+#define MODE_SHOW_HEADERS	1
+#define MODE_SHOW_NAMES		2
 
-#define LL_MAX				100
+#define LL_MAX			100
 
 static const struct option long_options[] = {
 	{"variable",	required_argument, NULL, 'r'},
@@ -28,21 +28,14 @@ static const struct option long_options[] = {
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		err("Wrong input parameters,");
-		err(" try %s -h' for more information.\n", program_name);
+		err("Wrong input parameters, try %s -h' for more information.\n", program_name);
 		return;
 	}
-	info("Usage: %s [-nv] [-r <name>] [-g <controllers>] ", program_name);
-	info("[-a] <path> ...\n");
-	info("   or: %s [-nv] [-r <name>] -g <controllers>:<path> ...\n",
-	     program_name);
+	info("Usage: %s [-nv] [-r <name>] [-g <controllers>] [-a] <path> ...\n", program_name);
 	info("Print parameter(s) of given group(s).\n");
-	info("  -a, --all			Print info about all relevant ");
-	info("controllers\n");
-	info("  -g <controllers>		Controller which info should ");
-	info("be displayed\n");
-	info("  -g <controllers>:<path>	Control group which info ");
-	info("should be displayed\n");
+	info("  -a, --all			Print info about all relevant controllers\n");
+	info("  -g <controllers>		Controller which info should be displayed\n");
+	info("  -g <controllers>:<path>	Control group which info should be displayed\n");
 	info("  -h, --help			Display this help\n");
 	info("  -n				Do not print headers\n");
 	info("  -r, --variable <name>		Define parameter to display\n");
@@ -50,8 +43,7 @@ static void usage(int status, const char *program_name)
 	info("parameter names\n");
 }
 
-static int get_controller_from_name(const char * const name,
-				    char **controller)
+static int get_controller_from_name(const char * const name, char **controller)
 {
 	char *dot;
 
@@ -61,19 +53,17 @@ static int get_controller_from_name(const char * const name,
 
 	dot = strchr(*controller, '.');
 	if (dot == NULL) {
-		err("cgget: error parsing parameter name\n");
-		err(	" '%s'", name);
+		err("cgget: error parsing parameter name '%s'", name);
 		return ECGINVAL;
 	}
-
 	*dot = '\0';
+
 	return 0;
 }
 
 static int create_cg(struct cgroup **cg_list[], int * const cg_list_len)
 {
-	*cg_list = realloc(*cg_list,
-			   ((*cg_list_len) + 1) * sizeof(struct cgroup *));
+	*cg_list = realloc(*cg_list, ((*cg_list_len) + 1) * sizeof(struct cgroup *));
 	if ((*cg_list) == NULL)
 		return ECGCONTROLLERCREATEFAILED;
 
@@ -84,6 +74,7 @@ static int create_cg(struct cgroup **cg_list[], int * const cg_list_len)
 		return ECGCONTROLLERCREATEFAILED;
 
 	(*cg_list_len)++;
+
 	return 0;
 }
 
@@ -102,9 +93,9 @@ static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
 	}
 
 	/*
-	 * if "-r" was provided, then we know that the cgroup(s) will be an
-	 * optarg at the end with no flag.  Let's temporarily populate the
-	 * first cgroup with the requested control values.
+	 * if "-r" was provided, then we know that the cgroup(s) will be
+	 * an optarg at the end with no flag.  Let's temporarily populate
+	 * the first cgroup with the requested control values.
 	 */
 	cg = (*cg_list)[0];
 
@@ -114,13 +105,11 @@ static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
 		if (!cgc) {
 			cgc = cgroup_add_controller(cg, controller.name);
 			if (!cgc) {
-				err("cgget: cannot find controller '%s'\n",
-				    controller.name);
+				err("cgget: cannot find controller '%s'\n", controller.name);
 				ret = ECGOTHER;
 				goto out;
 			}
 		}
-
 		ret = cgroup_get_controller_next(&handle, &controller);
 	}
 	if (ret == ECGEOF)
@@ -133,8 +122,10 @@ static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
 	cgroup_get_controller_end(&handle);
 
 	return ret;
+
 out:
 	cgroup_get_controller_end(&handle);
+
 	return ret;
 }
 
@@ -153,9 +144,9 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 	}
 
 	/*
-	 * if "-r" was provided, then we know that the cgroup(s) will be an
-	 * optarg at the end with no flag.  Let's temporarily populate the
-	 * first cgroup with the requested control values.
+	 * if "-r" was provided, then we know that the cgroup(s) will be
+	 * an optarg at the end with no flag.  Let's temporarily populate
+	 * the first cgroup with the requested control values.
 	 */
 	cg = (*cg_list)[0];
 
@@ -167,8 +158,7 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 	if (!cgc) {
 		cgc = cgroup_add_controller(cg, cntl_value_controller);
 		if (!cgc) {
-			err("cgget: cannot find controller '%s'\n",
-			    cntl_value_controller);
+			err("cgget: cannot find controller '%s'\n", cntl_value_controller);
 			ret = ECGOTHER;
 			goto out;
 		}
@@ -179,11 +169,11 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 out:
 	if (cntl_value_controller)
 		free(cntl_value_controller);
+
 	return ret;
 }
 
-static int parse_g_flag_no_colon(struct cgroup **cg_list[],
-				 int * const cg_list_len,
+static int parse_g_flag_no_colon(struct cgroup **cg_list[], int * const cg_list_len,
 				 const char * const ctrl_str)
 {
 	struct cgroup_controller *cgc;
@@ -238,8 +228,7 @@ static int split_cgroup_name(const char * const ctrl_str, char *cg_name)
 	return 0;
 }
 
-static int split_controllers(const char * const in,
-			     char **ctrl[], int * const ctrl_len)
+static int split_controllers(const char * const in, char **ctrl[], int * const ctrl_len)
 {
 	char *copy, *tok, *colon, *saveptr = NULL;
 	int ret = 0;
@@ -274,11 +263,11 @@ static int split_controllers(const char * const in,
 out:
 	if (saveptr)
 		free(saveptr);
+
 	return ret;
 }
 
-static int parse_g_flag_with_colon(struct cgroup **cg_list[],
-				   int * const cg_list_len,
+static int parse_g_flag_with_colon(struct cgroup **cg_list[], int * const cg_list_len,
 				   const char * const ctrl_str)
 {
 	struct cgroup_controller *cgc;
@@ -306,8 +295,7 @@ static int parse_g_flag_with_colon(struct cgroup **cg_list[],
 		if (!cgc) {
 			cgc = cgroup_add_controller(cg, controllers[i]);
 			if (!cgc) {
-				err("cgget: cannot find controller '%s'\n",
-				    controllers[i]);
+				err("cgget: cannot find controller '%s'\n", controllers[i]);
 				ret = ECGOTHER;
 				goto out;
 			}
@@ -317,6 +305,7 @@ static int parse_g_flag_with_colon(struct cgroup **cg_list[],
 out:
 	for (i = 0; i < controllers_len; i++)
 		free(controllers[i]);
+
 	return ret;
 }
 
@@ -327,8 +316,8 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 	int ret = 0;
 
 	/*
-	 * The first cgroup was temporarily populated and requires
-	 * the user to provide a cgroup name as an opt
+	 * The first cgroup was temporarily populated and requires the
+	 * user to provide a cgroup name as an opt
 	 */
 	if (argv[optind] == NULL && first_cg_is_dummy) {
 		usage(1, argv[0]);
@@ -337,8 +326,8 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 
 	/*
 	 * The user has provided a cgroup and controller via the
-	 * -g <controller>:<cgroup> flag and has also provided a cgroup via
-	 * the optind.  This was not supported by the previous cgget
+	 * -g <controller>:<cgroup> flag and has also provided a cgroup
+	 *  via the optind.  This was not supported by the previous cgget
 	 * implementation.  Continue that approach.
 	 *
 	 * Example of a command that will hit this code:
@@ -367,15 +356,13 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 			if (ret)
 				goto out;
 
-			strncpy((*cg_list)[(*cg_list_len) - 1]->name,
-				argv[optind],
+			strncpy((*cg_list)[(*cg_list_len) - 1]->name, argv[optind],
 				sizeof((*cg_list)[(*cg_list_len) - 1]->name) - 1);
 		} else if (cg != NULL && strlen(cg->name) == 0) {
 			/*
 			 * this cgroup was created based upon control/value
 			 * pairs or with a -g <controller> option.  we'll
-			 * populate it with the parameter provided by the
-			 * user
+			 * populate it with the parameter provided by the user
 			 */
 			strncpy(cg->name, argv[optind], sizeof(cg->name) - 1);
 		} else {
@@ -388,11 +375,9 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 			if (ret)
 				goto out;
 
-			strncpy((*cg_list)[(*cg_list_len) - 1]->name,
-				argv[optind],
+			strncpy((*cg_list)[(*cg_list_len) - 1]->name, argv[optind],
 				sizeof((*cg_list)[(*cg_list_len) - 1]->name) - 1);
 		}
-
 		optind++;
 	}
 
@@ -400,8 +385,8 @@ out:
 	return ret;
 }
 
-static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[],
-		      int * const cg_list_len, int * const mode)
+static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * const cg_list_len,
+		      int * const mode)
 {
 	bool do_not_fill_controller = false;
 	bool first_cgroup_is_dummy = false;
@@ -410,8 +395,7 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[],
 	int c;
 
 	/* Parse arguments. */
-	while ((c = getopt_long(argc, argv, "r:hnvg:a", long_options,
-				NULL)) > 0) {
+	while ((c = getopt_long(argc, argv, "r:hnvg:a", long_options, NULL)) > 0) {
 		switch (c) {
 		case 'h':
 			usage(0, argv[0]);
@@ -435,13 +419,11 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[],
 			fill_controller = true;
 			if (strchr(optarg, ':') == NULL) {
 				first_cgroup_is_dummy = true;
-				ret = parse_g_flag_no_colon(cg_list,
-					cg_list_len, optarg);
+				ret = parse_g_flag_no_colon(cg_list, cg_list_len, optarg);
 				if (ret)
 					goto err;
 			} else {
-				ret = parse_g_flag_with_colon(cg_list,
-					cg_list_len, optarg);
+				ret = parse_g_flag_with_colon(cg_list, cg_list_len, optarg);
 				if (ret)
 					goto err;
 			}
@@ -464,8 +446,7 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[],
 		exit(1);
 	}
 
-	ret = parse_opt_args(argc, argv, cg_list, cg_list_len,
-			     first_cgroup_is_dummy);
+	ret = parse_opt_args(argc, argv, cg_list, cg_list_len, first_cgroup_is_dummy);
 	if (ret)
 		goto err;
 
@@ -473,8 +454,7 @@ err:
 	return ret;
 }
 
-static int get_cv_value(struct control_value * const cv,
-			const char * const cg_name,
+static int get_cv_value(struct control_value * const cv, const char * const cg_name,
 			const char * const controller_name)
 {
 	bool is_multiline = false;
@@ -482,8 +462,8 @@ static int get_cv_value(struct control_value * const cv,
 	void *handle, *tmp;
 	int ret;
 
-	ret = cgroup_read_value_begin(controller_name, cg_name, cv->name,
-				      &handle, tmp_line, LL_MAX);
+	ret = cgroup_read_value_begin(controller_name, cg_name, cv->name, &handle, tmp_line,
+				      LL_MAX);
 	if (ret == ECGEOF)
 		goto read_end;
 	if (ret != 0) {
@@ -497,12 +477,10 @@ static int get_cv_value(struct control_value * const cv,
 			 */
 			tmp_ret = cgroup_test_subsys_mounted(controller_name);
 			if (tmp_ret == 0) {
-				err("cgget: cannot find controller '%s' ",
-				    controller_name);
-				err("in group '%s'\n", cg_name);
+				err("cgget: cannot find controller '%s' in group '%s'\n",
+				    controller_name, cg_name);
 			} else {
-				err("variable file read failed %s\n",
-				    cgroup_strerror(ret));
+				err("variable file read failed %s\n", cgroup_strerror(ret));
 			}
 		}
 
@@ -540,7 +518,6 @@ read_end:
 	cgroup_read_value_end(&handle);
 	if (ret == ECGEOF)
 		ret = 0;
-
 end:
 	if (is_multiline == false && cv->multiline_value) {
 		free(cv->multiline_value);
@@ -573,8 +550,7 @@ static int indent_multiline_value(struct control_value * const cv)
 	return 0;
 }
 
-static int fill_empty_controller(struct cgroup * const cg,
-				 struct cgroup_controller * const cgc)
+static int fill_empty_controller(struct cgroup * const cg, struct cgroup_controller * const cgc)
 {
 	struct dirent *ctrl_dir = NULL;
 	bool found_mount = false;
@@ -584,11 +560,9 @@ static int fill_empty_controller(struct cgroup * const cg,
 
 	pthread_rwlock_rdlock(&cg_mount_table_lock);
 
-	for (i = 0; i < CG_CONTROLLER_MAX && cg_mount_table[i].name[0] != '\0';
-	     i++) {
+	for (i = 0; i < CG_CONTROLLER_MAX && cg_mount_table[i].name[0] != '\0'; i++) {
 		if (strlen(cgc->name) == strlen(cg_mount_table[i].name) &&
-		    strncmp(cgc->name, cg_mount_table[i].name,
-			    strlen(cgc->name)) == 0) {
+		    strncmp(cgc->name, cg_mount_table[i].name, strlen(cgc->name)) == 0) {
 			found_mount = true;
 			break;
 		}
@@ -597,10 +571,8 @@ static int fill_empty_controller(struct cgroup * const cg,
 	if (found_mount == false)
 		goto out;
 
-	if (!cg_build_path_locked(NULL, path,
-				  cg_mount_table[i].name)) {
+	if (!cg_build_path_locked(NULL, path, cg_mount_table[i].name))
 		goto out;
-	}
 
 	path_len = strlen(path);
 	strncat(path, cg->name, FILENAME_MAX - path_len - 1);
@@ -609,8 +581,7 @@ static int fill_empty_controller(struct cgroup * const cg,
 	if (access(path, F_OK))
 		goto out;
 
-	if (!cg_build_path_locked(cg->name, path,
-		cg_mount_table[i].name))
+	if (!cg_build_path_locked(cg->name, path, cg_mount_table[i].name))
 		goto out;
 
 	dir = opendir(path);
@@ -632,8 +603,8 @@ static int fill_empty_controller(struct cgroup * const cg,
 			cgc->values[cgc->index - 1]->dirty = false;
 
 			/*
-			 * previous versions of cgget indented the second and
-			 * all subsequent lines.  continue that behavior
+			 * previous versions of cgget indented the second
+			 * and all subsequent lines. Continue that behavior
 			 */
 			if (strchr(cgc->values[cgc->index - 1]->value, '\n')) {
 				ret = indent_multiline_value(
@@ -649,11 +620,11 @@ out:
 		closedir(dir);
 
 	pthread_rwlock_unlock(&cg_mount_table_lock);
+
 	return ret;
 }
 
-static int get_controller_values(struct cgroup * const cg,
-				 struct cgroup_controller * const cgc)
+static int get_controller_values(struct cgroup * const cg, struct cgroup_controller * const cgc)
 {
 	int ret = 0;
 	int i;
@@ -759,8 +730,7 @@ int main(int argc, char *argv[])
 
 	ret = cgroup_init();
 	if (ret) {
-		err("%s: libcgroup initialization failed: %s\n", argv[0],
-		    cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		goto err;
 	}
 

--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -42,8 +42,7 @@ static struct cgroup *copy_name_value_from_cgroup(char src_cg_path[FILENAME_MAX]
 	/* copy the name-version values to the cgroup structure */
 	ret = cgroup_get_cgroup(src_cgroup);
 	if (ret != 0) {
-		err("cgroup %s error: %s\n", src_cg_path,
-		    cgroup_strerror(ret));
+		err("cgroup %s error: %s\n", src_cg_path, cgroup_strerror(ret));
 		goto scgroup_err;
 	}
 
@@ -64,18 +63,15 @@ static void usage(int status, const char *program_name)
 	}
 
 	info("Usage: %s [-r <name=value>] <cgroup_path> ...\n", program_name);
-	info("   or: %s --copy-from <source_cgroup_path> ", program_name);
-	info("<cgroup_path> ...\n");
+	info("   or: %s --copy-from <source_cgroup_path> <cgroup_path> ...\n", program_name);
 	info("Set the parameters of given cgroup(s)\n");
-	info("  -r, --variable <name>			Define parameter ");
-	info("to set\n");
+	info("  -r, --variable <name>			Define parameter to set\n");
 	info("  --copy-from <source_cgroup_path>	Control group whose ");
 	info("parameters will be copied\n");
 }
 #endif /* !UNIT_TEST */
 
-STATIC int parse_r_flag(const char * const program_name,
-			const char * const name_value_str,
+STATIC int parse_r_flag(const char * const program_name, const char * const name_value_str,
 			struct control_value * const name_value)
 {
 	char *copy, *buf;
@@ -91,8 +87,7 @@ STATIC int parse_r_flag(const char * const program_name,
 	/* parse optarg value */
 	buf = strtok(copy, "=");
 	if (buf == NULL) {
-		err("%s: wrong parameter of option -r: %s\n", program_name,
-		    optarg);
+		err("%s: wrong parameter of option -r: %s\n", program_name, optarg);
 		ret = -1;
 		goto err;
 	}
@@ -108,8 +103,7 @@ STATIC int parse_r_flag(const char * const program_name,
 	buf++;
 
 	if (strlen(buf) == 0) {
-		err("%s: wrong parameter of option -r: %s\n", program_name,
-		    optarg);
+		err("%s: wrong parameter of option -r: %s\n", program_name, optarg);
 		ret = -1;
 		goto err;
 	}
@@ -140,14 +134,12 @@ int main(int argc, char *argv[])
 
 	/* no parameter on input */
 	if (argc < 2) {
-		err("Usage is %s -r <name=value> ", argv[0]);
-		err("<relative path to cgroup>\n");
+		err("Usage is %s -r <name=value> relative path to cgroup>\n", argv[0]);
 		return -1;
 	}
 
 	/* parse arguments */
-	while ((c = getopt_long (argc, argv,
-		"r:h", long_options, NULL)) != -1) {
+	while ((c = getopt_long (argc, argv, "r:h", long_options, NULL)) != -1) {
 		switch (c) {
 		case 'h':
 			usage(0, argv[0]);
@@ -162,15 +154,11 @@ int main(int argc, char *argv[])
 			}
 			flags |= FL_RULES;
 
-			/*
-			 * add name-value pair to buffer
-			 * (= name_value variable)
-			 */
+			/* add name-value pair to buffer (= name_value variable) */
 			if (nv_number >= nv_max) {
 				nv_max += CG_NV_MAX;
 				name_value = (struct control_value *)
-					realloc(name_value,
-					nv_max * sizeof(struct control_value));
+					realloc(name_value, nv_max * sizeof(struct control_value));
 				if (!name_value) {
 					err("%s: not enough memory\n", argv[0]);
 					ret = -1;
@@ -178,8 +166,7 @@ int main(int argc, char *argv[])
 				}
 			}
 
-			ret = parse_r_flag(argv[0], optarg,
-					   &name_value[nv_number]);
+			ret = parse_r_flag(argv[0], optarg, &name_value[nv_number]);
 			if (ret)
 				goto err;
 
@@ -218,15 +205,13 @@ int main(int argc, char *argv[])
 	/* initialize libcgroup */
 	ret = cgroup_init();
 	if (ret) {
-		err("%s: libcgroup initialization failed: %s\n", argv[0],
-		    cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		goto err;
 	}
 
 	/* copy the name-value pairs from -r options */
 	if ((flags & FL_RULES) != 0) {
-		src_cgroup = create_cgroup_from_name_value_pairs(
-			"tmp", name_value, nv_number);
+		src_cgroup = create_cgroup_from_name_value_pairs("tmp", name_value, nv_number);
 		if (src_cgroup == NULL)
 			goto err;
 	}
@@ -243,8 +228,7 @@ int main(int argc, char *argv[])
 		cgroup = cgroup_new_cgroup(argv[optind]);
 		if (!cgroup) {
 			ret = ECGFAIL;
-			err("%s: can't add new cgroup: %s\n", argv[0],
-			    cgroup_strerror(ret));
+			err("%s: can't add new cgroup: %s\n", argv[0], cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 
@@ -259,8 +243,7 @@ int main(int argc, char *argv[])
 		/* modify cgroup based on values of the new one */
 		ret = cgroup_modify_cgroup(cgroup);
 		if (ret) {
-			err("%s: cgroup modify error: %s\n", argv[0],
-			    cgroup_strerror(ret));
+			err("%s: cgroup modify error: %s\n", argv[0], cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 

--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -24,8 +24,7 @@
 enum flag {
 	FL_LIST =	1,
 	FL_SILENT =	2,  /* do-not show any warning/error output */
-	FL_STRICT =	4,  /* don show the variables which are not on */
-			    /* whitelist */
+	FL_STRICT =	4,  /* don show the variables which are not on whitelist */
 	FL_OUTPUT =	8,  /* output should be redirect to the given file */
 	FL_BLACK =	16, /* blacklist set */
 	FL_WHITE =	32, /* whitelist set */
@@ -53,19 +52,16 @@ FILE *output_f;
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		err("Wrong input parameters, ");
-		err("try %s -h' for more information.\n", program_name);
+		err("Wrong input parameters, try %s -h' for more information.\n", program_name);
 		return;
 	}
 
-	info("Usage: %s [-h] [-s] [-b FILE] [-w FILE] [-f FILE] ",
+	info("Usage: %s [-h] [-s] [-b FILE] [-w FILE] [-f FILE] [controller] [...]\n",
 	     program_name);
-	info("[controller] [...]\n");
 	info("Generate the configuration file for given controllers\n");
 	info("  -b, --blacklist=FILE		Set the blacklist");
 	info(" configuration file (default %s)\n", BLACKLIST_CONF);
-	info("  -f, --file=FILE		Redirect the output ");
-	info("to output_file\n");
+	info("  -f, --file=FILE		Redirect the output to output_file\n");
 	info("  -h, --help			Display this help\n");
 	info("  -s, --silent			Ignore all warnings\n");
 	info("  -t, --strict			Don't show variables ");
@@ -89,8 +85,7 @@ int load_list(char *filename, struct black_list_type **p_list)
 
 	fw = fopen(filename, "r");
 	if (fw == NULL) {
-		err("ERROR: Failed to open file %s: %s\n", filename,
-		    strerror(errno));
+		err("ERROR: Failed to open file %s: %s\n", filename, strerror(errno));
 		*p_list = NULL;
 		return 1;
 	}
@@ -111,19 +106,16 @@ int load_list(char *filename, struct black_list_type **p_list)
 		if (ret == 0)
 			continue;
 
-		new = (struct black_list_type *)
-			malloc(sizeof(struct black_list_type));
+		new = (struct black_list_type *) malloc(sizeof(struct black_list_type));
 		if (new == NULL) {
-			err("ERROR: Memory allocation problem (%s)\n",
-			    strerror(errno));
+			err("ERROR: Memory allocation problem (%s)\n", strerror(errno));
 			ret = 1;
 			goto err;
 		}
 
 		new->name = strdup(name);
 		if (new->name == NULL) {
-			err("ERROR: Memory allocation problem (%s)\n",
-			    strerror(errno));
+			err("ERROR: Memory allocation problem (%s)\n", strerror(errno));
 			ret = 1;
 			free(new);
 			goto err;
@@ -139,7 +131,6 @@ int load_list(char *filename, struct black_list_type **p_list)
 			end = new;
 		}
 	}
-
 	fclose(fw);
 
 	*p_list = start;
@@ -176,8 +167,7 @@ void free_list(struct black_list_type *list)
 }
 
 /*
- * Test whether the variable is on the list
- * return values are:
+ * Test whether the variable is on the list return values are:
  * 1 ... was found
  * 0 ... no record was found
  */
@@ -190,19 +180,16 @@ int is_on_list(char *name, struct black_list_type *list)
 	while (record != NULL) {
 		/* if the variable name is found */
 		if (strcmp(record->name, name) == 0) {
-			/* return its value */
-			return 1;
+			return 1; /* return its value */
 		}
 		record = record->next;
 	}
 
-	/* the variable was not found */
-	return 0;
+	return 0; /* the variable was not found */
 }
 
 /*
- * Display permissions record for the given group
- * defined by path
+ * Display permissions record for the given group defined by path
  */
 static int display_permissions(const char *path, const char * const cg_name,
 			       const char * const ctrl_name)
@@ -224,8 +211,7 @@ static int display_permissions(const char *path, const char * const cg_name,
 
 	/* tasks permissions record */
 	/* get tasks file statistic */
-	ret = cgroup_build_tasks_procs_path(tasks_path, sizeof(tasks_path),
-					    cg_name, ctrl_name);
+	ret = cgroup_build_tasks_procs_path(tasks_path, sizeof(tasks_path), cg_name, ctrl_name);
 	if (ret) {
 		err("ERROR: can't build tasks/procs path: %d\n", ret);
 		return -1;
@@ -237,8 +223,7 @@ static int display_permissions(const char *path, const char * const cg_name,
 		return -1;
 	}
 
-	if ((sba.st_uid) || (sba.st_gid) ||
-	    (sbt.st_uid) || (sbt.st_gid)) {
+	if ((sba.st_uid) || (sba.st_gid) || (sbt.st_uid) || (sbt.st_gid)) {
 		/*
 		 * some uid or gid is nonroot, admin permission
 		 * tag is necessary
@@ -299,9 +284,9 @@ static int display_permissions(const char *path, const char * const cg_name,
  * tail
  */
 static int display_cgroup_data(struct cgroup *group,
-		char controller[CG_CONTROLLER_MAX][FILENAME_MAX],
-		const char *group_path, int root_path_len, int first,
-		const char *program_name)
+			       char controller[CG_CONTROLLER_MAX][FILENAME_MAX],
+			       const char *group_path, int root_path_len, int first,
+			       const char *program_name)
 {
 	struct cgroup_controller *group_controller = NULL;
 	char var_path[FILENAME_MAX];
@@ -320,15 +305,14 @@ static int display_cgroup_data(struct cgroup *group,
 	/* for all wanted controllers display controllers tag */
 	while (controller[i][0] != '\0') {
 		/* display the permission tags */
-		ret = display_permissions(group_path, group->name,
-					  controller[i]);
+		ret = display_permissions(group_path, group->name, controller[i]);
 		if (ret)
 			return ret;
 
 		group_controller = cgroup_get_controller(group, controller[i]);
 		if (group_controller == NULL) {
-			info("cannot find controller '%s' in group '%s'\n",
-			     controller[i], group->name);
+			info("cannot find controller '%s' in group '%s'\n", controller[i],
+			     group->name);
 			i++;
 			ret = -1;
 			continue;
@@ -347,10 +331,10 @@ static int display_cgroup_data(struct cgroup *group,
 
 			/*
 			 * For the non-root groups cgconfigparser set
-			 * permissions of variable files to 777. Thus
-			 * it is necessary to test the permissions of
-			 * variable files in the root group to find out
-			 * whether the variable is writable.
+			 * permissions of variable files to 777. Thus it
+			 * is necessary to test the permissions of variable
+			 * files in the root group to find out whether the
+			 * variable is writable.
 			 */
 			if (root_path_len >= FILENAME_MAX)
 				root_path_len = FILENAME_MAX - 1;
@@ -358,21 +342,18 @@ static int display_cgroup_data(struct cgroup *group,
 			strncpy(var_path, group_path, root_path_len);
 			var_path[root_path_len] = '\0';
 
-			strncat(var_path, "/",
-				FILENAME_MAX - strlen(var_path) - 1);
+			strncat(var_path, "/", FILENAME_MAX - strlen(var_path) - 1);
 			var_path[FILENAME_MAX-1] = '\0';
 
-			strncat(var_path, name,
-				FILENAME_MAX - strlen(var_path) - 1);
+			strncat(var_path, name,	FILENAME_MAX - strlen(var_path) - 1);
 			var_path[FILENAME_MAX-1] = '\0';
 
 			/* test whether the  write permissions */
 			ret = stat(var_path, &sb);
 			/*
 			 * freezer.state is not in root group so ret != 0,
-			 * but it should be listed
-			 * device.list should be read to create
-			 * device.allow input
+			 * but it should be listed device.list should be
+			 * read to create device.allow input
 			 */
 			/* 0200 == S_IWUSR */
 			if ((ret == 0) && ((sb.st_mode & 0200) == 0) &&
@@ -382,8 +363,8 @@ static int display_cgroup_data(struct cgroup *group,
 			}
 
 			/*
-			 * find whether the variable is blacklisted or
-			 * whitelisted
+			 * find whether the variable is blacklisted
+			 * or whitelisted
 			 */
 			bl = is_on_list(name, black_list);
 			wl = is_on_list(name, white_list);
@@ -423,18 +404,15 @@ static int display_cgroup_data(struct cgroup *group,
 
 			if (strcmp("devices.list", name) == 0) {
 				output_name = "devices.allow";
-				fprintf(output_f,
-					"\t\tdevices.deny=\"a *:* rwm\";\n");
+				fprintf(output_f, "\t\tdevices.deny=\"a *:* rwm\";\n");
 			}
 
-			ret = cgroup_get_value_string(group_controller,
-						      name, &value);
+			ret = cgroup_get_value_string(group_controller, name, &value);
 
 			/* variable can not be read */
 			if (ret != 0) {
 				ret = 0;
-				err("ERROR: Value of variable %s can be read\n",
-				    name);
+				err("ERROR: Value of variable %s can be read\n", name);
 				goto err;
 			}
 			fprintf(output_f, "\t\t%s=\"%s\";\n", output_name, value);
@@ -454,9 +432,8 @@ err:
  * creates the record about the hierarchie which contains
  * "controller" subsystem
  */
-static int display_controller_data(
-			char controller[CG_CONTROLLER_MAX][FILENAME_MAX],
-			const char *program_name)
+static int display_controller_data(char controller[CG_CONTROLLER_MAX][FILENAME_MAX],
+				   const char *program_name)
 {
 	char cgroup_name[FILENAME_MAX];
 	struct cgroup_file_info info;
@@ -471,8 +448,7 @@ static int display_controller_data(
 	 * start to parse the structure for the first controller -
 	 * controller[0] attached to hierarchy
 	 */
-	ret = cgroup_walk_tree_begin(controller[0], "/", 0,
-				     &handle, &info, &lvl);
+	ret = cgroup_walk_tree_begin(controller[0], "/", 0, &handle, &info, &lvl);
 	if (ret != 0)
 		return ret;
 
@@ -483,28 +459,26 @@ static int display_controller_data(
 		/* some group starts here */
 		if (info.type == CGROUP_FILE_TYPE_DIR) {
 			/* parse the group name from full_path*/
-			strncpy(cgroup_name, &info.full_path[prefix_len],
-				FILENAME_MAX);
+			strncpy(cgroup_name, &info.full_path[prefix_len], FILENAME_MAX);
 			cgroup_name[FILENAME_MAX-1] = '\0';
 
 			/* start to grab data about the new group */
 			group = cgroup_new_cgroup(cgroup_name);
 			if (group == NULL) {
-				info("cannot create group '%s'\n",
-					cgroup_name);
+				info("cannot create group '%s'\n", cgroup_name);
 				ret = ECGFAIL;
 				goto err;
 			}
 
 			ret = cgroup_get_cgroup(group);
 			if (ret != 0) {
-				info("cannot read group '%s': %s\n",
-					cgroup_name, cgroup_strerror(ret));
+				info("cannot read group '%s': %s\n", cgroup_name,
+				     cgroup_strerror(ret));
 				goto err;
 			}
 
-			display_cgroup_data(group, controller, info.full_path,
-					    prefix_len, first, program_name);
+			display_cgroup_data(group, controller, info.full_path, prefix_len, first,
+					    program_name);
 			first = 0;
 			cgroup_free(&group);
 		}
@@ -539,8 +513,7 @@ static int is_ctlr_on_list(char controllers[CG_CONTROLLER_MAX][FILENAME_MAX],
 
 
 /* print data about input cont_name controller */
-static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX],
-			     const char *program_name)
+static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX], const char *program_name)
 {
 	char controllers[CG_CONTROLLER_MAX][FILENAME_MAX] = {"\0"};
 	struct cgroup_mount_point controller;
@@ -558,20 +531,16 @@ static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX],
 		if (strcmp(path, controller.path) == 0) {
 			/* if it is still the same mount point */
 			if (max < CG_CONTROLLER_MAX) {
-				strncpy(controllers[max],
-					controller.name, FILENAME_MAX);
+				strncpy(controllers[max], controller.name, FILENAME_MAX);
 				(controllers[max])[FILENAME_MAX-1] = '\0';
 				max++;
 			}
 		} else {
-
 			/* we got new mount point, print it if needed */
-			if ((!(flags & FL_LIST) ||
-			     (is_ctlr_on_list(controllers, cont_names)))
-			    && (max != 0)) {
+			if ((!(flags & FL_LIST) || (is_ctlr_on_list(controllers, cont_names))) &&
+			    (max != 0)) {
 				(controllers[max])[0] = '\0';
-				ret = display_controller_data(controllers,
-							      program_name);
+				ret = display_controller_data(controllers, program_name);
 			}
 
 			strncpy(controllers[0], controller.name, FILENAME_MAX);
@@ -586,9 +555,7 @@ static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX],
 		ret = cgroup_get_controller_next(&handle, &controller);
 	}
 
-	if ((!(flags & FL_LIST) ||
-	     (is_ctlr_on_list(controllers, cont_names)))
-	    && (max != 0)) {
+	if ((!(flags & FL_LIST) || (is_ctlr_on_list(controllers, cont_names))) && (max != 0)) {
 		(controllers[max])[0] = '\0';
 		ret = display_controller_data(controllers, program_name);
 	}
@@ -634,8 +601,7 @@ static int show_mountpoints(const char *controller)
  * If yes then the data are printed. "cont_names" is list of controllers
  * which should be shown.
  */
-static void parse_mountpoint(cont_name_t cont_names[CG_CONTROLLER_MAX],
-			     char *name)
+static void parse_mountpoint(cont_name_t cont_names[CG_CONTROLLER_MAX], char *name)
 {
 	int i;
 
@@ -656,8 +622,7 @@ static void parse_mountpoint(cont_name_t cont_names[CG_CONTROLLER_MAX],
 			if (show_mountpoints(name)) {
 				/* the controller is not mounted */
 				if ((flags & FL_SILENT) == 0) {
-					err("ERROR: %s hierarchy not mounted\n",
-					    name);
+					err("ERROR: %s hierarchy not mounted\n", name);
 				}
 			break;
 			}
@@ -667,8 +632,7 @@ static void parse_mountpoint(cont_name_t cont_names[CG_CONTROLLER_MAX],
 }
 
 /* print data about input mount points */
-static int parse_mountpoints(cont_name_t cont_names[CG_CONTROLLER_MAX],
-			     const char *program_name)
+static int parse_mountpoints(cont_name_t cont_names[CG_CONTROLLER_MAX], const char *program_name)
 {
 	struct cgroup_mount_point mount;
 	struct controller_data info;
@@ -692,8 +656,7 @@ static int parse_mountpoints(cont_name_t cont_names[CG_CONTROLLER_MAX],
 
 	if (ret != ECGEOF) {
 		if ((flags &  FL_SILENT) != 0) {
-			err("E: in get next controller %s\n",
-			    cgroup_strerror(ret));
+			err("E: in get next controller %s\n", cgroup_strerror(ret));
 		}
 		final_ret = ret;
 	}
@@ -710,8 +673,7 @@ static int parse_mountpoints(cont_name_t cont_names[CG_CONTROLLER_MAX],
 
 	if (ret != ECGEOF) {
 		if ((flags &  FL_SILENT) != 0) {
-			err("E: in get next controller %s\n",
-			    cgroup_strerror(ret));
+			err("E: in get next controller %s\n", cgroup_strerror(ret));
 		}
 		final_ret = ret;
 	}
@@ -743,15 +705,13 @@ int main(int argc, char *argv[])
 	int c_number = 0;
 	int c, i;
 
-
 	for (i = 0; i < CG_CONTROLLER_MAX; i++)
 		wanted_cont[i][0] = '\0';
 
 	flags = 0;
 
 	/* parse arguments */
-	while ((c = getopt_long(argc, argv, "hsb:w:tf:", long_opts,
-				NULL)) > 0) {
+	while ((c = getopt_long(argc, argv, "hsb:w:tf:", long_opts, NULL)) > 0) {
 		switch (c) {
 		case 'h':
 			usage(0, argv[0]);
@@ -776,8 +736,7 @@ int main(int argc, char *argv[])
 			flags |= FL_OUTPUT;
 			output_f = fopen(optarg, "w");
 			if (output_f == NULL) {
-				err("%s: Failed to open file %s\n", argv[0],
-				    optarg);
+				err("%s: Failed to open file %s\n", argv[0], optarg);
 				return ECGOTHER;
 			}
 			break;

--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -20,10 +20,10 @@
 #include <stdio.h>
 
 
-#define MODE_SHOW_HEADERS		1
-#define MODE_SHOW_NAMES			2
+#define MODE_SHOW_HEADERS	1
+#define MODE_SHOW_NAMES		2
 
-#define LL_MAX				100
+#define LL_MAX			100
 
 #ifndef LIBCG_LIB
 static const struct option long_options[] = {
@@ -40,38 +40,27 @@ static const struct option long_options[] = {
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		err("Wrong input parameters, ");
-		err("try %s -h' for more information.\n", program_name);
+		err("Wrong input parameters, try %s -h' for more information.\n", program_name);
 		return;
 	}
 
-	info("Usage: %s [-nv] [-r <name>] [-g <controllers>] ",
-	     program_name);
-	info("[-a] <path> ...\n");
-	info("   or: %s [-nv] [-r <name>] -g <controllers>:<path> ...\n",
-	     program_name);
+	info("Usage: %s [-nv] [-r <name>] [-g <controllers>] [-a] <path> ...\n", program_name);
+	info("   or: %s [-nv] [-r <name>] -g <controllers>:<path> ...\n", program_name);
 	info("Print parameter(s) of given group(s).\n");
-	info("  -1, --v1			Provided parameters are in ");
-	info("v1 format\n");
-	info("  -2, --v2			Provided parameters are in ");
-	info("v2 format\n");
+	info("  -1, --v1			Provided parameters are in v1 format\n");
+	info("  -2, --v2			Provided parameters are in v2 format\n");
 	info("  -i, --ignore-unmappable       Do not return an error for ");
 	info("settings that cannot be converted\n");
-	info("  -a, --all			Print info about all relevant");
-	info(" controllers\n");
-	info("  -g <controllers>		Controller which info should");
-	info(" be displayed\n");
-	info("  -g <controllers>:<path>	Control group which info");
-	info(" should be displayed\n");
+	info("  -a, --all			Print info about all relevant controllers\n");
+	info("  -g <controllers>		Controller which info should be displayed\n");
+	info("  -g <controllers>:<path>	Control group which info should be displayed\n");
 	info("  -h, --help			Display this help\n");
 	info("  -n				Do not print headers\n");
 	info("  -r, --variable  <name>	Define parameter to display\n");
-	info("  -v, --values-only		Print only values, not ");
-	info("parameter names\n");
+	info("  -v, --values-only		Print only values, not parameter names\n");
 }
 
-static int get_controller_from_name(const char * const name,
-				    char **controller)
+static int get_controller_from_name(const char * const name, char **controller)
 {
 	char *dot;
 
@@ -91,8 +80,7 @@ static int get_controller_from_name(const char * const name,
 
 static int create_cg(struct cgroup **cg_list[], int * const cg_list_len)
 {
-	*cg_list = realloc(*cg_list,
-			   ((*cg_list_len) + 1) * sizeof(struct cgroup *));
+	*cg_list = realloc(*cg_list, ((*cg_list_len) + 1) * sizeof(struct cgroup *));
 	if ((*cg_list) == NULL)
 		return ECGCONTROLLERCREATEFAILED;
 
@@ -122,9 +110,9 @@ static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
 	}
 
 	/*
-	 * if "-r" was provided, then we know that the cgroup(s) will be an
-	 * optarg at the end with no flag.  Let's temporarily populate the
-	 * first cgroup with the requested control values.
+	 * if "-r" was provided, then we know that the cgroup(s) will be
+	 * an optarg at the end with no flag.  Let's temporarily populate
+	 * the first cgroup with the requested control values.
 	 */
 	cg = (*cg_list)[0];
 
@@ -173,9 +161,9 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 	}
 
 	/*
-	 * if "-r" was provided, then we know that the cgroup(s) will be an
-	 * optarg at the end with no flag.  Let's temporarily populate the
-	 * first cgroup with the requested control values.
+	 * if "-r" was provided, then we know that the cgroup(s) will be
+	 * an optarg at the end with no flag.  Let's temporarily populate
+	 * the first cgroup with the requested control values.
 	 */
 	cg = (*cg_list)[0];
 
@@ -187,8 +175,7 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 	if (!cgc) {
 		cgc = cgroup_add_controller(cg, cntl_value_controller);
 		if (!cgc) {
-			err("cgget: cannot find controller '%s'\n",
-			    cntl_value_controller);
+			err("cgget: cannot find controller '%s'\n", cntl_value_controller);
 			ret = ECGOTHER;
 			goto out;
 		}
@@ -203,8 +190,7 @@ out:
 	return ret;
 }
 
-static int parse_g_flag_no_colon(struct cgroup **cg_list[],
-				 int * const cg_list_len,
+static int parse_g_flag_no_colon(struct cgroup **cg_list[], int * const cg_list_len,
 				 const char * const ctrl_str)
 {
 	struct cgroup_controller *cgc;
@@ -223,9 +209,10 @@ static int parse_g_flag_no_colon(struct cgroup **cg_list[],
 	}
 
 	/*
-	 * if "-g <controller>" was provided, then we know that the cgroup(s)
-	 * will be an optarg at the end with no flag.  Let's temporarily
-	 * populate the first cgroup with the requested control values.
+	 * if "-g <controller>" was provided, then we know that the
+	 * cgroup(s) will be an optarg at the end with no flag.
+	 * Let's temporarily populate the first cgroup with the requested
+	 * control values.
 	 */
 	cg = *cg_list[0];
 
@@ -258,8 +245,7 @@ static int split_cgroup_name(const char * const ctrl_str, char *cg_name)
 	return 0;
 }
 
-static int split_controllers(const char * const in,
-			     char **ctrl[], int * const ctrl_len)
+static int split_controllers(const char * const in, char **ctrl[], int * const ctrl_len)
 {
 	char *copy, *tok, *colon, *saveptr = NULL;
 	int ret = 0;
@@ -298,8 +284,7 @@ out:
 	return ret;
 }
 
-static int parse_g_flag_with_colon(struct cgroup **cg_list[],
-				   int * const cg_list_len,
+static int parse_g_flag_with_colon(struct cgroup **cg_list[], int * const cg_list_len,
 				   const char * const ctrl_str)
 {
 	struct cgroup_controller *cgc;
@@ -347,8 +332,8 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 	int ret = 0;
 
 	/*
-	 * The first cgroup was temporarily populated and requires
-	 * the user to provide a cgroup name as an opt
+	 * The first cgroup was temporarily populated and requires the
+	 * user to provide a cgroup name as an opt
 	 */
 	if (argv[optind] == NULL && first_cg_is_dummy) {
 		usage(1, argv[0]);
@@ -357,15 +342,14 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 
 	/*
 	 * The user has provided a cgroup and controller via the
-	 * -g <controller>:<cgroup> flag and has also provided a cgroup via
-	 * the optind.  This was not supported by the previous cgget
-	 * implementation.  Continue that approach.
+	 * -g <controller>:<cgroup> flag and has also provided a cgroup
+	 *  via the optind.  This was not supported by the previous
+	 * cgget implementation.  Continue that approach.
 	 *
 	 * Example of a command that will hit this code:
 	 *	$ cgget -g cpu:mycgroup mycgroup
 	 */
-	if (argv[optind] != NULL && (*cg_list_len) > 0 &&
-	    strcmp((*cg_list)[0]->name, "") != 0) {
+	if (argv[optind] != NULL && (*cg_list_len) > 0 && strcmp((*cg_list)[0]->name, "") != 0) {
 		usage(1, argv[0]);
 		exit(-1);
 	}
@@ -387,15 +371,13 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 			if (ret)
 				goto out;
 
-			strncpy((*cg_list)[(*cg_list_len) - 1]->name,
-				argv[optind],
+			strncpy((*cg_list)[(*cg_list_len) - 1]->name, argv[optind],
 				sizeof((*cg_list)[(*cg_list_len) - 1]->name) - 1);
 		} else if (cg != NULL && strlen(cg->name) == 0) {
 			/*
 			 * this cgroup was created based upon control/value
 			 * pairs or with a -g <controller> option.  we'll
-			 * populate it with the parameter provided by the
-			 * user
+			 * populate it with the parameter provided by the user
 			 */
 			strncpy(cg->name, argv[optind], sizeof(cg->name) - 1);
 		} else {
@@ -408,8 +390,7 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 			if (ret)
 				goto out;
 
-			strncpy((*cg_list)[(*cg_list_len) - 1]->name,
-				argv[optind],
+			strncpy((*cg_list)[(*cg_list_len) - 1]->name, argv[optind],
 				sizeof((*cg_list)[(*cg_list_len) - 1]->name) - 1);
 		}
 
@@ -420,9 +401,8 @@ out:
 	return ret;
 }
 
-static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[],
-		      int * const cg_list_len, int * const mode,
-		      enum cg_version_t * const version,
+static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * const cg_list_len,
+		      int * const mode, enum cg_version_t * const version,
 		      bool * const ignore_unmappable)
 {
 	bool do_not_fill_controller = false;
@@ -432,8 +412,7 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[],
 	int c;
 
 	/* Parse arguments. */
-	while ((c = getopt_long(argc, argv, "r:hnvg:a12i", long_options,
-				NULL)) > 0) {
+	while ((c = getopt_long(argc, argv, "r:hnvg:a12i", long_options, NULL)) > 0) {
 		switch (c) {
 		case 'h':
 			usage(0, argv[0]);
@@ -457,13 +436,11 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[],
 			fill_controller = true;
 			if (strchr(optarg, ':') == NULL) {
 				first_cgroup_is_dummy = true;
-				ret = parse_g_flag_no_colon(cg_list,
-							cg_list_len, optarg);
+				ret = parse_g_flag_no_colon(cg_list, cg_list_len, optarg);
 				if (ret)
 					goto err;
 			} else {
-				ret = parse_g_flag_with_colon(cg_list,
-							cg_list_len, optarg);
+				ret = parse_g_flag_with_colon(cg_list, cg_list_len, optarg);
 				if (ret)
 					goto err;
 			}
@@ -495,8 +472,7 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[],
 		exit(1);
 	}
 
-	ret = parse_opt_args(argc, argv, cg_list, cg_list_len,
-			     first_cgroup_is_dummy);
+	ret = parse_opt_args(argc, argv, cg_list, cg_list_len, first_cgroup_is_dummy);
 	if (ret)
 		goto err;
 
@@ -505,8 +481,7 @@ err:
 }
 #endif /* !LIBCG_LIB */
 
-static int get_cv_value(struct control_value * const cv,
-			const char * const cg_name,
+static int get_cv_value(struct control_value * const cv, const char * const cg_name,
 			const char * const controller_name)
 {
 	bool is_multiline = false;
@@ -514,8 +489,8 @@ static int get_cv_value(struct control_value * const cv,
 	void *handle, *tmp;
 	int ret;
 
-	ret = cgroup_read_value_begin(controller_name, cg_name, cv->name,
-				      &handle, tmp_line, LL_MAX);
+	ret = cgroup_read_value_begin(controller_name, cg_name, cv->name, &handle, tmp_line,
+				      LL_MAX);
 	if (ret == ECGEOF)
 		goto read_end;
 	if (ret != 0) {
@@ -523,18 +498,16 @@ static int get_cv_value(struct control_value * const cv,
 			int tmp_ret;
 
 			/*
-			 * to maintain compatibility with an earlier version
-			 * of cgget, try to determine if the failure was due
-			 * to an invalid controller
+			 * to maintain compatibility with an earlier
+			 * version of cgget, try to determine if the
+			 * failure was due to an invalid controller
 			 */
 			tmp_ret = cgroup_test_subsys_mounted(controller_name);
 			if (tmp_ret == 0) {
-				err("cgget: cannot find controller '%s' in ",
-				    controller_name);
-				err("in group '%s'\n", cg_name);
+				err("cgget: cannot find controller '%s' in group '%s'\n",
+				    controller_name, cg_name);
 			} else {
-				err("variable file read failed %s\n",
-				    cgroup_strerror(ret));
+				err("variable file read failed %s\n", cgroup_strerror(ret));
 			}
 		}
 
@@ -601,8 +574,7 @@ static int indent_multiline_value(struct control_value * const cv)
 	return 0;
 }
 
-static int fill_empty_controller(struct cgroup * const cg,
-				 struct cgroup_controller * const cgc)
+static int fill_empty_controller(struct cgroup * const cg, struct cgroup_controller * const cgc)
 {
 	struct dirent *ctrl_dir = NULL;
 	char path[FILENAME_MAX];
@@ -616,8 +588,7 @@ static int fill_empty_controller(struct cgroup * const cg,
 			cg_mount_table[i].name[0] != '\0'; i++) {
 
 		if (strlen(cgc->name) == strlen(cg_mount_table[i].name) &&
-		    strncmp(cgc->name, cg_mount_table[i].name,
-			    strlen(cgc->name)) == 0) {
+		    strncmp(cgc->name, cg_mount_table[i].name, strlen(cgc->name)) == 0) {
 			found_mount = true;
 			break;
 		}
@@ -626,10 +597,8 @@ static int fill_empty_controller(struct cgroup * const cg,
 	if (found_mount == false)
 		goto out;
 
-	if (!cg_build_path_locked(NULL, path,
-				  cg_mount_table[i].name)) {
+	if (!cg_build_path_locked(NULL, path, cg_mount_table[i].name))
 		goto out;
-	}
 
 	path_len = strlen(path);
 	strncat(path, cg->name, FILENAME_MAX - path_len - 1);
@@ -661,12 +630,11 @@ static int fill_empty_controller(struct cgroup * const cg,
 			cgc->values[cgc->index - 1]->dirty = false;
 
 			/*
-			 * previous versions of cgget indented the second and
-			 * all subsequent lines.  continue that behavior
+			 * previous versions of cgget indented the second
+			 * and all subsequent lines. Continue that behavior
 			 */
 			if (strchr(cgc->values[cgc->index - 1]->value, '\n')) {
-				ret = indent_multiline_value(
-					cgc->values[cgc->index - 1]);
+				ret = indent_multiline_value(cgc->values[cgc->index - 1]);
 				if (ret)
 					goto out;
 			}
@@ -682,8 +650,7 @@ out:
 	return ret;
 }
 
-static int get_controller_values(struct cgroup * const cg,
-				 struct cgroup_controller * const cgc)
+static int get_controller_values(struct cgroup * const cg, struct cgroup_controller * const cgc)
 {
 	int ret = 0;
 	int i;
@@ -734,8 +701,7 @@ static int get_values(struct cgroup *cg_list[], int cg_list_len)
 	return ret;
 }
 
-static void print_control_values(const struct control_value * const cv,
-				 int mode)
+static void print_control_values(const struct control_value * const cv, int mode)
 {
 	if (mode & MODE_SHOW_NAMES)
 		info("%s: ", cv->name);
@@ -746,8 +712,7 @@ static void print_control_values(const struct control_value * const cv,
 		info("%s\n", cv->value);
 }
 
-static void print_controller(const struct cgroup_controller * const cgc,
-			     int mode)
+static void print_controller(const struct cgroup_controller * const cgc, int mode)
 {
 	int i;
 
@@ -778,8 +743,7 @@ static void print_cgroups(struct cgroup *cg_list[], int cg_list_len, int mode)
 }
 
 static int convert_cgroups(struct cgroup **cg_list[], int cg_list_len,
-			   enum cg_version_t in_version,
-			   enum cg_version_t out_version)
+			   enum cg_version_t in_version, enum cg_version_t out_version)
 {
 	struct cgroup **cg_converted_list;
 	int i = 0, j, ret = 0;
@@ -795,8 +759,8 @@ static int convert_cgroups(struct cgroup **cg_list[], int cg_list_len,
 			goto out;
 		}
 
-		ret = cgroup_convert_cgroup(cg_converted_list[i],
-			out_version, (*cg_list)[i], in_version);
+		ret = cgroup_convert_cgroup(cg_converted_list[i], out_version, (*cg_list)[i],
+					    in_version);
 		if (ret)
 			goto out;
 	}
@@ -808,8 +772,8 @@ out:
 			cgroup_free(&(cg_converted_list[i]));
 	} else {
 		/*
-		 * The conversion succeeded or was unmappable.  Free the old
-		 * list.
+		 * The conversion succeeded or was unmappable.
+		 * Free the old list.
 		 */
 		for (i = 0; i < cg_list_len; i++)
 			cgroup_free(cg_list[i]);
@@ -837,13 +801,11 @@ int main(int argc, char *argv[])
 
 	ret = cgroup_init();
 	if (ret) {
-		err("%s: libcgroup initialization failed: %s\n", argv[0],
-		    cgroup_strerror(ret));
+		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		goto err;
 	}
 
-	ret = parse_opts(argc, argv, &cg_list, &cg_list_len, &mode, &version,
-			 &ignore_unmappable);
+	ret = parse_opts(argc, argv, &cg_list, &cg_list_len, &mode, &version, &ignore_unmappable);
 	if (ret)
 		goto err;
 
@@ -876,8 +838,7 @@ err:
 #endif /* !LIBCG_LIB */
 
 #ifdef LIBCG_LIB
-int cgroup_cgxget(struct cgroup **cg,
-		  enum cg_version_t version, bool ignore_unmappable)
+int cgroup_cgxget(struct cgroup **cg, enum cg_version_t version, bool ignore_unmappable)
 {
 	struct cgroup *disk_cg, *out_cg;
 	int ret;

--- a/src/tools/cgxset.c
+++ b/src/tools/cgxset.c
@@ -72,26 +72,20 @@ static void usage(int status, const char *program_name)
 		return;
 	}
 
-	info("Usage: %s [-r <name=value>] <cgroup_path> ...\n",
-	     program_name);
-	info("   or: %s --copy-from <source_cgroup_path> ", program_name);
-	info("<cgroup_path> ...\n");
+	info("Usage: %s [-r <name=value>] <cgroup_path> ...\n", program_name);
+	info("   or: %s --copy-from <source_cgroup_path> <cgroup_path> ...\n", program_name);
 	info("Set the parameters of given cgroup(s)\n");
-	info("  -1, --v1                      Provided parameters are in ");
-	info("v1 format\n");
-	info("  -2, --v2                      Provided parameters are in ");
-	info("v2 format\n");
+	info("  -1, --v1                      Provided parameters are in v1 format\n");
+	info("  -2, --v2                      Provided parameters are in v2 format\n");
 	info("  -i, --ignore-unmappable       Do not return an error for ");
 	info("settings that cannot be converted\n");
-	info("  -r, --variable <name>			Define parameter ");
-	info("to set\n");
+	info("  -r, --variable <name>			Define parameter to set\n");
 	info("  --copy-from <source_cgroup_path>	Control group whose ");
 	info("parameters will be copied\n");
 }
 #endif /* !UNIT_TEST */
 
-STATIC int parse_r_flag(const char * const program_name,
-			const char * const name_value_str,
+STATIC int parse_r_flag(const char * const program_name, const char * const name_value_str,
 			struct control_value * const name_value)
 {
 	char *copy, *buf;
@@ -107,8 +101,7 @@ STATIC int parse_r_flag(const char * const program_name,
 	/* parse optarg value */
 	buf = strtok(copy, "=");
 	if (buf == NULL) {
-		err("%s: wrong parameter of option -r: %s\n", program_name,
-		    optarg);
+		err("%s: wrong parameter of option -r: %s\n", program_name, optarg);
 		ret = -1;
 		goto err;
 	}
@@ -124,8 +117,7 @@ STATIC int parse_r_flag(const char * const program_name,
 	buf++;
 
 	if (strlen(buf) == 0) {
-		err("%s: wrong parameter of option -r: %s\n", program_name,
-		    optarg);
+		err("%s: wrong parameter of option -r: %s\n", program_name, optarg);
 		ret = -1;
 		goto err;
 	}
@@ -159,14 +151,12 @@ int main(int argc, char *argv[])
 
 	/* no parametr on input */
 	if (argc < 2) {
-		err("Usage is %s -r <name=value> <relative path to cgroup>\n",
-		    argv[0]);
+		err("Usage is %s -r <name=value> <relative path to cgroup>\n", argv[0]);
 		return -1;
 	}
 
 	/* parse arguments */
-	while ((c = getopt_long (argc, argv,
-		"r:h12i", long_options, NULL)) != -1) {
+	while ((c = getopt_long (argc, argv, "r:h12i", long_options, NULL)) != -1) {
 		switch (c) {
 		case 'h':
 			usage(0, argv[0]);
@@ -180,25 +170,19 @@ int main(int argc, char *argv[])
 			}
 			flags |= FL_RULES;
 
-			/*
-			 * add name-value pair to buffer
-			 * (= name_value variable)
-			 */
+			/* add name-value pair to buffer (= name_value variable) */
 			if (nv_number >= nv_max) {
 				nv_max += CG_NV_MAX;
 				name_value = (struct control_value *)
-					realloc(name_value,
-					nv_max * sizeof(struct control_value));
+					realloc(name_value, nv_max * sizeof(struct control_value));
 				if (!name_value) {
-					err("%s: not enough memory\n",
-					    argv[0]);
+					err("%s: not enough memory\n", argv[0]);
 					ret = -1;
 					goto err;
 				}
 			}
 
-			ret = parse_r_flag(argv[0], optarg,
-					   &name_value[nv_number]);
+			ret = parse_r_flag(argv[0], optarg, &name_value[nv_number]);
 			if (ret)
 				goto err;
 
@@ -253,8 +237,7 @@ int main(int argc, char *argv[])
 
 	/* copy the name-value pairs from -r options */
 	if ((flags & FL_RULES) != 0) {
-		src_cgroup = create_cgroup_from_name_value_pairs(
-						"tmp", name_value, nv_number);
+		src_cgroup = create_cgroup_from_name_value_pairs("tmp", name_value, nv_number);
 		if (src_cgroup == NULL)
 			goto err;
 	}
@@ -271,8 +254,7 @@ int main(int argc, char *argv[])
 		cgroup = cgroup_new_cgroup(argv[optind]);
 		if (!cgroup) {
 			ret = ECGFAIL;
-			err("%s: can't add new cgroup: %s\n", argv[0],
-			    cgroup_strerror(ret));
+			err("%s: can't add new cgroup: %s\n", argv[0], cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 
@@ -290,13 +272,13 @@ int main(int argc, char *argv[])
 			goto err;
 		}
 
-		ret = cgroup_convert_cgroup(converted_src_cgroup, CGROUP_DISK,
-					    src_cgroup, src_version);
+		ret = cgroup_convert_cgroup(converted_src_cgroup, CGROUP_DISK, src_cgroup,
+					    src_version);
 		if (ret == ECGNOVERSIONCONVERT && ignore_unmappable)
 			/*
 			 * The user has specified that we should ignore
-			 * any errors due to being unable to map from v1 to
-			 * v2 or vice versa
+			 * any errors due to being unable to map from
+			 * v1 to v2 or vice versa
 			 */
 			ret = 0;
 		else if (ret)
@@ -308,8 +290,7 @@ int main(int argc, char *argv[])
 		/* modify cgroup based on values of the new one */
 		ret = cgroup_modify_cgroup(cgroup);
 		if (ret) {
-			err("%s: cgroup modify error: %s\n", argv[0],
-			    cgroup_strerror(ret));
+			err("%s: cgroup modify error: %s\n", argv[0], cgroup_strerror(ret));
 			goto cgroup_free_err;
 		}
 
@@ -329,8 +310,8 @@ err:
 #endif /* !UNIT_TEST */
 
 #ifdef LIBCG_LIB
-int cgroup_cgxset(const struct cgroup * const cgroup,
-		  enum cg_version_t version, bool ignore_unmappable)
+int cgroup_cgxset(const struct cgroup * const cgroup, enum cg_version_t version,
+		  bool ignore_unmappable)
 {
 	struct cgroup *converted_cgroup;
 	int ret;
@@ -341,13 +322,11 @@ int cgroup_cgxset(const struct cgroup * const cgroup,
 		goto err;
 	}
 
-	ret = cgroup_convert_cgroup(converted_cgroup, CGROUP_DISK,
-				    cgroup, version);
+	ret = cgroup_convert_cgroup(converted_cgroup, CGROUP_DISK, cgroup, version);
 	if (ret == ECGNOVERSIONCONVERT && ignore_unmappable)
 		/*
-		 * The user has specified that we should ignore
-		 * any errors due to being unable to map from v1 to
-		 * v2 or vice versa
+		 * The user has specified that we should ignore any errors
+		 * due to being unable to map from v1 to v2 or vice versa
 		 */
 		ret = 0;
 	else if (ret)

--- a/src/tools/lscgroup.c
+++ b/src/tools/lscgroup.c
@@ -17,8 +17,9 @@
 
 enum flag {
 	/*
-	 * the flag set if there is a cgroup on output
-	 * if there is no one we want to display all cgroups
+	 * the flag set if there is a cgroup on
+	 * output if there is no one we want to
+	 * display all cgroups
 	 */
 	FL_LIST = 1
 };
@@ -37,13 +38,11 @@ static inline void trim_filepath(char *path)
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		err("Wrong input parameters, ");
-		err("try %s -h' for more information.\n", program_name);
+		err("Wrong input parameters, try %s -h' for more information.\n", program_name);
 		return;
 	}
 
-	info("Usage: %s [-h] [[-g] <controllers>:<path>] [...]\n",
-	     program_name);
+	info("Usage: %s [-h] [[-g] <controllers>:<path>] [...]\n", program_name);
 	info("List all cgroups\n");
 	info("  -g <controllers>:<path>	Control group to be ");
 	info("displayed (-g is optional)\n");
@@ -52,11 +51,10 @@ static void usage(int status, const char *program_name)
 }
 
 /*
- * if the info about controller "name" should be printed,
- *  then the function returns nonzero value
+ * if the info about controller "name" should be printed, then the function
+ * returns nonzero value
  */
-static int is_ctlr_on_list(struct cgroup_group_spec *cgroup_list,
-			const char *name)
+static int is_ctlr_on_list(struct cgroup_group_spec *cgroup_list, const char *name)
 {
 	int j;
 
@@ -86,8 +84,7 @@ static int display_controller_data(char *input_path, char *controller, char *nam
 	int lvl, len, ret;
 	void *handle;
 
-	ret = cgroup_walk_tree_begin(controller, input_path, 0,
-				     &handle, &info, &lvl);
+	ret = cgroup_walk_tree_begin(controller, input_path, 0, &handle, &info, &lvl);
 	if (ret != 0)
 		return ret;
 
@@ -115,11 +112,9 @@ static int display_controller_data(char *input_path, char *controller, char *nam
 }
 
 /*
- * print data about input cgroup_list cgroups
- * if FL_LIST flag is set then if the function does not find
- * the cgroup it returns ECGEOF
+ * print data about input cgroup_list cgroups if FL_LIST flag is set then
+ * if the function does not find the cgroup it returns ECGEOF
  */
-
 static int print_cgroup(struct cgroup_group_spec *cgroup_spec, int flags)
 {
 	struct cgroup_mount_point controller;
@@ -140,17 +135,14 @@ static int print_cgroup(struct cgroup_group_spec *cgroup_spec, int flags)
 	while (ret == 0) {
 		if (strcmp(path, controller.path) == 0) {
 			/* if it is still the same mount point */
-			strncat(all_conts, ",",
-				FILENAME_MAX-strlen(all_conts)-1);
-			strncat(all_conts, controller.name,
-				FILENAME_MAX-strlen(all_conts)-1);
+			strncat(all_conts, ",",	FILENAME_MAX-strlen(all_conts)-1);
+			strncat(all_conts, controller.name, FILENAME_MAX-strlen(all_conts)-1);
 			all_conts[sizeof(all_conts) - 1] = '\0';
 		} else {
 			/* we got new mount point, print it if needed */
 			if (output) {
-				ret = display_controller_data(
-							cgroup_spec->path,
-							con_name, all_conts);
+				ret = display_controller_data(cgroup_spec->path, con_name,
+							      all_conts);
 				if (ret)
 					return ret;
 				if ((flags & FL_LIST) != 0) {
@@ -184,18 +176,14 @@ static int print_cgroup(struct cgroup_group_spec *cgroup_spec, int flags)
 	if (ret != ECGEOF)
 		return ret;
 
-	if (output) {
-		ret = display_controller_data(cgroup_spec->path,
-					      con_name, all_conts);
-	}
+	if (output)
+		ret = display_controller_data(cgroup_spec->path, con_name, all_conts);
 
 	return ret;
 }
 
 
-static int cgroup_list_cgroups(char *tname,
-			       struct cgroup_group_spec *cgroup_list[],
-			       int flags)
+static int cgroup_list_cgroups(char *tname, struct cgroup_group_spec *cgroup_list[], int flags)
 {
 	int final_ret = 0;
 	int ret = 0;
@@ -219,13 +207,11 @@ static int cgroup_list_cgroups(char *tname,
 			final_ret = 0;
 		} else {
 			final_ret = ret;
-			err("cgroups can't be listed: %s\n",
-			    cgroup_strerror(ret));
+			err("cgroups can't be listed: %s\n", cgroup_strerror(ret));
 		}
 	} else {
 		/* we have he list of controllers which should be print */
-		while ((cgroup_list[i] != NULL)
-			&& ((ret == ECGEOF) || (ret == 0))) {
+		while ((cgroup_list[i] != NULL)	&& ((ret == ECGEOF) || (ret == 0))) {
 
 			ret = print_cgroup(cgroup_list[i], flags);
 			if (ret != 0) {
@@ -236,9 +222,9 @@ static int cgroup_list_cgroups(char *tname,
 					/* other problem */
 					final_ret = ret;
 				}
-				err("%s: cannot find group %s..:%s: %s\n",
-				    tname, cgroup_list[i]->controllers[0],
-				    cgroup_list[i]->path,
+
+				err("%s: cannot find group %s..:%s: %s\n", tname,
+				    cgroup_list[i]->controllers[0], cgroup_list[i]->path,
 				    cgroup_strerror(final_ret));
 			}
 			i++;
@@ -272,11 +258,10 @@ int main(int argc, char *argv[])
 			ret = 0;
 			goto err;
 		case 'g':
-			ret = parse_cgroup_spec(cgroup_list, optarg,
-				CG_HIER_MAX);
+			ret = parse_cgroup_spec(cgroup_list, optarg, CG_HIER_MAX);
 			if (ret) {
-				err("%s: cgroup controller and path", argv[0]);
-				err(" path parsing failed (%s)\n", optarg);
+				err("%s: cgroup controller and path parsing failed (%s)\n",
+				    argv[0], optarg);
 				return ret;
 			}
 			break;
@@ -289,11 +274,10 @@ int main(int argc, char *argv[])
 
 	/* read the list of controllers */
 	while (optind < argc) {
-		ret = parse_cgroup_spec(cgroup_list, argv[optind],
-				CG_HIER_MAX);
+		ret = parse_cgroup_spec(cgroup_list, argv[optind], CG_HIER_MAX);
 		if (ret) {
-			err("%s: cgroup controller an path parsing ", argv[0]);
-			err("failed (%s)\n", argv[optind]);
+			err("%s: cgroup controller an path parsing failed (%s)\n", argv[0],
+			    argv[optind]);
 			return -1;
 		}
 		optind++;

--- a/src/tools/lssubsys.c
+++ b/src/tools/lssubsys.c
@@ -17,7 +17,7 @@
 
 
 enum flag {
-	FL_MOUNT = 1,	/* show the mount points */
+	FL_MOUNT = 1,		/* show the mount points */
 	FL_LIST = 2,
 	FL_ALL = 4,		/* show all subsystems - not mounted too */
 	FL_HIERARCHY = 8,	/* show info about hierarchies */
@@ -29,8 +29,7 @@ typedef char cont_name_t[FILENAME_MAX];
 static void usage(int status, const char *program_name)
 {
 	if (status != 0) {
-		err("Wrong input parameters, ");
-		err("try %s -h' for more information.\n", program_name);
+		err("Wrong input parameters, try %s -h' for more information.\n", program_name);
 		return;
 	}
 
@@ -41,37 +40,35 @@ static void usage(int status, const char *program_name)
 	info("  -a, --all			Display information ");
 	info("about all controllers (including not mounted ones)\n");
 	info("  -h, --help			Display this help\n");
-	info("  -i, --hierarchies		Display information about ");
-	info("hierarchies\n");
+	info("  -i, --hierarchies		Display information about hierarchies\n");
 	info("  -m, --mount-points		Display mount points\n");
 	info("  -M, --all-mount-points	Display all mount points\n");
 	info("(Note: currently supported on cgroups v1 only)\n");
 }
 
-static int print_controller_mount(const char *controller, int flags,
-				  cont_name_t cont_names, int hierarchy)
+static int print_controller_mount(const char *controller, int flags, cont_name_t cont_names,
+				  int hierarchy)
 {
 	char path[FILENAME_MAX];
 	void *handle;
 	int ret = 0;
 
-	if (!(flags & FL_MOUNT) && !(flags & FL_HIERARCHY)) {
-		/* print only hierarchy name */
+	/* print only hierarchy name */
+	if (!(flags & FL_MOUNT) && !(flags & FL_HIERARCHY))
 		info("%s\n", cont_names);
-	}
-	if (!(flags & FL_MOUNT) && (flags & FL_HIERARCHY)) {
-		/* print only hierarchy name and number*/
+
+	/* print only hierarchy name and number*/
+	if (!(flags & FL_MOUNT) && (flags & FL_HIERARCHY))
 		info("%s %d\n", cont_names, hierarchy);
-	}
+
 	if (flags & FL_MOUNT) {
 		/* print hierarchy name and mount point(s) */
-		ret = cgroup_get_subsys_mount_point_begin(controller, &handle,
-							  path);
+		ret = cgroup_get_subsys_mount_point_begin(controller, &handle, path);
 		/* intentionally ignore error from above call */
 		while (ret == 0) {
 			info("%s %s\n", cont_names, path);
+			/* first mount record is enough */
 			if (!(flags & FL_MOUNT_ALL))
-				/* first mount record is enough */
 				goto stop;
 			ret = cgroup_get_subsys_mount_point_next(&handle, path);
 		}
@@ -84,8 +81,7 @@ stop:
 }
 
 /* display all controllers attached to the given hierarchy */
-static int print_all_controllers_in_hierarchy(const char *tname,
-					      int hierarchy, int flags)
+static int print_all_controllers_in_hierarchy(const char *tname, int hierarchy, int flags)
 {
 	struct controller_data info;
 	enum cg_version_t version;
@@ -96,8 +92,8 @@ static int print_all_controllers_in_hierarchy(const char *tname,
 	int ret = 0;
 
 	/*
-	 * Initialize libcgroup and intentionally ignore its result,
-	 * no mounted controller is valid use case.
+	 * Initialize libcgroup and intentionally ignore its result, no
+	 * mounted controller is valid use case.
 	 */
 	(void) cgroup_init();
 
@@ -113,8 +109,8 @@ static int print_all_controllers_in_hierarchy(const char *tname,
 			goto end;
 
 		/*
-		 * v1 controllers should be in the hierachy.  v2 controllers
-		 * will have a hierarchy value of zero
+		 * v1 controllers should be in the hierachy.
+		 * v2 controllers will have a hierarchy value of zero
 		 */
 		if (version == CGROUP_V1 && info.hierarchy != hierarchy)
 			goto next;
@@ -133,15 +129,14 @@ static int print_all_controllers_in_hierarchy(const char *tname,
 			strncat(cont_names, info.name, FILENAME_MAX-1);
 			cont_names[sizeof(cont_names) - 1] = '\0';
 		}
+
 next:
 		ret = cgroup_get_all_controller_next(&handle, &info);
 		if (ret && ret != ECGEOF)
 			goto end;
 	}
 
-	ret = print_controller_mount(cont_name,
-		flags, cont_names, hierarchy);
-
+	ret = print_controller_mount(cont_name, flags, cont_names, hierarchy);
 end:
 	cgroup_get_all_controller_end(&handle);
 
@@ -153,11 +148,11 @@ end:
 
 
 /*
- * go through the list of all controllers gather them based on hierarchy number
- * and print them
+ * go through the list of all controllers gather them based on hierarchy
+ * number and print them
  */
-static int cgroup_list_all_controllers(const char *tname,
-	cont_name_t cont_name[CG_CONTROLLER_MAX], int c_number, int flags)
+static int cgroup_list_all_controllers(const char *tname, cont_name_t cont_name[CG_CONTROLLER_MAX],
+				       int c_number, int flags)
 {
 	struct controller_data info;
 	int h_list[CG_CONTROLLER_MAX];	/* list of hierarchies */
@@ -171,9 +166,10 @@ static int cgroup_list_all_controllers(const char *tname,
 	while (ret == 0) {
 		if (info.hierarchy == 0) {
 			/* the controller is not attached to any hierachy */
-			if (flags & FL_ALL)
+			if (flags & FL_ALL) {
 				/* display only if -a flag is set */
 				info("%s\n", info.name);
+			}
 		}
 		is_on_list = 0;
 		j = 0;
@@ -185,15 +181,13 @@ static int cgroup_list_all_controllers(const char *tname,
 			j++;
 		}
 
-		if ((info.hierarchy != 0) &&
-			((flags & FL_ALL) ||
-			(!(flags & FL_LIST) || (is_on_list == 1)))) {
+		if ((info.hierarchy != 0) && ((flags & FL_ALL) ||
+		    (!(flags & FL_LIST) || (is_on_list == 1)))) {
 			/*
-			 * the controller is attached to some hierarchy and
-			 * either should be output all controllers, or the
-			 * controller is on the output list
+			 * the controller is attached to some hierarchy
+			 * and either should be output all controllers,
+			 * or the controller is on the output list
 			 */
-
 			h_list[counter] = info.hierarchy;
 			counter++;
 			for (j = 0; j < counter-1; j++) {
@@ -214,15 +208,12 @@ static int cgroup_list_all_controllers(const char *tname,
 	if (ret == ECGEOF)
 		ret = 0;
 	if (ret) {
-		err("cgroup_get_controller_begin/next failed (%s)\n",
-		    cgroup_strerror(ret));
+		err("cgroup_get_controller_begin/next failed (%s)\n", cgroup_strerror(ret));
 		return ret;
 	}
 
-
 	for (j = 0; j < counter; j++)
-		ret = print_all_controllers_in_hierarchy(tname,
-			h_list[j], flags);
+		ret = print_all_controllers_in_hierarchy(tname,	h_list[j], flags);
 
 	return ret;
 }

--- a/src/tools/tools-common.c
+++ b/src/tools/tools-common.c
@@ -23,8 +23,7 @@
 
 #include <sys/types.h>
 
-int parse_cgroup_spec(struct cgroup_group_spec **cdptr, char *optarg,
-		      int capacity)
+int parse_cgroup_spec(struct cgroup_group_spec **cdptr, char *optarg, int capacity)
 {
 	char *cptr = NULL, *pathptr = NULL, *temp;
 	struct cgroup_group_spec *ptr;
@@ -40,8 +39,7 @@ int parse_cgroup_spec(struct cgroup_group_spec **cdptr, char *optarg,
 
 	if (i == capacity) {
 		/* No free slot found */
-		fprintf(stderr, "Max allowed hierarchies %d reached\n",
-			capacity);
+		fprintf(stderr, "Max allowed hierarchies %d reached\n", capacity);
 		return -1;
 	}
 
@@ -125,8 +123,7 @@ void cgroup_free_group_spec(struct cgroup_group_spec *cl)
 }
 
 
-int cgroup_string_list_init(struct cgroup_string_list *list,
-			    int initial_size)
+int cgroup_string_list_init(struct cgroup_string_list *list, int initial_size)
 {
 	if (list == NULL)
 		return ECGINVAL;
@@ -157,15 +154,13 @@ void cgroup_string_list_free(struct cgroup_string_list *list)
 	free(list->items);
 }
 
-int cgroup_string_list_add_item(struct cgroup_string_list *list,
-				const char *item)
+int cgroup_string_list_add_item(struct cgroup_string_list *list, const char *item)
 {
 	if (list == NULL)
 		return ECGINVAL;
 
 	if (list->size <= list->count) {
-		char **tmp = realloc(list->items,
-				sizeof(char *) * list->size*2);
+		char **tmp = realloc(list->items, sizeof(char *) * list->size*2);
 		if (tmp == NULL)
 			return ECGFAIL;
 		list->items = tmp;
@@ -189,8 +184,8 @@ static int _compare_string(const void *a, const void *b)
 }
 
 
-int cgroup_string_list_add_directory(struct cgroup_string_list *list,
-				     char *dirname, char *program_name)
+int cgroup_string_list_add_directory(struct cgroup_string_list *list, char *dirname,
+				     char *program_name)
 {
 	int start, ret, count = 0;
 	struct dirent *item;
@@ -203,36 +198,33 @@ int cgroup_string_list_add_directory(struct cgroup_string_list *list,
 
 	d = opendir(dirname);
 	if (!d) {
-		fprintf(stderr, "%s: cannot open %s: %s\n", program_name,
-			dirname, strerror(errno));
+		fprintf(stderr, "%s: cannot open %s: %s\n", program_name, dirname,
+			strerror(errno));
 		exit(1);
 	}
 
 	do {
 		errno = 0;
 		item = readdir(d);
-		if (item && (item->d_type == DT_REG ||
-			     item->d_type == DT_LNK)) {
+		if (item && (item->d_type == DT_REG || item->d_type == DT_LNK)) {
 			char *tmp;
 
 			ret = asprintf(&tmp, "%s/%s", dirname, item->d_name);
 			if (ret < 0) {
-				fprintf(stderr, "%s: out of memory\n",
-					program_name);
+				fprintf(stderr, "%s: out of memory\n", program_name);
 				exit(1);
 			}
 			ret = cgroup_string_list_add_item(list, tmp);
 			free(tmp);
 			count++;
 			if (ret) {
-				fprintf(stderr, "%s: %s\n", program_name,
-					cgroup_strerror(ret));
+				fprintf(stderr, "%s: %s\n", program_name, cgroup_strerror(ret));
 				exit(1);
 			}
 		}
 		if (!item && errno) {
-			fprintf(stderr, "%s: cannot read %s: %s\n",
-				program_name, dirname, strerror(errno));
+			fprintf(stderr, "%s: cannot read %s: %s\n", program_name, dirname,
+				strerror(errno));
 			exit(1);
 		}
 	} while (item != NULL);
@@ -240,11 +232,10 @@ int cgroup_string_list_add_directory(struct cgroup_string_list *list,
 
 	/* sort the names found in the directory */
 	if (count > 0)
-		qsort(&list->items[start], count, sizeof(char *),
-		      _compare_string);
+		qsort(&list->items[start], count, sizeof(char *), _compare_string);
+
 	return 0;
 }
-
 
 /* allowed mode strings are octal version: "755" */
 int parse_mode(char *string, mode_t *pmode, const char *program_name)
@@ -271,8 +262,7 @@ err:
 	return -1;
 }
 
-int parse_uid_gid(char *string, uid_t *uid, gid_t *gid,
-		  const char *program_name)
+int parse_uid_gid(char *string, uid_t *uid, gid_t *gid, const char *program_name)
 {
 	char *grp_string = NULL;
 	char *pwd_string = NULL;
@@ -294,18 +284,18 @@ int parse_uid_gid(char *string, uid_t *uid, gid_t *gid,
 		if (pwd != NULL) {
 			*uid = pwd->pw_uid;
 		} else {
-			fprintf(stderr, "%s: can't find uid of user %s.\n",
-				program_name, pwd_string);
+			fprintf(stderr, "%s: can't find uid of user %s.\n", program_name,
+				pwd_string);
 			return -1;
 		}
 	}
 	if (grp_string != NULL) {
 		grp = getgrnam(grp_string);
-		if (grp != NULL)
+		if (grp != NULL) {
 			*gid = grp->gr_gid;
-		else {
-			fprintf(stderr, "%s: can't find gid of group %s.\n",
-				program_name, grp_string);
+		} else {
+			fprintf(stderr, "%s: can't find gid of group %s.\n", program_name,
+				grp_string);
 			return -1;
 		}
 	}

--- a/src/tools/tools-common.h
+++ b/src/tools/tools-common.h
@@ -19,10 +19,10 @@ extern "C" {
 
 #include <libcgroup.h>
 
-#define cgroup_err(x...) cgroup_log(CGROUP_LOG_ERROR, "Error: " x)
-#define cgroup_warn(x...) cgroup_log(CGROUP_LOG_WARNING, "Warning: " x)
-#define cgroup_info(x...) cgroup_log(CGROUP_LOG_INFO, "Info: " x)
-#define cgroup_dbg(x...) cgroup_log(CGROUP_LOG_DEBUG, x)
+#define cgroup_err(x...)	cgroup_log(CGROUP_LOG_ERROR, "Error: " x)
+#define cgroup_warn(x...)	cgroup_log(CGROUP_LOG_WARNING, "Warning: " x)
+#define cgroup_info(x...)	cgroup_log(CGROUP_LOG_INFO, "Info: " x)
+#define cgroup_dbg(x...)	cgroup_log(CGROUP_LOG_DEBUG, x)
 
 #define err(x...)	fprintf(stderr, x)
 #define info(x...)	fprintf(stdout, x)
@@ -49,16 +49,16 @@ struct cgroup_string_list {
  * The option must have form of 'controller1,controller2,..:group_name'.
  *
  * The parsed list of controllers and group name is added at the end of
- * provided cdptr, i.e. on place of first NULL cgroup_group_spec*.
+ * provided cdptr,
+ * i.e. on place of first NULL cgroup_group_spec*.
  *
- * @param cdptr Target data structure to fill. New item is allocated and added
- *		at the end.
+ * @param cdptr Target data structure to fill. New item is allocated and
+ *	added at the end.
  * @param optarg Argument to parse.
  * @param capacity The capacity of the cdptr array.
  * @return 0 on success, != 0 on error.
  */
-int parse_cgroup_spec(struct cgroup_group_spec **cdptr, char *optarg,
-		int capacity);
+int parse_cgroup_spec(struct cgroup_group_spec **cdptr, char *optarg, int capacity);
 
 /**
  * Free a single cgroup_group_spec structure.
@@ -66,14 +66,12 @@ int parse_cgroup_spec(struct cgroup_group_spec **cdptr, char *optarg,
  */
 void cgroup_free_group_spec(struct cgroup_group_spec *cl);
 
-
 /**
  * Initialize a new list.
  * @param list The list to initialize.
  * @param initial_size The initial size of the list to pre-allocate.
  */
-int cgroup_string_list_init(struct cgroup_string_list *list,
-			    int initial_size);
+int cgroup_string_list_init(struct cgroup_string_list *list, int initial_size);
 
 /**
  * Destroy a list, automatically freeing all its items.
@@ -82,26 +80,23 @@ int cgroup_string_list_init(struct cgroup_string_list *list,
 void cgroup_string_list_free(struct cgroup_string_list *list);
 
 /**
- * Adds new item to the list. It automatically resizes underlying array if
- * needed.
+ * Adds new item to the list. It automatically resizes underlying array if needed.
  * @param list The list to modify.
  * @param item The item to add. The item is automatically copied to new buffer.
  */
-int cgroup_string_list_add_item(struct cgroup_string_list *list,
-				const char *item);
+int cgroup_string_list_add_item(struct cgroup_string_list *list, const char *item);
 
 /**
- * Add alphabetically sorted files present in given directory (without subdirs)
- * to list of strings. The function exits on error.
+ * Add alphabetically sorted files present in given directory
+ * (without subdirs) to list of strings.
+ * The function exits on error.
  * @param list The list to add files to.
  * @param dirname Full path to directory to examime.
- * @param program_name Name of the executable, it will be used for printing
- * errors to stderr.
- *
+ * @param program_name Name of the executable, it will be used for
+ *	printing errors to stderr.
  */
-int cgroup_string_list_add_directory(struct cgroup_string_list *list,
-				     char *dirname, char *program_name);
-
+int cgroup_string_list_add_directory(struct cgroup_string_list *list, char *dirname,
+				     char *program_name);
 
 /**
  * Parse file permissions as octal number.
@@ -118,18 +113,16 @@ int parse_mode(char *string, mode_t *pmode, const char *program_name);
  * @param gid Parsed GID (-1 if 'group' is missing in the string).
  * @param program_name Argv[0] to show error messages.
  */
-int parse_uid_gid(char *string, uid_t *uid, gid_t *gid,
-		  const char *program_name);
+int parse_uid_gid(char *string, uid_t *uid, gid_t *gid, const char *program_name);
 
 /**
- * Functions that are defined as STATIC can be placed within the UNIT_TEST
- * ifdef.  This will allow them to be included in the unit tests while
- * remaining static in a normal libcgroup build.
+ * Functions that are defined as STATIC can be placed within the
+ * UNIT_TEST ifdef.  This will allow them to be included in the unit tests
+ * while remaining static in a normal libcgroup build.
  */
 #ifdef UNIT_TEST
 
-int parse_r_flag(const char * const program_name,
-		 const char * const name_value_str,
+int parse_r_flag(const char * const program_name, const char * const name_value_str,
 		 struct control_value * const name_value);
 
 #endif /* UNIT_TEST */


### PR DESCRIPTION
This patch series increases the source code column width to 100.
The 100-column width is more comfortable to read over 80 columns
and also introduces, and removes empty lines across the files, making
it more readable.

This is the third in the series of patch sets, that modifies `./src/tools/*` files.
