### PR TITLE
config: remove dead code in config_validate_namespaces()

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -831,12 +831,6 @@ static int config_validate_namespaces(void)
 		 */
 		mount_path = cg_mount_table[i].mount.path;
 
-		if (!mount_path) {
-			last_errno = errno;
-			error = ECGOTHER;
-			goto out_error;
-		}
-
 		/*
 		 * Setup the namespace for the subsystems having the same
 		 * mount point.


### PR DESCRIPTION
Remove the logically dead code, reported by the Coverity tool:

CID 258280 (#1 of 1): Logically dead code (DEADCODE)dead_error_begin:
Execution cannot reach this statement: last_errno = *__errno_locat....

cg_mount_table[i].mount.path can never be NULL, so remove that check in
the config_validate_namespaces().

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>