### PR TITLE
wrapper.c: return on failure in cgroup_add_all_controllers()

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -120,6 +120,7 @@ int cgroup_add_all_controllers(struct cgroup *cgroup)
 			ret = ECGINVAL;
 			fprintf(stderr, "controller %s can't be add\n",
 				info.name);
+			goto end;
 		}
 
 next:


### PR DESCRIPTION
Add missing goto statement, to return on failure, reported by Coverity
tool:

CID 258281 (#1 of 1): Unused value (UNUSED_VALUE)assigned_value:
Assigning value ECGINVAL to ret here, but that stored value is
overwritten before it can be used.

the tool reported about unused ret value, but it turned out that the
NULL ret value is for failed attempt to add a controller to the desired
cgroup and needs bailing out after losing the handle. Fix it by
introducing the goto statement in cgroup_add_all_controllers()

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>