### PR TITLE
config: fix string termination issues

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -591,14 +591,20 @@ void cgroup_config_cleanup_mount_table(void)
  */
 int cgroup_config_insert_into_namespace_table(char *name, char *nspath)
 {
+	char *ns_tbl_name, *ns_tbl_path;
 	if (namespace_table_index >= CG_CONTROLLER_MAX)
 		return 0;
 
 	pthread_rwlock_wrlock(&namespace_table_lock);
 
-	strcpy(config_namespace_table[namespace_table_index].name, name);
-	strcpy(config_namespace_table[namespace_table_index].mount.path,
-	       nspath);
+	ns_tbl_name = config_namespace_table[namespace_table_index].name;
+	strncpy(ns_tbl_name, name, CONTROL_NAMELEN_MAX - 1);
+	ns_tbl_name[CONTROL_NAMELEN_MAX - 1 ] = '\0';
+
+	ns_tbl_path = config_namespace_table[namespace_table_index].mount.path;
+	strncpy(ns_tbl_path, nspath, FILENAME_MAX - 1);
+	ns_tbl_path[FILENAME_MAX - 1] = '\0';
+
 	config_namespace_table[namespace_table_index].mount.next = NULL;
 	namespace_table_index++;
 


### PR DESCRIPTION
Fix non-terminated string warnings, reported by the Coverity tool:

CID 258293 (#2 of 2): Copy into fixed size buffer (STRING_OVERFLOW).
fixed_size_dest: You might overrun the 32-character fixed-size string
config_namespace_table[namespace_table_index].name by copying name
without checking the length.

fix one another similar string
config_namespace_table[namespace_table_index].mount.path in the same
function cgroup_config_insert_into_namespace_table() by explicitly
terminating by appending '\0';

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>