### PR TITLE
tools/cgget: fix a resource leak get_cv_value() [v2.0.2]

### DIFF
--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -509,7 +509,7 @@ static int get_cv_value(struct control_value * const cv,
 			tmp = realloc(cv->multiline_value, sizeof(char) *
 				(strlen(cv->multiline_value) + strlen(tmp_line) + 3));
 			if (tmp == NULL)
-				goto end;
+				goto read_end;
 
 			cv->multiline_value = tmp;
 			strcat(cv->multiline_value, "\n\t");


### PR DESCRIPTION
Fix a resource leak in get_cv_value(), reported by Coverity tool:

CID 258291 (#1 of 1): Resource leak (RESOURCE_LEAK). leaked_storage:
Variable handle going out of scope leaks the storage it points to.

failure on the realloc(), doesn't free the *handle. Fix it by using
the goto read_end(), that does the job of freeing the handle.

Suggested-by: Tom Hromatka <tom.hromatka@oracle.com>
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>