### PR TITLE
tools/cgxget: replace strcat() with strncat()

### DIFF
--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -560,11 +560,11 @@ static int indent_multiline_value(struct control_value * const cv)
 	char *tok, *saveptr = NULL;
 
 	tok = strtok_r(cv->value, "\n", &saveptr);
-	strcat(tmp_val, tok);
+	strncat(tmp_val, tok, CG_CONTROL_VALUE_MAX - 1);
 	/* don't indent the first value */
 	while ((tok = strtok_r(NULL, "\n", &saveptr))) {
-		strcat(tmp_val, "\n\t");
-		strcat(tmp_val, tok);
+		strncat(tmp_val, "\n\t", (CG_CONTROL_VALUE_MAX - (strlen(tmp_val) + 1)));
+		strncat(tmp_val, tok, (CG_CONTROL_VALUE_MAX - (strlen(tmp_val) + 1)));
 	}
 
 	cv->multiline_value = strdup(tmp_val);


### PR DESCRIPTION
Fix copy into fixed size buffer warning, reported by Coverity tool:

CID 258284 (#4 of 4): Copy into fixed size buffer (STRING_OVERFLOW)1.
fixed_size_dest: You might overrun the 4096-character fixed-size string
tmp_val by copying tok without checking the length.

In indent_multiline_value(), warned about the usage of strcat(), that
might overwrite the string. Fix it by replacing strcat() -> strncat()
in the function.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>