### PR TITLE
api.c: add ret value fix in cgroup_change_cgroup_flags() [v2.0.2]

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -4113,6 +4113,11 @@ int cgroup_change_cgroup_flags(uid_t uid, gid_t gid,
 
 			cgroup_dbg("control group %s is template\n", newdest);
 			ret = cgroup_create_template_group(newdest, tmp, flags);
+			if (ret) {
+				cgroup_warn("failed to create cgroup based on template %s\n",
+					    newdest);
+				goto finished;
+			}
 		}
 
 		/* Apply the rule */


### PR DESCRIPTION
Fix the unused ret value warning, reported by Coverity:

CID 258304 (#1 of 1): Unused value (UNUSED_VALUE)returned_value:
Assigning value from cgroup_create_template_group(newdest, tmp, flags)
to ret here, but that stored value is overwritten before it can be used.

It turns out that cgroup_change_cgroup_flags(), calls the function
cgroup_create_template_group() to a cgroup based on a template, which
may fail and we don't check the return value for the error.  This fix
adds the check and bails out on error.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>