### PR TITLE
tools/cgsnapshot: add ret value fix in parse_controllers()

### DIFF
--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -541,6 +541,8 @@ static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX], const ch
 			    (max != 0)) {
 				(controllers[max])[0] = '\0';
 				ret = display_controller_data(controllers, program_name);
+				if (ret)
+					goto err;
 			}
 
 			strncpy(controllers[0], controller.name, FILENAME_MAX);
@@ -560,6 +562,7 @@ static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX], const ch
 		ret = display_controller_data(controllers, program_name);
 	}
 
+err:
 	cgroup_get_controller_end(&handle);
 	if (ret != ECGEOF)
 		return ret;


### PR DESCRIPTION
Fix the unused ret value warning, reported by Coverity:

CID 258275 (#1 of 1): Unused value (UNUSED_VALUE)returned_value:
Assigning value from display_controller_data(controllers, program_name)
to ret here, but that stored value is overwritten before it can be used.

The parse_controllers(), doesn't check for errors in the value returned
by display_controller_data(). The return value might very well contain
an error, that might go unnoticed. Fix it by adding a check for the
return value.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>