### PR TITLE
abstraction-cpu: fix resource leak in read_setting()

### DIFF
--- a/src/abstraction-cpu.c
+++ b/src/abstraction-cpu.c
@@ -40,10 +40,8 @@ static int read_setting(const char * const cgroup_name, const char * const contr
 		goto end;
 
 	*value = strdup(tmp_line);
-	if ((*value) == NULL) {
+	if ((*value) == NULL)
 		ret = ECGOTHER;
-		goto end;
-	}
 
 read_end:
 	cgroup_read_value_end(&handle);


### PR DESCRIPTION
Fix a resource leak, reported by Coverity tool:

CID 258274 (#1 of 1): Resource leak (RESOURCE_LEAK)6. leaked_storage:
Variable handle going out of scope leaks the storage it points to

In read_setting(), currently, we goto end label, on the failure of
strdup() before closing the handle, leaking the resource. Fix it by
removing the goto, that allows the code flow to close the handle and
execute the code under the end label.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>