### PR TITLE
wrapper.c: null terminate string in cgroup_new_cgroup() [v2.0.0]

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -48,7 +48,8 @@ struct cgroup *cgroup_new_cgroup(const char *name)
 		return NULL;
 
 	init_cgroup(cgroup);
-	strncpy(cgroup->name, name, sizeof(cgroup->name) - 1);
+	strncpy(cgroup->name, name, FILENAME_MAX - 1);
+	cgroup->name[FILENAME_MAX - 1] = '\0';
 
 	return cgroup;
 }


### PR DESCRIPTION
Fix non-terminated string warning, reported by Coverity tool:

CID 258290 (#1 of 1): String not null terminated (STRING_NULL)46.
string_null: Passing unterminated string aux_cgroup->name to
cgroup_create_cgroup, which expects a null-terminated string.

The call patch leading to this warning:
```
config.c::cgroup_config_create_template_group()
- wrapper.c::cgroup_new_cgroup()
```
fix it by null terminating the string.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>