### PR TITLE
api.c: fix string termination in cgroup_get_procname_from_procfs() [v2.0.0]

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -5301,7 +5301,7 @@ int cgroup_get_procname_from_procfs(pid_t pid, char **procname)
 	 * Get the full patch of process name from /proc/<pid>/exe.
 	 */
 	memset(buf, '\0', sizeof(buf));
-	sprintf(path, "/proc/%d/exe", pid);
+	snprintf(path, FILENAME_MAX, "/proc/%d/exe", pid);
 	if (readlink(path, buf, sizeof(buf)) < 0) {
 		/*
 		 * readlink() fails if a kernel thread, and a process


### PR DESCRIPTION
Fix non-terminated string warning, reported by Coverity tool:

CID 258273 (#2 of 2): String not null terminated (STRING_NULL)6.
string_null: Passing unterminated string buf to strdup, which expects a
null-terminated string.

use snprintf() instead of sprintf(), to string terminate
cgroup_get_procname_from_procfs().

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>