### PR TITLE
api: null terminate readlink buffer in cg_get_procname_from_proc_cmdl…

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -5218,6 +5218,9 @@ static int cg_get_procname_from_proc_cmdline(pid_t pid,
 	if (readlink(path, buf_cwd, sizeof(buf_cwd)) < 0)
 		return ECGROUPNOTEXIST;
 
+	/* readlink doesn't append a null */
+	buf_cwd[FILENAME_MAX - 1] = '\0';
+
 	sprintf(path, "/proc/%d/cmdline", pid);
 	f = fopen(path, "re");
 	if (!f)


### PR DESCRIPTION
…ine()

Fix readlink buffer null termination warning, reported by Coverity tool:

CID 258276 (#1 of 1): String not null terminated (STRING_NULL).
string_null: Passing unterminated string buf_cwd to strcat, which
expects a null-terminated string.

As per the man pages (man 2 readlink):
"readlink() does not append a null byte to buf.  It  will  (silently)
truncate the contents (to a length of bufsiz characters), in case the
buffer is too small to hold all of the contents."

Explicitly null terminate the buffer passed to readlink() in
cg_get_procname_from_proc_cmdline().

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>