### PR TITLE
api: null terminate readlink buffer in cgroup_get_procname_from_procfs() [v2.0.02]

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -5310,6 +5310,9 @@ int cgroup_get_procname_from_procfs(pid_t pid, char **procname)
 		*procname = pname_status;
 		return 0;
 	}
+	/* readlink doesn't append a null */
+	buf[FILENAME_MAX - 1] = '\0';
+
 	if (!strncmp(pname_status, basename(buf), TASK_COMM_LEN - 1)) {
 		/*
 		 * The taken process name from /proc/<pid>/status is


### PR DESCRIPTION
Fix readlink buffer null termination warning, reported by Coverity tool:

CID 258273 (#2 of 2): String not null terminated (STRING_NULL).
string_null: Passing unterminated string buf to strdup, which expects a
null-terminated string.

As per the man pages (man 2 readlink):
"readlink() does not append a null byte to buf.  It  will (silently)
truncate the contents (to a length of bufsiz characters), in case the
buffer is too small to hold all of the contents."

Explicitly null terminate the buffer passed to readlink() in
cgroup_get_procname_from_procfs()

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>