### PR TITLE
tools/cgget: fix resource leak in get_cv_value() [v2.0.2]

### DIFF
--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -496,7 +496,7 @@ static int get_cv_value(struct control_value * const cv,
 	strncpy(cv->value, tmp_line, CG_CONTROL_VALUE_MAX - 1);
 	cv->multiline_value = strdup(cv->value);
 	if (cv->multiline_value == NULL)
-		goto end;
+		goto read_end;
 
 	while((ret = cgroup_read_value_next(&handle, tmp_line, LL_MAX)) == 0) {
 		if (ret == 0) {


### PR DESCRIPTION
Fix a resource leak, reported by the Coverity tool:

CID 258291 (#1 of 1): Resource leak (RESOURCE_LEAK)8. leaked_storage:
Variable handle going out of scope leaks the storage it points to.

In get_cv_value(), currently, we goto end label, on the failure of
strdup() before closing the handle, leaking the resource. Fix it by
removing the goto, that allows the code flow to close the handle and
execute the code under the end label.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>