### PR TITLE
tools/cgxget: fix the resource leak in convert_cgroup()

### DIFF
--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -769,7 +769,7 @@ out:
 	if (ret != 0 && ret != ECGNOVERSIONCONVERT) {
 		/* The conversion failed */
 		for (j = 0; j < i; j++)
-			cgroup_free(&(cg_converted_list[i]));
+			cgroup_free(&(cg_converted_list[j]));
 	} else {
 		/*
 		 * The conversion succeeded or was unmappable.


### PR DESCRIPTION
Fix a resource leak warning reported by the Coverity tool:

CID 258272 (#1-2 of 2): Resource leak (RESOURCE_LEAK). leaked_storage:
Variable cg_converted_list going out of scope leaks the storage it
points to.

while free'ing() the cg_converted_list() via cgroup_free(), wrong array
index variable was passed, causing the resource leak. Fix it by passing
the right index variable.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>