### PR TITLE
api.c: check for invalid error code in cgroup_strerror()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -4558,10 +4558,15 @@ cleanup_path:
 
 const char *cgroup_strerror(int code)
 {
+	int idx = code % ECGROUPNOTCOMPILED;
+
 	if (code == ECGOTHER)
 		return strerror_r(cgroup_get_last_errno(), errtext, MAXLEN);
 
-	return cgroup_strerror_codes[code % ECGROUPNOTCOMPILED];
+	if (idx >= sizeof(cgroup_strerror_codes)/sizeof(cgroup_strerror_codes[0]))
+		return "Invalid error code";
+
+	return cgroup_strerror_codes[idx];
 }
 
 /**


### PR DESCRIPTION
Fix array overflow warning, reported by the Coverity tool:

CID 258309 (#1 of 1): Out-of-bounds read (OVERRUN). overrun-local:
Overrunning array cgroup_strerror_codes of 32 8-byte elements at element
index 49999 (byte offset 399999) using index code % ECGROUPNOTCOMPILED
(which evaluates to 49999).

there are chances of users passing error codes, resulting in crossing
the upper bound of the cgroup_strerror_codes[], fix it by introducing
bound checks.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>