### PR TITLE
tools/cgsnapshot: fix out-of-bounds write in parse_controllers() [v2.0.2]

### DIFF
--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -566,7 +566,7 @@ static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX],
 			/* we got new mount point, print it if needed */
 			if ((!(flags & FL_LIST) ||
 				(is_ctlr_on_list(controllers, cont_names)))
-				&& (max != 0)) {
+				&& (max != 0 && max < CG_CONTROLLER_MAX)) {
 				(controllers[max])[0] = '\0';
 				ret = display_controller_data(
 					controllers, program_name);
@@ -586,7 +586,7 @@ static int parse_controllers(cont_name_t cont_names[CG_CONTROLLER_MAX],
 
 	if ((!(flags & FL_LIST) ||
 		(is_ctlr_on_list(controllers, cont_names)))
-		&& (max != 0)) {
+		&& (max != 0 && max < CG_CONTROLLER_MAX)) {
 		(controllers[max])[0] = '\0';
 		ret = display_controller_data(
 			controllers, program_name);


### PR DESCRIPTION
Fix Out-of-bounds write warning, reported by Coverity tool:

CID 258289 (#2 of 2): Out-of-bounds write (OVERRUN)16. overrun-local:
Overrunning array controllers of 100 4096-byte elements at element index
100 (byte offset 413695) using index max (which evaluates to 100).

there are chances, that the index variable max dereferences controller
array might be over the array size of 100. Add upper bound checks
to index variable max, so that it doesn't overrun the controller array.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>