### PR TITLE
api.c: fix null deference in is_cgrp_ctrl_shared_mnt()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -2734,6 +2734,9 @@ static int is_cgrp_ctrl_shared_mnt(char *controller)
 	int ret = 0;
 	int i;
 
+	if (!controller)
+		return ret;
+
 	pthread_rwlock_rdlock(&cg_mount_table_lock);
 
 	for (i = 0; cg_mount_table[i].name[0] != '\0'; i++) {


### PR DESCRIPTION
Fix explicit null dereferenced warning, reported by Coverity tool:

CID 258306 (#1 of 1): Explicit null dereferenced (FORWARD_NULL).
var_deref_model: Passing null pointer controller_name to
cgroup_find_parent, which dereferences it.

the code path which leads to the null dereference:
```
cgroup_delete_cgroup_ext()
- cgroup_find_parent()
  - is_cgrp_ctrl_shared_mnt()
```
is_cgrp_ctrl_shared_mnt(), assumes that the controller_name is non-NULL
but there are changes that, this static function might be called with
NULL controller_name, let's fix it with a check.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>