### PR TITLE
daemon/cgrulesengd: check the bytes read in cgre_receive_unix_domain_… [v2.0.2]

### DIFF
--- a/src/daemon/cgrulesengd.c
+++ b/src/daemon/cgrulesengd.c
@@ -609,6 +609,7 @@ static void cgre_receive_unix_domain_msg(int sk_unix)
 	socklen_t caddr_len;
 	struct stat buff_stat;
 	char path[FILENAME_MAX];
+	size_t ret_len;
 
 	caddr_len = sizeof(caddr);
 	fd_client = accept(sk_unix, (struct sockaddr *)&caddr, &caddr_len);
@@ -629,7 +630,8 @@ static void cgre_receive_unix_domain_msg(int sk_unix)
 				pid);
 		goto close;
 	}
-	if (read(fd_client, &flags, sizeof(flags)) < 0) {
+	ret_len = read(fd_client, &flags, sizeof(flags));
+	if (ret_len != sizeof(flags)) {
 		flog(LOG_WARNING, "Warning: error reading daemon socket: %s\n",
 				strerror(errno));
 		goto close;


### PR DESCRIPTION
…msg()

Fix ignoring the number of bytes read, warning reported by Coverity
tool:

CID 258286 (#2 of 2): Ignoring number of bytes read (CHECKED_RETURN).
check_return: read(int, void *, size_t) returns the number of bytes
read, but it is ignored.

In cgre_receive_unix_domain_msg(), the number of bytes read() is
ignored, while reading from the flag value from the socket. Coverity
warns on not checking the number of bytes read, fix it.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>