### PR TITLE
api.c: fix dereference after null check

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -5862,6 +5862,9 @@ int cgroup_get_controller_version(const char * const controller, enum cg_version
 		return 0;
 	}
 
+	if (!controller)
+		return ECGINVAL;
+
 	*version = CGROUP_UNK;
 
 	for (i = 0; cg_mount_table[i].name[0] != '\0'; i++) {


### PR DESCRIPTION
Fix dereference after null check warning, reported by Coverity tool:

CID 258308 (#1 of 1): Dereference after null check (FORWARD_NULL).
var_deref_model: Passing null pointer controller to strncmp, which
dereferences it.

Fix the warning in cgroup_get_controller_version(), by checking for the
an empty controller in the case of cgroup v1.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>