### PR TITLE
tools/cgxget: de-allocate cg_convert_list[] in convert_cgroup()

### DIFF
--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -770,6 +770,7 @@ out:
 		/* The conversion failed */
 		for (j = 0; j < i; j++)
 			cgroup_free(&(cg_converted_list[j]));
+		free(cg_converted_list);
 	} else {
 		/*
 		 * The conversion succeeded or was unmappable.


### PR DESCRIPTION
The commit 66799b867c7 (tools/cgxget: fix the resource leak in
convert_cgroup()), is a partial fix. It de-allocated the array members
of the dynamically allocated cg_converted_list[], but fails to free()
the cg_converted_list.  Fix the resource leak by de-allocating it.

Fixes: 66799b867c7 (tools/cgxget: fix the resource leak in convert_group)
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>