### PR TITLE
api.c: add precision to fscanf(), in cgroup_get_all_controller_next() [v2.0.2]

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -5454,7 +5454,11 @@ int cgroup_get_all_controller_next(void **handle, struct controller_data *info)
 	if (!info)
 		return ECGINVAL;
 
-	err = fscanf(proc_cgroup, "%s %d %d %d\n", subsys_name,
+	/*
+	 * check Linux Kernel sources/kernel/cgroup/cgroup.c cgroup_init_early(),
+	 * MAX_CGROUP_TYPE_NAMELEN check for details on why 32 is used.
+	 */
+	err = fscanf(proc_cgroup, "%32s %d %d %d\n", subsys_name,
 			&hierarchy, &num_cgroups, &enabled);
 
 	if (err != 4)


### PR DESCRIPTION
Fix calling risky function warning, reported by Coverity tool:

CID 258300 (#1 of 1): Calling risky function
(DC.STREAM_BUFFER)dont_call: fscanf assumes an arbitrarily long string,
so callers must use correct precision specifiers or never use fscanf.

As per secure coding standard, using '%s' in the fscanf() is not
recommend, hence fix it by using the precision of macro
MAX_CGROUP_TYPE_NAMELEN borrowed from Linux Kernel for the maximum
allowed controller/subsys_name length.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>