### PR TITLE
api.c: add precision to fscanf(), in cgroup_get_current_controller_pa…

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -4526,7 +4526,11 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller, char *
 		char *token;
 		int num;
 
-		ret = fscanf(pid_cgroup_fd, "%d:%[^:]:%s\n", &num, controllers, cgroup_path);
+		/*
+		 * 4096 == FILENAME_MAX, keeping the coverity happy with precision
+		 * for the cgroup_path.
+		 */
+		ret = fscanf(pid_cgroup_fd, "%d:%[^:]:%4096s\n", &num, controllers, cgroup_path);
 		/*
 		 * Magic numbers like "3" seem to be integrating into my daily
 		 * life, I need some magic to help make them disappear :)


### PR DESCRIPTION
…th()

Fix calling risky function warning, reported by Coverity tool:

CID 258301 (#1 of 1): Calling risky function
(DC.STREAM_BUFFER)dont_call: fscanf assumes an arbitrarily long string,
so callers must use correct precision specifiers or never use fscanf.

As per secure coding standard, using '%s' in the fscanf() is not
recommend, hence fix it by using the precision of macro
MAX_CGROUP_TYPE_NAMELEN borrowed from Linux Kernel for the maximum
allowed controller/subsys_name length.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>