### PR TITLE
daemon/cgrulesengd: check the bytes read in cgre_receive_unix_domain_…

### DIFF
--- a/src/daemon/cgrulesengd.c
+++ b/src/daemon/cgrulesengd.c
@@ -619,7 +619,8 @@ static void cgre_receive_unix_domain_msg(int sk_unix)
 		return;
 	}
 
-	if (read(fd_client, &pid, sizeof(pid)) < 0) {
+	ret_len = read(fd_client, &pid, sizeof(pid));
+	if (ret_len != sizeof(pid)) {
 		flog(LOG_WARNING, "Warning: 'read' command error: %s\n", strerror(errno));
 		goto close;
 	}


### PR DESCRIPTION
…msg()

Fix ignoring the number of bytes read, warning reported by Coverity
tool:

CID 258286 (#1 of 1): Ignoring number of bytes read (CHECKED_RETURN).
check_return: read(int, void *, size_t) returns the number of bytes
read, but it is ignored.

In cgre_receive_unix_domain_msg(), the number of bytes read() is
ignored, while reading from the flag value of the pid. Coverity warns on
not checking the number of bytes read, fix it.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>