### PR TITLE
api.c: fix TOCTOU in cg_chmod_path()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -212,16 +212,20 @@ int cg_chmod_path(const char *path, mode_t mode, int owner_is_umask)
 {
 	mode_t mask = -1U;
 	struct stat buf;
+	int fd = -1;
 
 	if (owner_is_umask) {
 		mode_t umask, gmask, omask;
 
+		fd = open(path, O_RDONLY);
+		if (fd == -1)
+			goto fail;
 		/*
 		 * Use owner permissions as an umask for group and others
 		 * permissions because we trust kernel to initialize owner
 		 * permissions to something useful.  Keep SUID and SGID bits.
 		 */
-		if (stat(path, &buf) == -1)
+		if (fstat(fd, &buf) == -1)
 			goto fail;
 
 		/* 0700 == S_IRWXU */
@@ -232,14 +236,19 @@ int cg_chmod_path(const char *path, mode_t mode, int owner_is_umask)
 		mask = umask|gmask|omask|S_ISUID|S_ISGID|S_ISVTX;
 	}
 
-	if (chmod(path, mode & mask))
+	if (fchmod(fd, mode & mask))
 		goto fail;
+
+	close(fd);
 
 	return 0;
 
 fail:
 	cgroup_warn("cannot change permissions of file %s: %s\n", path, strerror(errno));
 	last_errno = errno;
+
+	if (fd > 0)
+		close(fd);
 
 	return ECGOTHER;
 }


### PR DESCRIPTION
Fix TOCTOU warning, reported by Coverity Tool:

CID 258267 (#1 of 1): Time of check time of use (TOCTOU)2.
fs_check_call: Calling function stat to perform check on path.

in cg_chmod_path(), the file name is stat() and not immediately followed
by the file operation. One way to fix it, open the file and use the file
descriptor to manipulate the file.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>