### PR TITLE
log: introduce CGROUP_LOG_CONT level for logging 

### DIFF
--- a/include/libcgroup/log.h
+++ b/include/libcgroup/log.h
@@ -72,10 +72,15 @@ extern "C" {
  */
 enum cgroup_log_level {
 	/**
+	 * Continue printing the log message, with the previous log level.
+	 * Used to print log messages without the line break.
+	 */
+	CGROUP_LOG_CONT = 0,
+	/**
 	 * Something serious happened and libcgroup failed to perform requested
 	 * operation.
 	 */
-	CGROUP_LOG_ERROR = 1,
+	CGROUP_LOG_ERROR,
 	/**
 	 * Something bad happened but libcgroup recovered from the error.
 	 */

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -70,10 +70,11 @@ extern "C" {
 
 #define CGROUP_FILE_PREFIX	"cgroup"
 
-#define cgroup_err(x...) cgroup_log(CGROUP_LOG_ERROR, "Error: " x)
-#define cgroup_warn(x...) cgroup_log(CGROUP_LOG_WARNING, "Warning: " x)
-#define cgroup_info(x...) cgroup_log(CGROUP_LOG_INFO, "Info: " x)
-#define cgroup_dbg(x...) cgroup_log(CGROUP_LOG_DEBUG, x)
+#define cgroup_err(x...)	cgroup_log(CGROUP_LOG_ERROR, "Error: " x)
+#define cgroup_warn(x...)	cgroup_log(CGROUP_LOG_WARNING, "Warning: " x)
+#define cgroup_info(x...)	cgroup_log(CGROUP_LOG_INFO, "Info: " x)
+#define cgroup_dbg(x...)	cgroup_log(CGROUP_LOG_DEBUG, x)
+#define cgroup_cont(x...)	cgroup_log(CGROUP_LOG_CONT, x)
 
 #define CGROUP_DEFAULT_LOGLEVEL CGROUP_LOG_ERROR
 

--- a/src/tools/tools-common.h
+++ b/src/tools/tools-common.h
@@ -23,6 +23,7 @@ extern "C" {
 #define cgroup_warn(x...)	cgroup_log(CGROUP_LOG_WARNING, "Warning: " x)
 #define cgroup_info(x...)	cgroup_log(CGROUP_LOG_INFO, "Info: " x)
 #define cgroup_dbg(x...)	cgroup_log(CGROUP_LOG_DEBUG, x)
+#define cgroup_cont(x...)	cgroup_log(CGROUP_LOG_CONT, x)
 
 #define err(x...)	fprintf(stderr, x)
 #define info(x...)	fprintf(stdout, x)


### PR DESCRIPTION
There are cases, where we might want to print a very long/multiline log
message to the user. We could call the cgroup_log(), multiple times to
fit the log message, but the downside is that every time the
cgroup_log() called, the log level is prefixed to the message, hence
introducing loglevel char string in the mid of the log message.
For example, calling the cgroup_warn() twice to print a long warning:
```
cgroup_warn("cgroup v1 expects /proc/cgroup, check if ");
cgroup_warn("/proc mounted with subset=pid option\n");
```
output:
-------
```
$ sudo CGROUP_LOGLEVEL=DEBUG ./src/tools/cgget -g cpu:user.slice
...
Warning: cgroup v1 expects /proc/cgroup, check if Warning: /proc mounted
with subset=pid option
```
Introduce a new logging level, CGROUP_LOG_CONT and cgroup_cont() macro,
that will continue printing the log message, when loglevel is set to other
than default log level. The above code can be rewritten as:
```
cgroup_warn("cgroup v1 expects/proc/cgroup, check if ");
cgroup_cont("/proc mounted with subset=pid option\n");
```
output:
-------
```
$ sudo CGROUP_LOGLEVEL=DEBUG ./src/tools/cgget -g cpu:user.slice
...
Warning: cgroup v1 expects /proc/cgroup, check if /proc mounted with
subset=pid option
```
Also, make comsetic changes to cgroup_*().

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>