### PR TITLE
api: Use GNU strerror_r when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,11 @@ AC_FUNC_REALLOC
 AC_FUNC_STAT
 AC_CHECK_FUNCS([getmntent hasmntopt memset mkdir rmdir strdup])
 
+orig_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -D_GNU_SOURCE"
+AC_FUNC_STRERROR_R
+CFLAGS="$orig_CFLAGS"
+
 AC_SEARCH_LIBS(
 	[fts_open],
 	[fts],

--- a/src/api.c
+++ b/src/api.c
@@ -4571,9 +4571,13 @@ const char *cgroup_strerror(int code)
 {
 	int idx = code % ECGROUPNOTCOMPILED;
 
-	if (code == ECGOTHER)
+	if (code == ECGOTHER) {
+#ifdef STRERROR_R_CHAR_P
 		return strerror_r(cgroup_get_last_errno(), errtext, MAXLEN);
-
+#else
+		return strerror_r(cgroup_get_last_errno(), errtext, sizeof (errtext)) ? "unknown error" : errtext;
+#endif
+	}
 	if (idx >= sizeof(cgroup_strerror_codes)/sizeof(cgroup_strerror_codes[0]))
 		return "Invalid error code";
 


### PR DESCRIPTION
GNU strerror_r is only available in glibc, musl impelents the XSI
version which is slightly different, therefore check if GNU version is
available before using it, otherwise use the XSI compliant version.

Signed-off-by: Khem Raj <raj.khem@gmail.com>