### PR TITLE
support /proc mounted with subset=pid [v3.0+] 

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1407,7 +1407,7 @@ err:
 }
 
 /*
- * Reads /proc/mounts and populates the cgroup v1/v2 mount points into the
+ * Reads /proc/self/mounts and populates the cgroup v1/v2 mount points into the
  * global cg_mount_table.
  * This function should be called with cg_mount_table_lock taken.
  */
@@ -1419,9 +1419,9 @@ static int cgroup_populate_mount_points(char *controllers[CG_CONTROLLER_MAX])
 	FILE *proc_mount;
 	int ret = 0;
 
-	proc_mount = fopen("/proc/mounts", "re");
+	proc_mount = fopen("/proc/self/mounts", "re");
 	if (proc_mount == NULL) {
-		cgroup_err("cannot open /proc/mounts: %s\n", strerror(errno));
+		cgroup_err("cannot open /proc/self/mounts: %s\n", strerror(errno));
 		last_errno = errno;
 		ret = ECGOTHER;
 		goto err;
@@ -1537,7 +1537,7 @@ static int cg_test_mounted_fs(void)
 	FILE *proc_mount = NULL;
 	int ret = 1;
 
-	proc_mount = fopen("/proc/mounts", "re");
+	proc_mount = fopen("/proc/self/mounts", "re");
 	if (proc_mount == NULL)
 		return 0;
 


### PR DESCRIPTION
`/proc` filesystem can be mounted with `subset=pid` as one of its mount
options. This option hides all the top-level files and directories,
those are not related to processes. The cgroup v1 filesystem depends
on the `/proc/cgroups` to populate the cgroups controllers and will fail
during the `cgroup_init()` phase, when not available, whereas cgroup v2
considers this as a deprecated file and recommends reading the list of
controller from `<unified mount point>/cgroup.controllers`[1].

This patch series contains two patches. The first patch replaces the
`/proc/mounts` with `/proc/mounts` in `src/api.c`, as the file to read the
current mount points in the system and the second patch adds the support
for reading the controllers from the cgroup.controller, when the /proc
mount is mounted with `subset=pid` option only when the system is booted
with the unified mode and will fail to initialize in the case we find the
cgroup v1 mounted, i.e, the system booted with legacy or hybrid mode.

[1] https://docs.kernel.org/admin-guide/cgroup-v2.html#deprecated-v1-core-features
