### PR TITLE
api.c: fix file open in cg_chmod_path()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -212,14 +212,14 @@ int cg_chmod_path(const char *path, mode_t mode, int owner_is_umask)
 {
 	mode_t mask = -1U;
 	struct stat buf;
-	int fd = -1;
+	int fd;
+
+	fd = open(path, O_RDONLY);
+	if (fd == -1)
+		goto fail;
 
 	if (owner_is_umask) {
 		mode_t umask, gmask, omask;
-
-		fd = open(path, O_RDONLY);
-		if (fd == -1)
-			goto fail;
 		/*
 		 * Use owner permissions as an umask for group and others
 		 * permissions because we trust kernel to initialize owner


### PR DESCRIPTION
In cg_chmod_path(), the commit 8b9665c29cb8 ("api.c: fix TOCTOU in
cg_chmod_path()), converted the file operations from stat -> fstat and
chmod -> fchmod to fix a Coverity warning.  The newly replaced file
operations operate on file descriptors and hence introduced a side
effect of opening the file at the wrong code block, that would only work
as expected when the caller calls cg_chmod_path() with owner_is_umask
set.

Fix it by moving the file operation out of the conditional block, so it
works in both of the cases of owner_is_umask being set or unset.

Fixes: 8b9665c29cb8 ("api.c: fix TOCTOU in cg_chmod_path())
Suggested-by: Tom Hromatka <tom.hromatka@oracle.com>
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>