### PR TITLE
Use Automake DIST_SUBDIRS [v3.0+]

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,7 @@
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS= -I m4
-SUBDIRS = dist doc include samples scripts src
-if WITH_TESTS
-SUBDIRS += tests
-endif
+DIST_SUBDIRS = dist doc include scripts src tests samples
+SUBDIRS = $(DIST_SUBDIRS)
 
 EXTRA_DIST = README_daemon libcgroup.doxyfile README_systemd CONTRIBUTING.md
 

--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,9 @@ AC_CONFIG_FILES([Makefile
 	scripts/Makefile
 	scripts/init.d/cgconfig
 	scripts/init.d/cgred
+	tests/Makefile
+	tests/ftests/Makefile
+	tests/gunit/Makefile
 	samples/Makefile
 	samples/c/Makefile
 	samples/config/Makefile
@@ -227,10 +230,6 @@ AC_CONFIG_FILES([Makefile
 	doc/man/Makefile
 	dist/Makefile
 	libcgroup.pc])
-AM_COND_IF([WITH_TESTS],
-	[AC_CONFIG_FILES([tests/Makefile
-		tests/ftests/Makefile
-		tests/gunit/Makefile])])
 AC_CONFIG_FILES([dist/libcgroup.spec:dist/libcgroup.spec.in])
 CFLAGS="$CFLAGS -Wall"
 AC_OUTPUT

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,2 +1,3 @@
-SUBDIRS = man
+DIST_SUBDIRS = man
+SUBDIRS = $(DIST_SUBDIRS)
 

--- a/samples/Makefile.am
+++ b/samples/Makefile.am
@@ -1,1 +1,2 @@
-SUBDIRS = config c
+DIST_SUBDIRS = config c
+SUBDIRS = $(DIST_SUBDIRS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,6 +2,7 @@
 
 BUILT_SOURCES = parse.c parse.h
 
+DIST_SUBDIRS = . daemon pam tools python
 SUBDIRS = . daemon pam tools
 if ENABLE_PYTHON
 SUBDIRS += python


### PR DESCRIPTION
This patchset, has two patches. Where the first one introduces `DIST_SUBDIRS`
to ship the directories/sub-directories as part of the tarball created using `make dist*`
and use `SUBDIRS` to add build conditions.

The second patch is built upon the usage of `DIST_SUBDIRS`, where it removes the
`AM_COND` for `--disable-tests` configure option from the list `AC_CONFIG_FILES`
and does a conditional build using `WITH_TESTS` in the makefile.