### PR TITLE
tools/cgsnapshot: fix wrong array size in is_ctrl_on_list() [v2.0]

### DIFF
--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -516,7 +516,7 @@ err:
 }
 
 static int is_ctlr_on_list(char controllers[CG_CONTROLLER_MAX][FILENAME_MAX],
-			cont_name_t wanted_conts[FILENAME_MAX])
+			cont_name_t wanted_conts[CG_CONTROLLER_MAX])
 {
 	int i = 0;
 	int j = 0;


### PR DESCRIPTION
GCC throws -Wstringop-overflow warning:
```
  CC       cgsnapshot-cgsnapshot.o
cgsnapshot.c: In function 'parse_controllers':
cgsnapshot.c:540:53: warning: 'is_ctlr_on_list' accessing 16777216 bytes in a region of size 409600 [-Wstringop-overflow=]
  540 |                         if ((!(flags & FL_LIST) || (is_ctlr_on_list(controllers, cont_names))) &&
      |                                                    ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cgsnapshot.c:540:53: note: referencing argument 2 of type 'char(*)[4096]'
cgsnapshot.c:495:12: note: in a call to function 'is_ctlr_on_list'
  495 | static int is_ctlr_on_list(char controllers[CG_CONTROLLER_MAX][FILENAME_MAX],
      |            ^~~~~~~~~~~~~~~
cgsnapshot.c:560:37: warning: 'is_ctlr_on_list' accessing 16777216 bytes in a region of size 409600 [-Wstringop-overflow=]
  560 |         if ((!(flags & FL_LIST) || (is_ctlr_on_list(controllers, cont_names))) &&
      |                                    ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cgsnapshot.c:560:37: note: referencing argument 2 of type 'char(*)[4096]'
cgsnapshot.c:495:12: note: in a call to function 'is_ctlr_on_list'
  495 | static int is_ctlr_on_list(char controllers[CG_CONTROLLER_MAX][FILENAME_MAX],
      |            ^~~~~~~~~~~~~~~
```
the warning is seen due to the mismatch in the array size of the second argument passed to is_ctlr_on_list() from parse_controllers().  Fix, this long standing warning by chaging the size of the second function argument in is_ctrl_on_list().

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>