### PR TITLE
Merge libcgroup-tests repo back into libcgroup repo [release-2.0]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = googletest
 	url = https://github.com/google/googletest.git
 	fetchRecurseSubmodules = true
-[submodule "tests"]
-	path = tests
-	url = https://github.com/libcgroup/libcgroup-tests.git

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,11 +11,6 @@ fi
 # update the git submodules - libcgroup-tests and googletest
 git submodule update --init --recursive
 
-# configure libcgroup-tests
-pushd tests
-git checkout release-2.0
-popd
-
 # configure googletest
 pushd googletest/googletest
 git checkout release-1.8.0

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,15 @@
+get_all_controller
+get_controller
+get_mount_point
+get_procs
+get_variable_names
+libcg_ba
+libcgrouptest01
+pathtest
+proctest
+read_stats
+setuid
+test_named_hierarchy
+walk_task
+walk_test
+wrapper_test

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,26 @@
+SUBDIRS = ftests gunit tools
+
+INCLUDES = -I$(top_srcdir)/include
+LDADD = $(top_builddir)/src/.libs/libcgroup.la
+
+libcgrouptest01_SOURCES=libcgrouptest01.c test_functions.c libcgrouptest.h
+libcg_ba_SOURCES=libcg_ba.cpp
+setuid_SOURCES=setuid.c
+walk_test_SOURCES=walk_test.c
+read_stats_SOURCES=read_stats.c
+walk_task_SOURCES=walk_task.c
+get_controller_SOURCES=get_controller.c
+get_mount_point_SOURCES=get_mount_point.c
+proctest_SOURCES=proctest.c
+get_all_controller_SOURCES=get_all_controller.c
+get_variable_names_SOURCES=get_variable_names.c
+test_named_hierarchy_SOURCES=test_named_hierarchy.c
+get_procs_SOURCES=get_procs.c
+wrapper_test_SOURCES=wrapper_test.c
+logger_SOURCES=logger.c
+
+EXTRA_DIST = runlibcgrouptest.sh logger.sh
+
+# The legacy tests have been disabled because they do not successfully run
+# on Travis CI.
+#TESTS = wrapper_test runlibcgrouptest.sh logger.sh

--- a/tests/ftests/.gitignore
+++ b/tests/ftests/.gitignore
@@ -1,0 +1,5 @@
+tmp.conf
+*.log
+*.pyc
+*.swp
+*.trs

--- a/tests/ftests/001-cgget-basic_cgget_v1.py
+++ b/tests/ftests/001-cgget-basic_cgget_v1.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Basic cgget functionality test
+#
+# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER='cpu'
+CGNAME="001cgget"
+
+SETTING='cpu.shares'
+VALUE='512'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 cpu controller"
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+    Cgroup.set(config, CGNAME, SETTING, VALUE)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    value = Cgroup.get(config, controller=None, cgname=CGNAME,
+                       setting=SETTING, print_headers=False,
+                       values_only=True)
+
+    if value != VALUE:
+        result = consts.TEST_FAILED
+        cause = "cgget expected {} but received {}".format(VALUE, value)
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/002-cgdelete-recursive_delete.py
+++ b/tests/ftests/002-cgdelete-recursive_delete.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+#
+# Cgroup recursive cgdelete functionality test
+#
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from process import Process
+import sys
+
+CONTROLLER = 'cpuset'
+PARENT = '002cgdelete'
+CHILD = 'childcg'
+GRANDCHILD = 'grandchildcg'
+
+def prereqs(config):
+    # This test should run on both cgroup v1 and v2
+    return consts.TEST_PASSED, None
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT)
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT, CHILD))
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT, CHILD, GRANDCHILD))
+
+    version = CgroupVersion.get_version(CONTROLLER)
+    if version == CgroupVersion.CGROUP_V1:
+        # cgdelete in a cgroup v1 controller should be able to move a process
+        # from a child cgroup to its parent.
+        #
+        # Moving a process from a child cgroup to its parent isn't (easily)
+        # supported in cgroup v2 because of cgroup v2's restriction that
+        # processes only be located in leaf cgroups
+        config.process.create_process_in_cgroup(config, CONTROLLER,
+                                         os.path.join(PARENT, CHILD, GRANDCHILD))
+
+def test(config):
+    Cgroup.delete(config, CONTROLLER, PARENT, recursive=True)
+
+    return consts.TEST_PASSED, None
+
+def teardown(config):
+    pass
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/003-cgget-basic_cgget_v2.py
+++ b/tests/ftests/003-cgget-basic_cgget_v2.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Basic cgget functionality test
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER='cpuset'
+CGNAME="003cgget"
+
+SETTING='cpuset.mems'
+VALUE='0'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v2 cpuset controller"
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+    Cgroup.set(config, CGNAME, SETTING, VALUE)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    value = Cgroup.get(config, controller=None, cgname=CGNAME,
+                       setting=SETTING, print_headers=False,
+                       values_only=True)
+
+    if value != VALUE:
+        result = consts.TEST_FAILED
+        cause = "cgget expected {} but received {}".format(VALUE, value)
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/004-cgsnapshot-basic_snapshot_v1.py
+++ b/tests/ftests/004-cgsnapshot-basic_snapshot_v1.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+#
+# Basic cgsnapshot functionality test
+#
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from run import Run
+import sys
+
+CONTROLLER='memory'
+CGNAME="004cgsnapshot"
+CGSNAPSHOT = """group 004cgsnapshot {
+                    memory {
+                            memory.use_hierarchy="1";
+                            memory.soft_limit_in_bytes="9223372036854771712";
+                            memory.force_empty="";
+                            memory.move_charge_at_immigrate="0";
+                            memory.kmem.tcp.max_usage_in_bytes="0";
+                            memory.max_usage_in_bytes="0";
+                            memory.oom_control="oom_kill_disable 0
+                                under_oom 0
+                                oom_kill 0"; 
+                            memory.limit_in_bytes="9223372036854771712";
+                            memory.swappiness="60";
+                            memory.kmem.failcnt="0";
+                            memory.kmem.max_usage_in_bytes="0";
+                            memory.failcnt="0";
+                            memory.kmem.tcp.failcnt="0";
+                            memory.kmem.limit_in_bytes="9223372036854771712";
+                            memory.use_hierarchy="1";
+                            memory.kmem.tcp.limit_in_bytes="9223372036854771712";
+"""
+
+CGSNAPSHOT_SWAP = """                            memory.memsw.failcnt="0";
+                            memory.memsw.limit_in_bytes="9223372036854771712";
+                            memory.memsw.max_usage_in_bytes="0";
+                    }
+            }"""
+
+CGSNAPSHOT_NOSWAP = """                    }
+            }"""
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 memory controller"
+        return result, cause
+
+    if not config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test must be run within a container"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        # check if the memsw.failcnt file exists.  if so, add it to the
+        # expected snapshot
+        Cgroup.get(config, setting="memory.memsw.failcnt", cgname=CGNAME)
+        expected_str = CGSNAPSHOT + CGSNAPSHOT_SWAP
+    except:
+        # memsw files don't exist.  exclude them from the snapshot
+        expected_str = CGSNAPSHOT + CGSNAPSHOT_NOSWAP
+
+    expected = Cgroup.snapshot_to_dict(expected_str)
+    actual = Cgroup.snapshot(config, controller=CONTROLLER)
+
+    if expected[CGNAME] != actual[CGNAME]:
+        result = consts.TEST_FAILED
+        cause = "Expected cgsnapshot result did not equal actual cgsnapshot"
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/005-cgsnapshot-basic_snapshot_v2.py
+++ b/tests/ftests/005-cgsnapshot-basic_snapshot_v2.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+#
+# Basic cgsnapshot functionality test
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER='cpuset'
+CGNAME="005cgsnapshot"
+CGSNAPSHOT = """group 005cgsnapshot {
+                    cpuset {
+                            cpuset.cpus.partition="member";
+                            cpuset.mems="";
+                            cpuset.cpus="";
+                    }
+            }"""
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v2 cpuset controller"
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    expected = Cgroup.snapshot_to_dict(CGSNAPSHOT)
+    actual = Cgroup.snapshot(config, controller=CONTROLLER)
+
+    if expected[CGNAME] != actual[CGNAME]:
+        result = consts.TEST_FAILED
+        cause = "Expected cgsnapshot result did not equal actual cgsnapshot"
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/006-cgrules-basic_cgrules_v1.py
+++ b/tests/ftests/006-cgrules-basic_cgrules_v1.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Basic cgrules functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from process import Process
+import sys
+
+CONTROLLER='cpu'
+PARENT_CGNAME='006cgrules'
+CHILD_CGNAME='childcg'
+
+# move all perl processes to the 006cgrules/childcg cgroup in the
+# cpu controller
+CGRULE="*:/usr/bin/perl cpu {}".format(os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+
+cg = Cgroup(os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test cannot be run within a container"
+        return result, cause
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 cpu controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+
+    Cgroup.set_cgrules_conf(config, CGRULE, append=False)
+    cg.start_cgrules(config)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = config.process.create_process(config)
+    proc_cgroup = Process.get_cgroup(config, pid, CONTROLLER)
+
+    # proc/{pid}/cgroup alsways prepends a '/' to the cgroup path
+    if proc_cgroup != os.path.join('/', PARENT_CGNAME, CHILD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = "PID {} was expected to be in cgroup {} but is in cgroup {}".format(
+                    pid, os.path.join('/', PARENT_CGNAME, CHILD_CGNAME), proc_cgroup)
+
+    return result, cause
+
+def teardown(config):
+    # destroy the child processes
+    config.process.join_children(config)
+    cg.join_children(config)
+    Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/007-cgrules-basic_cgrules_v2.py
+++ b/tests/ftests/007-cgrules-basic_cgrules_v2.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+#
+# Basic cgrules functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from process import Process
+import sys
+
+CONTROLLER='cpuset'
+CGNAME='007cgrules'
+
+# move all perl processes to the 007cgrules cgroup in the
+# cpuset controller
+CGRULE="*:/usr/bin/perl cpuset {}".format(CGNAME)
+
+cg = Cgroup(CGNAME)
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test cannot be run within a container"
+        return result, cause
+
+    if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v2 cpuset controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+    Cgroup.set_cgrules_conf(config, CGRULE, append=False)
+    cg.start_cgrules(config)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = config.process.create_process(config)
+    proc_cgroup = Process.get_cgroup(config, pid, CONTROLLER)
+
+    # proc/{pid}/cgroup alsways prepends a '/' to the cgroup path
+    if proc_cgroup != os.path.join('/', CGNAME):
+        result = consts.TEST_FAILED
+        cause = "PID {} was expected to be in cgroup {} but is in cgroup {}".format(
+                    pid, os.path.join('/', CGNAME), proc_cgroup)
+
+    return result, cause
+
+def teardown(config):
+    # destroy the child processes
+    config.process.join_children(config)
+    cg.join_children(config)
+    Cgroup.delete(config, CONTROLLER, CGNAME, recursive=False)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/008-cgget-multiple_r_flags.py
+++ b/tests/ftests/008-cgget-multiple_r_flags.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - multiple '-r' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+CGNAME = '008cgget'
+
+SETTING1 = 'memory.limit_in_bytes'
+VALUE1 = '1048576'
+
+SETTING2='memory.soft_limit_in_bytes'
+VALUE2 = '1024000'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+    Cgroup.set(config, CGNAME, SETTING1, VALUE1)
+    Cgroup.set(config, CGNAME, SETTING2, VALUE2)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=CGNAME,
+                     setting=[SETTING1, SETTING2])
+
+    if out.splitlines()[0] != "{}:".format(CGNAME):
+        result = consts.TEST_FAILED
+        cause = "cgget expected the cgroup name {} in the first line.\n" \
+                "Instead it received {}".format(CGNAME, out.splitlines()[0])
+
+    if out.splitlines()[1] != "{}: {}".format(SETTING1, VALUE1):
+        result = consts.TEST_FAILED
+        cause = "cgget expected the following:\n\t" \
+                "{}: {}\nbut received:\n\t{}".format(
+                SETTING1, VALUE1, out.splitlines()[1])
+
+    if out.splitlines()[2] != "{}: {}".format(SETTING2, VALUE2):
+        result = consts.TEST_FAILED
+        cause = "cgget expected the following:\n\t" \
+                "{}: {}\nbut received:\n\t{}".format(
+                SETTING2, VALUE2, out.splitlines()[2])
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/009-cgget-g_flag_controller_only.py
+++ b/tests/ftests/009-cgget-g_flag_controller_only.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - '-g' <controller>
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = '009cgget'
+
+EXPECTED_OUT = [
+    '''009cgget:
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=CGNAME)
+
+    for expected_out in EXPECTED_OUT:
+        if len(out.splitlines()) == len(expected_out.splitlines()):
+            break
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected {} lines but received {} lines'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
+        return result, cause
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != expected_out.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    expected_out.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - '-g' <controller>:<path>
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = '010cgget'
+
+EXPECTED_OUT = [
+    '''cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller="{}:{}".format(CONTROLLER, CGNAME),
+                     print_headers=False)
+
+    for expected_out in EXPECTED_OUT:
+        if len(out.splitlines()) == len(expected_out.splitlines()):
+            break
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected line count: {}, but received line count: {}'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
+        return result, cause
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected {} lines but received {} lines'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
+        return result, cause
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != expected_out.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    expected_out.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/011-cgget-r_flag_two_cgroups.py
+++ b/tests/ftests/011-cgget-r_flag_two_cgroups.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - '-r' <name> <cgroup1> <cgroup2>
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+CGNAME1 = '011cgget1'
+CGNAME2 = '011cgget2'
+
+SETTING = 'memory.limit_in_bytes'
+VALUE = '2048000'
+
+EXPECTED_OUT = '''011cgget1:
+memory.limit_in_bytes: 2048000
+
+011cgget2:
+memory.limit_in_bytes: 2048000
+'''
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+    Cgroup.set(config, CGNAME1, SETTING, VALUE)
+    Cgroup.set(config, CGNAME2, SETTING, VALUE)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=[CGNAME1, CGNAME2],
+                     setting=SETTING)
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/012-cgget-multiple_r_flags2.py
+++ b/tests/ftests/012-cgget-multiple_r_flags2.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - multiple '-r' flags and multiple cgroups
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+CGNAME1 = '012cgget1'
+CGNAME2 = '012cgget2'
+
+SETTING1 = 'memory.limit_in_bytes'
+VALUE1 = '4194304'
+
+SETTING2 = 'memory.soft_limit_in_bytes'
+VALUE2 = '4096000'
+
+EXPECTED_OUT = '''{}:
+{}
+{}
+
+{}:
+{}
+{}
+'''.format(CGNAME1, VALUE1, VALUE2, CGNAME2, VALUE1, VALUE2)
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+    Cgroup.set(config, CGNAME1, SETTING1, VALUE1)
+    Cgroup.set(config, CGNAME1, SETTING2, VALUE2)
+    Cgroup.set(config, CGNAME2, SETTING1, VALUE1)
+    Cgroup.set(config, CGNAME2, SETTING2, VALUE2)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=[CGNAME1, CGNAME2],
+                     setting=[SETTING1, SETTING2], values_only=True)
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/013-cgget-multiple_g_flags.py
+++ b/tests/ftests/013-cgget-multiple_g_flags.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - multiple '-g' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER1 = 'freezer'
+CONTROLLER2 = 'cpu'
+CGNAME = '013cgget'
+
+EXPECTED_OUT = [
+    '''013cgget:
+    freezer.self_freezing: 0
+    freezer.parent_freezing: 0
+    freezer.state: THAWED
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''013cgget:
+    freezer.self_freezing: 0
+    freezer.parent_freezing: 0
+    freezer.state: THAWED
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''013cgget:
+    freezer.self_freezing: 0
+    freezer.parent_freezing: 0
+    freezer.state: THAWED
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER1, CGNAME)
+    Cgroup.create(config, CONTROLLER2, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=[CONTROLLER1, CONTROLLER2],
+                     cgname=CGNAME)
+
+    for expected_out in EXPECTED_OUT:
+        if len(out.splitlines()) == len(expected_out.splitlines()):
+            break
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected {} lines but received {} lines'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
+        return result, cause
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != expected_out.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    expected_out.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER1, CGNAME)
+    Cgroup.delete(config, CONTROLLER2, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/014-cgget-a_flag.py
+++ b/tests/ftests/014-cgget-a_flag.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - exercise the '-a' flag
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER1='memory'
+CONTROLLER2='cpuset'
+CGNAME="014cgget"
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER1, CGNAME)
+    Cgroup.create(config, CONTROLLER2, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, cgname=CGNAME, all_controllers=True)
+
+    # arbitrary check to ensure we read several lines
+    if len(out.splitlines()) < 20:
+        result = consts.TEST_FAILED
+        cause = "Expected multiple lines, but only received {}".format(
+                len(out.splitlines()))
+        return result, cause
+
+    # arbitrary check for a setting that's in both cgroup v1 and cgroup v2
+    # memory.stat
+    if not "\tpgmajfault" in out:
+        result = consts.TEST_FAILED
+        cause = "Unexpected output\n{}".format(out)
+        return result, cause
+
+    # make sure that a cpuset value was in the output:
+    if not "cpuset.cpus" in out:
+        result = consts.TEST_FAILED
+        cause = "Failed to find cpuset settings in output\n{}".format(out)
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER1, CGNAME)
+    Cgroup.delete(config, CONTROLLER2, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/015-cgget-multiline_r_flag.py
+++ b/tests/ftests/015-cgget-multiline_r_flag.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - get a multiline value via the '-r' flag
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER='memory'
+CGNAME="015cgget"
+
+SETTING='memory.stat'
+VALUE='512'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=CGNAME,
+                     setting=SETTING, print_headers=True,
+                     values_only=False)
+
+    # arbitrary check to ensure we read several lines
+    if len(out.splitlines()) < 10:
+        result = consts.TEST_FAILED
+        cause = "Expected multiple lines, but only received {}".format(
+                len(out.splitlines()))
+        return result, cause
+
+    # arbitrary check for a setting that's in both cgroup v1 and cgroup v2
+    # memory.stat
+    if not "\tunevictable" in out:
+        result = consts.TEST_FAILED
+        cause = "Unexpected output\n{}".format(out)
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/016-cgget-invalid_options.py
+++ b/tests/ftests/016-cgget-invalid_options.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - multiple '-g' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from run import RunError
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = '016cgget'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    # Github Actions has issues with cgget and the code coverage profiler.
+    # This causes issues with the error handling of this test
+    if not config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test must be run within a container'
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        # cgget -g cpu
+        Cgroup.get(config, controller=CONTROLLER)
+    except RunError as re:
+        if not "Wrong input parameters," in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#1 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = "#1 Expected return code of 255 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #1 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget -g cpu:016cgget 016cgget
+        Cgroup.get(config, controller="{}:{}".format(CONTROLLER, CGNAME),
+                   cgname=CGNAME)
+    except RunError as re:
+        if not "Wrong input parameters," in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#2 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = "#2 Expected return code of 255 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #2 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget -r invalidsetting 016cgget
+        Cgroup.get(config, setting="invalidsetting", cgname=CGNAME,
+                   print_headers=False, values_only=True)
+    except RunError as re:
+        if not "cgget: error parsing parameter name" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#3 Expected 'cgget: error parsing parameter name' to be in stderr"
+            return result, cause
+
+        # legacy cgget returns 0 but populates stderr for this case.
+        # This feels wrong, so the updated cgget returns ECGINVAL
+        if re.ret != 91 and re.ret != 0:
+            result = consts.TEST_FAILED
+            cause = "#3 Expected return code of 0 or 91 but received {}".format(
+                    re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #3 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget -r invalid.setting 016cgget
+        Cgroup.get(config, setting="invalid.setting", cgname=CGNAME,
+                   print_headers=False, values_only=True)
+    except RunError as re:
+        if not "cgget: cannot find controller" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#4 Expected 'cgget: cannot find controller' to be in stderr"
+            return result, cause
+
+        # legacy cgget returns 0 but populates stderr for this case.
+        # This feels wrong, so the updated cgget returns ECGOTHER
+        if re.ret != 96 and re.ret != 0:
+            result = consts.TEST_FAILED
+            cause = "#4 Expected return code of 0 or 96 but received {}".format(
+                    re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #4 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget -r cpu.invalid 016cgget
+        Cgroup.get(config, setting="{}.invalid".format(CONTROLLER),
+                   cgname=CGNAME, print_headers=False, values_only=True)
+    except RunError as re:
+        if not "variable file read failed" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#5 Expected 'variable file read failed' to be in stderr"
+            return result, cause
+
+        # legacy cgget returns 0 but populates stderr for this case.
+        # This feels wrong, so the updated cgget returns ECGOTHER
+        if re.ret != 96 and re.ret != 0:
+            result = consts.TEST_FAILED
+            cause = "#5 Expected return code of 0 or 96 but received {}".format(
+                    re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #5 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget with no parameters
+        Cgroup.get(config, controller=None, cgname=None, setting=None,
+                   print_headers=True, values_only=False,
+                   all_controllers=False, cghelp=False)
+    except RunError as re:
+        if not "Wrong input parameters," in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#6 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 1:
+            result = consts.TEST_FAILED
+            cause = "#6 Expected return code of 1 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #6 erroneously passed"
+        return result, cause
+
+    # cgget -h
+    ret = Cgroup.get(config, cghelp=True)
+    if not "Print parameter(s)" in ret:
+        result = consts.TEST_FAILED
+        cause = "#7 Failed to print help text"
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/017-cgconfig-load_file.py
+++ b/tests/ftests/017-cgconfig-load_file.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+#
+# cgconfigparser functionality test using a configuration file
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = '017cgconfig'
+CFS_PERIOD = '500000'
+CFS_QUOTA = '100000'
+SHARES = '999'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+        cpu.cfs_period_us = {};
+        cpu.cfs_quota_us = {};
+        cpu.shares = {};
+    }}
+}}'''.format(CGNAME, CONTROLLER, CFS_PERIOD, CFS_QUOTA, SHARES)
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '017cgconfig.conf')
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 cpu controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    period = Cgroup.get(config, cgname=CGNAME, setting='cpu.cfs_period_us',
+                        print_headers=False, values_only=True)
+    if period != CFS_PERIOD:
+            result = consts.TEST_FAILED
+            cause = "cfs_period_us failed.  Expected {}, Received {}".format(
+                    CFS_PERIOD, period)
+            return result, cause
+
+    quota = Cgroup.get(config, cgname=CGNAME, setting='cpu.cfs_quota_us',
+                       print_headers=False, values_only=True)
+    if quota != CFS_QUOTA:
+            result = consts.TEST_FAILED
+            cause = "cfs_quota_us failed.  Expected {}, Received {}".format(
+                    CFS_QUOTA, quota)
+            return result, cause
+
+    shares = Cgroup.get(config, cgname=CGNAME, setting='cpu.shares',
+                        print_headers=False, values_only=True)
+    if shares != SHARES:
+            result = consts.TEST_FAILED
+            cause = "shares failed.  Expected {}, Received {}".format(
+                    SHARES, shares)
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+    os.remove(CONFIG_FILE_NAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/018-cgconfig-load_dir.py
+++ b/tests/ftests/018-cgconfig-load_dir.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+#
+# cgconfigparser functionality test using a configuration directory
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CPU_CTRL = 'cpu'
+MEMORY_CTRL = 'memory'
+CGNAME = '018cgconfig'
+CFS_PERIOD = '400000'
+CFS_QUOTA = '50000'
+SHARES = '123'
+
+LIMIT_IN_BYTES = '409600'
+SOFT_LIMIT_IN_BYTES = '376832'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+        cpu.cfs_period_us = {};
+        cpu.cfs_quota_us = {};
+        cpu.shares = {};
+    }}
+    {} {{
+        memory.limit_in_bytes = {};
+        memory.soft_limit_in_bytes = {};
+    }}
+}}'''.format(CGNAME, CPU_CTRL, CFS_PERIOD, CFS_QUOTA, SHARES,
+             MEMORY_CTRL, LIMIT_IN_BYTES, SOFT_LIMIT_IN_BYTES)
+
+CONFIG_FILE_DIR = os.path.join(os.getcwd(), '018cgconfig')
+CONFIG_FILE_NAME = os.path.join(CONFIG_FILE_DIR, 'cgconfig.conf')
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 cpu controller"
+        return result, cause
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 memory controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    os.mkdir(CONFIG_FILE_DIR)
+
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.configparser(config, load_dir=CONFIG_FILE_DIR)
+
+    period = Cgroup.get(config, cgname=CGNAME, setting='cpu.cfs_period_us',
+                        print_headers=False, values_only=True)
+    if period != CFS_PERIOD:
+            result = consts.TEST_FAILED
+            cause = "cfs_period_us failed.  Expected {}, Received {}".format(
+                    CFS_PERIOD, period)
+            return result, cause
+
+    quota = Cgroup.get(config, cgname=CGNAME, setting='cpu.cfs_quota_us',
+                       print_headers=False, values_only=True)
+    if quota != CFS_QUOTA:
+            result = consts.TEST_FAILED
+            cause = "cfs_quota_us failed.  Expected {}, Received {}".format(
+                    CFS_QUOTA, quota)
+            return result, cause
+
+    shares = Cgroup.get(config, cgname=CGNAME, setting='cpu.shares',
+                        print_headers=False, values_only=True)
+    if shares != SHARES:
+            result = consts.TEST_FAILED
+            cause = "shares failed.  Expected {}, Received {}".format(
+                    SHARES, shares)
+            return result, cause
+
+    limit = Cgroup.get(config, cgname=CGNAME, setting='memory.limit_in_bytes',
+                       print_headers=False, values_only=True)
+    if limit != LIMIT_IN_BYTES:
+            result = consts.TEST_FAILED
+            cause = "limit_in_bytes failed.  Expected {}, Received {}".format(
+                    LIMIT_IN_BYTES, limit)
+            return result, cause
+
+    soft_limit = Cgroup.get(config, cgname=CGNAME,
+                            setting='memory.soft_limit_in_bytes',
+                            print_headers=False, values_only=True)
+    if soft_limit != SOFT_LIMIT_IN_BYTES:
+            result = consts.TEST_FAILED
+            cause = "soft_limit_in_bytes failed.  Expected {}, Received {}".format(
+                    SOFT_LIMIT_IN_BYTES, soft_limit)
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CPU_CTRL, CGNAME)
+    Cgroup.delete(config, MEMORY_CTRL, CGNAME)
+    os.remove(CONFIG_FILE_NAME)
+    os.rmdir(CONFIG_FILE_DIR)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/019-cgconfig-uidgid_dperm_fperm.py
+++ b/tests/ftests/019-cgconfig-uidgid_dperm_fperm.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+#
+# cgconfigparser functionality test - '-a', '-d', '-f' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from run import Run
+import sys
+import utils
+
+CONTROLLER = 'cpuset'
+CGNAME = '019cgconfig'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+    }}
+}}'''.format(CGNAME, CONTROLLER)
+
+USER = 'cguser019'
+GROUP = 'cggroup019'
+DPERM = '515'
+FPERM = '246'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '019cgconfig.conf')
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+    if config.args.container:
+        config.container.run(['useradd', '-p', 'Test019#1', USER])
+        config.container.run(['groupadd', GROUP])
+    else:
+        Run.run(['sudo', 'useradd', '-p', 'Test019#1', USER])
+        Run.run(['sudo', 'groupadd', '-f', GROUP])
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME, dflt_usr=USER,
+                        dflt_grp=GROUP, dperm=DPERM, fperm=FPERM)
+
+    mnt_path = Cgroup.get_controller_mount_point(CONTROLLER)
+    cpus_path = os.path.join(mnt_path, CGNAME, 'cpuset.cpus')
+
+    user = utils.get_file_owner_username(config, cpus_path)
+    group = utils.get_file_owner_group_name(config, cpus_path)
+
+    if user != USER:
+        result = consts.TEST_FAILED
+        cause = "Owner name failed.  Expected {}, received {}\n".format(
+                USER, user)
+        return result, cause
+
+    if group != GROUP:
+        result = consts.TEST_FAILED
+        cause = "Owner group failed.  Expected {}, received {}\n".format(
+                GROUP, group)
+        return result, cause
+
+    fperm = utils.get_file_permissions(config, cpus_path)
+    if fperm != FPERM:
+        result = consts.TEST_FAILED
+        cause = "File permissions failed.  Expected {}, received {}\n".format(
+                FPERM, fperm)
+        return result, cause
+
+    dperm = utils.get_file_permissions(config, os.path.join(mnt_path, CGNAME))
+    if dperm != DPERM:
+        result = consts.TEST_FAILED
+        cause = "Directory permissions failed.  Expected {}, received {}\n".format(
+                DPERM, dperm)
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    os.remove(CONFIG_FILE_NAME)
+
+    try:
+        if config.args.container:
+            config.container.run(['userdel', USER])
+            config.container.run(['groupdel', GROUP])
+        else:
+            Run.run(['sudo', 'userdel', '-r', USER])
+            Run.run(['sudo', 'groupdel', GROUP])
+    except:
+        pass
+
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/020-cgconfig-tasks_perms_owner.py
+++ b/tests/ftests/020-cgconfig-tasks_perms_owner.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+#
+# cgconfigparser functionality test - '-s', '-t', flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from run import Run
+import sys
+import utils
+
+CONTROLLER = 'cpuset'
+CGNAME = '020cgconfig'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+    }}
+}}'''.format(CGNAME, CONTROLLER)
+
+USER = 'cguser020'
+GROUP = 'cggroup020'
+TPERM = '642'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '020cgconfig.conf')
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 cpuset controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+    if config.args.container:
+        config.container.run(['useradd', '-p', 'Test020#1', USER])
+        config.container.run(['groupadd', GROUP])
+    else:
+        Run.run(['sudo', 'useradd', '-p', 'Test020#1', USER])
+        Run.run(['sudo', 'groupadd', '-f', GROUP])
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME, tperm=TPERM,
+                        tasks_usr=USER, tasks_grp=GROUP)
+
+    mnt_path = Cgroup.get_controller_mount_point(CONTROLLER)
+    tasks_path = os.path.join(mnt_path, CGNAME, 'tasks')
+
+    user = utils.get_file_owner_username(config, tasks_path)
+    group = utils.get_file_owner_group_name(config, tasks_path)
+
+    if user != USER:
+        result = consts.TEST_FAILED
+        cause = "Owner name failed.  Expected {}, received {}\n".format(
+                USER, user)
+        return result, cause
+
+    if group != GROUP:
+        result = consts.TEST_FAILED
+        cause = "Owner group failed.  Expected {}, received {}\n".format(
+                GROUP, group)
+        return result, cause
+
+    tperm = utils.get_file_permissions(config, tasks_path)
+    if tperm != TPERM:
+        result = consts.TEST_FAILED
+        cause = "File permissions failed.  Expected {}, received {}\n".format(
+                TPERM, tperm)
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    os.remove(CONFIG_FILE_NAME)
+
+    try:
+        if config.args.container:
+            config.container.run(['userdel', USER])
+            config.container.run(['groupdel', GROUP])
+        else:
+            Run.run(['sudo', 'userdel', '-r', USER])
+            Run.run(['sudo', 'groupdel', GROUP])
+    except:
+        pass
+
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/021-cgconfig-invalid_options.py
+++ b/tests/ftests/021-cgconfig-invalid_options.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# cgconfigparser functionality test - invalid and help options
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from run import RunError
+import sys
+
+CONTROLLER = 'cpuset'
+CGNAME = '021cgconfig'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+	cpuset.cpus = abc123;
+    }}
+}}'''.format(CGNAME, CONTROLLER)
+
+USER = 'cguser021'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '021cgconfig.conf')
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    ret = Cgroup.configparser(config, cghelp=True)
+    if not "Parse and load the specified cgroups" in ret:
+        result = consts.TEST_FAILED
+        cause = "Failed to print cgconfigparser help text"
+        return result, cause
+
+    try:
+        Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+    except RunError as re:
+        if not "Invalid argument" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "Expected 'Invalid argument' to be in stderr"
+            return result, cause
+
+        if re.ret != 96:
+            result = consts.TEST_FAILED
+            cause = "Expected return code of 96 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case erroneously passed"
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    os.remove(CONFIG_FILE_NAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/022-cgset-multiple_r_flag.py
+++ b/tests/ftests/022-cgset-multiple_r_flag.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+# Advanced cgset functionality test - set multiple values via the '-r' flag
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+CGNAME = "022cgset"
+
+SETTINGS = ['memory.limit_in_bytes',
+            'memory.soft_limit_in_bytes',
+            'memory.swappiness']
+VALUES = ['1024000', '512000', '55']
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 memory controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.set(config, cgname=CGNAME, setting=SETTINGS, value=VALUES)
+
+    for i, setting in enumerate(SETTINGS):
+        value = Cgroup.get(config, cgname=CGNAME, setting=setting,
+                           print_headers=False, values_only=True)
+
+        if value != VALUES[i]:
+            result = consts.TEST_FAILED
+            cause = "Expected {} to be set to {}, but received {}".format(
+                    setting, VALUES[i], value)
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/023-cgset-copy_from.py
+++ b/tests/ftests/023-cgset-copy_from.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# Advanced cgset functionality test - test the '--copy-from' option
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+SRC_CGNAME = '023cgsetsrc'
+DST_CGNAME = '023cgsetdst'
+
+SETTINGS = ['memory.limit_in_bytes',
+            'memory.soft_limit_in_bytes',
+            'memory.swappiness']
+VALUES = ['122880', '40960', '42']
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 memory controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, SRC_CGNAME)
+    Cgroup.create(config, CONTROLLER, DST_CGNAME)
+    Cgroup.set(config, cgname=SRC_CGNAME, setting=SETTINGS, value=VALUES)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.set(config, cgname=DST_CGNAME, copy_from=SRC_CGNAME)
+
+    for i, setting in enumerate(SETTINGS):
+        value = Cgroup.get(config, cgname=DST_CGNAME, setting=setting,
+                           print_headers=False, values_only=True)
+
+        if value != VALUES[i]:
+            result = consts.TEST_FAILED
+            cause = "Expected {} to be set to {}, but received {}".format(
+                    setting, VALUES[i], value)
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, SRC_CGNAME)
+    Cgroup.delete(config, CONTROLLER, DST_CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/025-cgset-multiple_cgroups.py
+++ b/tests/ftests/025-cgset-multiple_cgroups.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Advanced cgset functionality test - set multiple cgroups' values
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+CGNAME1 = "025cgset1"
+CGNAME2 = "025gset2"
+
+SETTING = 'memory.swappiness'
+VALUE = '42'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 memory controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.set(config, cgname=[CGNAME1, CGNAME2], setting=SETTING, value=VALUE)
+
+    value = Cgroup.get(config, cgname=CGNAME1, setting=SETTING,
+                       print_headers=False, values_only=True)
+    if value != VALUE:
+            result = consts.TEST_FAILED
+            cause = "Expected {} to be set to {} in {}, but received {}".format(
+                    setting, VALUES[i], CGNAME1, value)
+            return result, cause
+
+    value = Cgroup.get(config, cgname=CGNAME2, setting=SETTING,
+                       print_headers=False, values_only=True)
+    if value != VALUE:
+            result = consts.TEST_FAILED
+            cause = "Expected {} to be set to {} in {}, but received {}".format(
+                    setting, VALUES[i], CGNAME2, value)
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/026-cgset-multiple_r_multiple_cgroup.py
+++ b/tests/ftests/026-cgset-multiple_r_multiple_cgroup.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# Advanced cgset functionality test - set multiple values in multiple cgroups
+#                                     via the '-r' flag
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+CGNAMES = ['026cgset1', '026cgset2']
+
+SETTINGS = ['memory.limit_in_bytes',
+            'memory.soft_limit_in_bytes',
+            'memory.swappiness']
+VALUES = ['2048000', '1024000', '89']
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 memory controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    for cg in CGNAMES:
+        Cgroup.create(config, CONTROLLER, cg)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.set(config, cgname=CGNAMES, setting=SETTINGS, value=VALUES)
+
+    for i, setting in enumerate(SETTINGS):
+        for cg in CGNAMES:
+            value = Cgroup.get(config, cgname=cg, setting=setting,
+                               print_headers=False, values_only=True)
+
+            if value != VALUES[i]:
+                result = consts.TEST_FAILED
+                cause = "Expected {} to be set to {} in {}, but received {}".format(
+                    setting, VALUES[i], cg, value)
+                return result, cause
+
+    return result, cause
+
+def teardown(config):
+    for cg in CGNAMES:
+        Cgroup.delete(config, CONTROLLER, cg)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/027-cgset-invalid_options.py
+++ b/tests/ftests/027-cgset-invalid_options.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+#
+# Advanced cgset functionality test - invalid options
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from run import RunError
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME1 = '027cgset1'
+CGNAME2 = '027cgset2'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        # cgset -r cpu.shares=100 --copy-from 027cgset2 027cgset1
+        Cgroup.set(config, cgname=CGNAME1, setting="cpu.shares", value="100",
+                   copy_from=CGNAME2)
+    except RunError as re:
+        if not "Wrong input parameters," in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#1 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = "#1 Expected return code of 255 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #1 erroneously passed"
+        return result, cause
+
+    try:
+        # cgset -r cpu.shares=100
+        Cgroup.set(config, cgname=None, setting="cpu.shares", value="100")
+    except RunError as re:
+        if not "cgset: no cgroup specified" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#2 Expected 'no cgroup specified' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = "#2 Expected return code of 255 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #2 erroneously passed"
+        return result, cause
+
+    try:
+        # cgset 027cgset1
+        Cgroup.set(config, cgname=CGNAME1)
+    except RunError as re:
+        if not "cgset: no name-value pair was set" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#3 Expected 'no name-value pair' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = "#3 Expected return code of 255 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #3 erroneously passed"
+        return result, cause
+
+    try:
+        # cgset - no flags provided
+        Cgroup.set(config)
+    except RunError as re:
+        if not "Usage is" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#4 Expected 'Usage is' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = "#4 Expected return code of 255 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #4 erroneously passed"
+        return result, cause
+
+    try:
+        # cgset -r cpu.shares= 027cgset1
+        Cgroup.set(config, cgname=CGNAME1, setting="cpu.shares", value="")
+    except RunError as re:
+        if not "wrong parameter of option -r" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#5 Expected 'Wrong parameter of option' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = "#5 Expected return code of 255 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #5 erroneously passed"
+        return result, cause
+
+    # cgset -h
+    ret = Cgroup.set(config, cghelp=True)
+    if not "Usage:" in ret:
+        result = consts.TEST_FAILED
+        cause = "#6 Failed to print help text"
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/028-cgclear-basic_cgclear.py
+++ b/tests/ftests/028-cgclear-basic_cgclear.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+#
+# Basic cgclear functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup
+import consts
+import ftests
+import os
+from process import Process
+from run import Run
+import sys
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test is highly destructive to the cgroup hierarchy and\n" \
+                "does not have the necessary permissions within a container."
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    pass
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    ret = Cgroup.clear(config, cghelp=True)
+    if not "Usage:" in ret:
+        result = consts.TEST_FAILED
+        cause = "Failed to print help text"
+        return result, cause
+
+    before = Run.run('mount | wc -l', shell_bool=True)
+    Cgroup.clear(config)
+    after = Run.run('mount | wc -l', shell_bool=True)
+
+    if after >= before:
+        result = consts.TEST_FAILED
+        cause = "Cgroups were not unmounted.\n" \
+                "Before count {}, after count {}".format(before, after)
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    pass
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/029-lssubsys-basic_lssubsys.py
+++ b/tests/ftests/029-lssubsys-basic_lssubsys.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+#
+# Basic lssubsys functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+import utils
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    pass
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    mount_list = Cgroup.get_cgroup_mounts(config, expand_v2_mounts=False)
+
+    # cgroup v2 mounts won't show up unless '-a' is specified
+    lssubsys_list = Cgroup.lssubsys(config, ls_all=False)
+
+    for mount in mount_list:
+        if mount.version == CgroupVersion.CGROUP_V2:
+            continue
+
+        if mount.controller == "name=systemd" or mount.controller == "systemd":
+            continue
+
+        found = False
+        for lsmount in lssubsys_list.splitlines():
+            if ',' in lsmount:
+                for ctrl in lsmount.split(','):
+                    if ctrl == mount.controller:
+                        found = True
+                        break
+
+            if lsmount == mount.controller:
+                found = True
+                break
+
+        if not found:
+            result = consts.TEST_FAILED
+            cause = "Failed to find {} in lssubsys list".format(
+                      mount.controller)
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    pass
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/030-lssubsys-lssubsys_all.py
+++ b/tests/ftests/030-lssubsys-lssubsys_all.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+# 'lssubsys -a' test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+import utils
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    pass
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    mount_list = Cgroup.get_cgroup_mounts(config, expand_v2_mounts=True)
+
+    # cgroup v2 mounts won't show up unless '-a' is specified
+    lssubsys_list = Cgroup.lssubsys(config, ls_all=True)
+
+    for mount in mount_list:
+        if mount.controller == "name=systemd" or mount.controller == "systemd":
+            continue
+
+        found = False
+        for lsmount in lssubsys_list.splitlines():
+            if ',' in lsmount:
+                for ctrl in lsmount.split(','):
+                    if ctrl == mount.controller:
+                        found = True
+                        break
+
+            if lsmount == mount.controller:
+                found = True
+                break
+
+        if not found:
+            result = consts.TEST_FAILED
+            cause = "Failed to find {} in lssubsys list".format(
+                      mount.controller)
+            return result, cause
+
+    ret = Cgroup.lssubsys(config, cghelp=True)
+    if not "Usage:" in ret:
+        result = consts.TEST_FAILED
+        cause = "Failed to print help text"
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    pass
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/031-lscgroup-g_flag.py
+++ b/tests/ftests/031-lscgroup-g_flag.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# lscgroup functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+import utils
+
+CONTROLLER = 'cpuset'
+PARENT_CGNAME = '031lscgroup'
+CHILD_CGNAME = 'childlscgroup'
+GRANDCHILD_CGNAME = 'grandchildlscgroup'
+
+# lscgroup is inconsistent in its handling of trailing slashes
+#
+# When invoking lscgroup with no flags, no trailing slashes are present in
+# any of the cgroups.
+#
+# When invoking lscgroup with the -g flag, a trailing slash is present on
+# the first cgroup returned (i.e. the cgroup specified in the -g flag)
+#
+EXPECTED_OUT1 = '''{}:/{}/
+{}:/{}/{}
+{}:/{}/{}/{}'''.format(CONTROLLER, PARENT_CGNAME,
+                       CONTROLLER, PARENT_CGNAME, CHILD_CGNAME,
+                       CONTROLLER, PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME)
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+    Cgroup.create(config, CONTROLLER,
+                  os.path.join(PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME))
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.lscgroup(config, controller=CONTROLLER, path=PARENT_CGNAME)
+    if out != EXPECTED_OUT1:
+        result = consts.TEST_FAILED
+        cause = "Expected lscgroup output doesn't match received output\n" \
+                "Expected:\n{}\n" \
+                "Received:\n{}\n".format(utils.indent(EXPECTED_OUT1, 4),
+                                         utils.indent(out, 4))
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/032-lscgroup-multiple_g_flags.py
+++ b/tests/ftests/032-lscgroup-multiple_g_flags.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+#
+# lscgroup functionality test - multiple '-g' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+import utils
+
+CONTROLLER = 'cpuset'
+PARENT_CGNAME = '032lscgroup'
+CHILD_CGNAME = 'childlscgroup'
+GRANDCHILD_CGNAME = 'grandchildlscgroup'
+SIBLING_CGNAME = '032sibling'
+SIBLING_CHILD_CGNAME = 'cousinlscgroup'
+
+# lscgroup is inconsistent in its handling of trailing slashes
+#
+# When invoking lscgroup with no flags, no trailing slashes are present in
+# any of the cgroups.
+#
+# When invoking lscgroup with the -g flag, a trailing slash is present on
+# the first cgroup returned (i.e. the cgroup specified in the -g flag)
+#
+EXPECTED_OUT1 = '''{}:/{}/
+{}:/{}/{}
+{}:/{}/{}/{}
+{}:/{}/
+{}:/{}/{}'''.format(CONTROLLER, PARENT_CGNAME,
+                    CONTROLLER, PARENT_CGNAME, CHILD_CGNAME,
+                    CONTROLLER, PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME,
+                    CONTROLLER, SIBLING_CGNAME,
+                    CONTROLLER, SIBLING_CGNAME, SIBLING_CHILD_CGNAME)
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+    Cgroup.create(config, CONTROLLER,
+                  os.path.join(PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME))
+
+    Cgroup.create(config, CONTROLLER, SIBLING_CGNAME)
+    Cgroup.create(config, CONTROLLER,
+                  os.path.join(SIBLING_CGNAME, SIBLING_CHILD_CGNAME))
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.lscgroup(config, controller=[CONTROLLER, CONTROLLER],
+                          path=[PARENT_CGNAME, SIBLING_CGNAME])
+    if out != EXPECTED_OUT1:
+        result = consts.TEST_FAILED
+        cause = "Expected lscgroup output doesn't match received output\n" \
+                "Expected:\n{}\n" \
+                "Received:\n{}\n".format(utils.indent(EXPECTED_OUT1, 4),
+                                         utils.indent(out, 4))
+        return result, cause
+
+    ret = Cgroup.lscgroup(config, cghelp=True)
+    if not "Usage:" in ret:
+        result = consts.TEST_FAILED
+        cause = "Failed to print help text"
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+    Cgroup.delete(config, CONTROLLER, SIBLING_CGNAME, recursive=True)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/033-cgget-no_flags.py
+++ b/tests/ftests/033-cgget-no_flags.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - no flags, only a cgroup
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpuset'
+CGNAME = '033cgget'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=CGNAME)
+
+    if out.splitlines()[0] != "{}:".format(CGNAME):
+        result = consts.TEST_FAILED
+        cause = "cgget expected the cgroup name {} in the first line.\n" \
+                "Instead it received {}".format(CGNAME, out.splitlines()[0])
+
+    if len(out.splitlines()) < 5:
+        result = consts.TEST_FAILED
+        cause = "Too few lines output by cgget.  Received {} lines".format(
+                len(out.splitlines()))
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/034-cgexec-basic_cgexec.py
+++ b/tests/ftests/034-cgexec-basic_cgexec.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# Cgroup cgexec test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from process import Process
+from run import Run
+import sys
+
+import time
+
+CONTROLLER = 'cpuset'
+CGNAME = '034cgexec'
+
+def prereqs(config):
+    if not config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test must be run within a container"
+        return result, cause
+
+    return consts.TEST_PASSED, None
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    config.process.create_process_in_cgroup(config, CONTROLLER, CGNAME,
+                                            cgclassify=False)
+
+    pids = Cgroup.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
+    if pids is None:
+        result = consts.TEST_FAILED
+        cause = "No processes were found in cgroup {}".format(CGNAME)
+        return result, cause
+
+    # run cgexec -h
+    ret = Cgroup.cgexec(config, controller=CONTROLLER, cgname=CGNAME,
+                        cmdline=None, cghelp=True)
+    if not "Run the task in given control group(s)" in ret:
+        result = consts.TEST_FAILED
+        cause = "Failed to print cgexec help text: {}".format(ret)
+        return result, cause
+
+    return consts.TEST_PASSED, None
+
+def teardown(config):
+    pids = Cgroup.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
+    if pids:
+        for p in pids.splitlines():
+            if config.args.container:
+                config.container.run(['kill', '-9', p])
+            else:
+                Run.run(['sudo', 'kill', '-9', p])
+
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/035-cgset-set_cgroup_type.py
+++ b/tests/ftests/035-cgset-set_cgroup_type.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#
+# cgget/cgset cgroup.type functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+# Which controller isn't all that important, but it is important that we
+# have a cgroup v2 controller
+CONTROLLER = 'cpu'
+CGNAME = "035cgset"
+
+SETTING = 'cgroup.type'
+BEFORE = 'domain'
+AFTER = 'threaded'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test cannot be run within a container"
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires cgroup v2"
+
+    return result, cause
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+    before = Cgroup.get(config, controller=None, cgname=CGNAME,
+                        setting=SETTING, print_headers=False,
+                        values_only=True)
+    if before != BEFORE:
+        result = consts.TEST_SKIPPED
+        cause = "Skipping test.  Unexpected value in {}: {}".format(SETTING,
+                    before)
+
+    return result, cause
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.set(config, CGNAME, SETTING, AFTER)
+
+    after = Cgroup.get(config, controller=None, cgname=CGNAME,
+                       setting=SETTING, print_headers=False,
+                       values_only=True)
+
+    if after != AFTER:
+        result = consts.TEST_FAILED
+        cause = "cgget expected {} but received {}".format(AFTER, after)
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -1,0 +1,29 @@
+#
+# libcgroup functional tests Makefile.am
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+TESTS = ftests.sh ftests-nocontainer.sh
+
+EXTRA_DIST = *.py README.md ftests.sh ftests-nocontainer.sh
+
+clean-local: clean-local-check
+.PHONY: clean-local-check
+clean-local-check:
+	-rm -f *.pyc

--- a/tests/ftests/README.md
+++ b/tests/ftests/README.md
@@ -1,0 +1,65 @@
+## Functional Test Suite for libcgroup
+
+This folder contains the functional test suite for libcgroup.
+The functional test suite utilizes lxc containers to guarantee
+a non-destructive test environment.
+
+The tests can be invoked individually, as a group of related
+tests, or from automake via the standard 'make check'
+command.
+
+## Invocation
+
+Run a single test (first cd to tests/ftests):
+
+    ./001-cgget-basic_cgget.py
+    or
+    ./ftests.py -N 15      # Run test #015
+
+Run a suite of tests (first cd to tests/ftests):
+
+    ./ftests.py -s cgget   # Run all cgget tests
+
+Run all the tests by hand
+
+    ./ftests.py
+    # This may be advantageous over running make check
+    # because it will try to re-use the same lxc
+    # container for all of the tests.  This should
+    # provide a significant performance increase
+
+Run the tests from automake
+
+    make check
+    # Then examine the *.trs and *.log files for
+    # specifics regarding each test result
+
+## Results
+
+The test suite will generate test results upon completion of
+the test run.  An example result is below:
+
+```
+Test Results:
+        Run Date:                     Jun 03 13:41:35
+        Passed:                               1  test
+        Skipped:                              0 tests
+        Failed:                               0 tests
+-----------------------------------------------------------------
+Timing Results:
+        Test                               Time (sec)
+        ---------------------------------------------------------
+        setup                                    6.95
+        001-cgget-basic_cgget.py                 0.07
+        teardown                                 0.00
+        ---------------------------------------------------------
+        Total Run Time                           7.02
+```
+
+A log file can also be generated to help in debugging failed
+tests.  Run `ftests.py -h` to view the syntax.
+
+To generate a log file called foo.log at a debug level (8) run
+the following:
+
+        ./ftests.py -l 8 -L foo.log

--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -1,0 +1,832 @@
+#
+# Cgroup class for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import consts
+import copy
+from controller import Controller
+from enum import Enum
+import multiprocessing as mp
+import os
+from run import Run, RunError
+import time
+import utils
+
+class CgroupMount(object):
+    def __init__(self, mount_line):
+        entries = mount_line.split()
+
+        if entries[2] == "cgroup":
+            self.version = CgroupVersion.CGROUP_V1
+        elif entries[2] == "cgroup2":
+            self.version = CgroupVersion.CGROUP_V2
+        else:
+            raise ValueError("Unknown cgroup version")
+
+        self.mount_point = entries[1]
+
+        self.controller = None
+        if self.version == CgroupVersion.CGROUP_V1:
+            self.controller = entries[3].split(',')[-1]
+
+            if self.controller == "clone_children":
+                # the cpuset controller may append this option to the end
+                # rather than the controller name like all other controllers
+                self.controller = "cpuset"
+
+    def __str__(self):
+        out_str = "CgroupMount"
+        out_str += "\n\tMount Point = {}".format(self.mount_point)
+        out_str += "\n\tCgroup Version = {}".format(self.version)
+        if self.controller is not None:
+            out_str += "\n\tController = {}".format(self.controller)
+
+        return out_str
+
+class CgroupVersion(Enum):
+    CGROUP_UNK = 0
+    CGROUP_V1 = 1
+    CGROUP_V2 = 2
+
+    # given a controller name, get the cgroup version of the controller
+    @staticmethod
+    def get_version(controller):
+        with open('/proc/mounts', 'r') as mntf:
+            for line in mntf.readlines():
+                mnt_path = line.split()[1]
+
+                if line.split()[0] == 'cgroup':
+                    for option in line.split()[3].split(','):
+                        if option == controller:
+                            return CgroupVersion.CGROUP_V1
+                elif line.split()[0] == 'cgroup2':
+                    with open(os.path.join(mnt_path, 'cgroup.controllers'), 'r') as ctrlf:
+                        controllers = ctrlf.readline()
+                        for ctrl in controllers.split():
+                            if ctrl == controller:
+                                return CgroupVersion.CGROUP_V2
+
+        raise IndexError("Unknown version for controller {}".format(controller))
+
+class Cgroup(object):
+    # This class is analogous to libcgroup's struct cgroup
+    def __init__(self, name):
+        self.name = name
+        # self.controllers maps to
+        # struct cgroup_controller *controller[CG_CONTROLLER_MAX];
+        self.controllers = dict()
+
+        self.children = list()
+
+    def __str__(self):
+        out_str = "Cgroup {}\n".format(self.name)
+        for ctrl_key in self.controllers:
+            out_str += utils.indent(str(self.controllers[ctrl_key]), 4)
+
+        return out_str
+
+    def __eq__(self, other):
+        if not isinstance(other, Cgroup):
+            return False
+
+        if not self.name == other.name:
+            return False
+
+        if self.controllers != other.controllers:
+            return False
+
+        return True
+
+    @staticmethod
+    def build_cmd_path(cmd):
+        return os.path.join(consts.LIBCG_MOUNT_POINT,
+                            'src/tools/{}'.format(cmd))
+
+    @staticmethod
+    def build_daemon_path(cmd):
+        return os.path.join(consts.LIBCG_MOUNT_POINT,
+                            'src/daemon/{}'.format(cmd))
+
+    # TODO - add support for all of the cgcreate options
+    @staticmethod
+    def create(config, controller_list, cgname):
+        if isinstance(controller_list, str):
+            controller_list = [controller_list]
+
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgcreate'))
+
+        controllers_and_path = '{}:{}'.format(
+            ','.join(controller_list), cgname)
+
+        cmd.append('-g')
+        cmd.append(controllers_and_path)
+
+        if config.args.container:
+            config.container.run(cmd)
+        else:
+            Run.run(cmd)
+
+    @staticmethod
+    def delete(config, controller_list, cgname, recursive=False):
+        if isinstance(controller_list, str):
+            controller_list = [controller_list]
+
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgdelete'))
+
+        if recursive:
+            cmd.append('-r')
+
+        controllers_and_path = '{}:{}'.format(
+            ''.join(controller_list), cgname)
+
+        cmd.append('-g')
+        cmd.append(controllers_and_path)
+
+        if config.args.container:
+            config.container.run(cmd)
+        else:
+            Run.run(cmd)
+
+    @staticmethod
+    def set(config, cgname=None, setting=None, value=None, copy_from=None,
+            cghelp=False):
+        """cgset equivalent method
+
+        The following variants of cgset are being tested by the
+        automated functional tests:
+
+        Command                                          Test Number
+        cgset -r setting=value cgname                        various
+        cgset -r setting1=val1 -r setting2=val2
+              -r setting3=val2 cgname                            022
+        cgset --copy_from foo bar                                023
+        cgset --copy_from foo bar1 bar2                          024
+        cgset -r setting=value foo bar                           025
+        cgset -r setting1=value1 setting2=value2 foo bar         026
+        various invalid flag combinations                        027
+        """
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgset'))
+
+        if setting is not None or value is not None:
+            if isinstance(setting, str) and isinstance(value, str):
+                cmd.append('-r')
+                cmd.append('{}={}'.format(setting, value))
+            elif isinstance(setting, list) and isinstance(value, list):
+                if len(setting) != len(value):
+                    raise ValueError('Settings list length must equal values list length')
+
+                for idx, stg in enumerate(setting):
+                    cmd.append('-r')
+                    cmd.append('{}={}'.format(stg, value[idx]))
+            else:
+                raise ValueError('Invalid inputs to cgget:\nsetting: {}\n' \
+                                 'value{}'.format(setting, value))
+
+        if copy_from is not None:
+            cmd.append('--copy-from')
+            cmd.append(copy_from)
+
+        if cgname is not None:
+            if isinstance(cgname, str):
+                # use the string as is
+                cmd.append(cgname)
+            elif isinstance(cgname, list):
+                for cg in cgname:
+                    cmd.append(cg)
+
+        if cghelp:
+            cmd.append('-h')
+
+        if config.args.container:
+            return config.container.run(cmd)
+        else:
+            return Run.run(cmd)
+
+    @staticmethod
+    def get(config, controller=None, cgname=None, setting=None,
+            print_headers=True, values_only=False,
+            all_controllers=False, cghelp=False):
+        """cgget equivalent method
+
+        Returns:
+        str: The stdout result of cgget
+
+        The following variants of cgget() are being tested by the
+        automated functional tests:
+
+        Command                                          Test Number
+        cgget -r cpuset.cpus mycg                                001
+        cgget -r cpuset.cpus -r cpuset.mems mycg                 008
+        cgget -g cpu mycg                                        009
+        cgget -g cpu:mycg                                        010
+        cgget -r cpuset.cpus mycg1 mycg2                         011
+        cgget -r cpuset.cpus -r cpuset.mems mycg1 mycg2          012
+        cgget -g cpu -g freezer mycg                             013
+        cgget -a mycg                                            014
+        cgget -r memory.stat mycg (multiline value read)         015
+        various invalid flag combinations                        016
+        """
+        cmd = list()
+        cmd.append(Cgroup.build_cmd_path('cgget'))
+
+        if not print_headers:
+            cmd.append('-n')
+        if values_only:
+            cmd.append('-v')
+
+        if setting is not None:
+            if isinstance(setting, str):
+                # the user provided a simple string.  use it as is
+                cmd.append('-r')
+                cmd.append(setting)
+            elif isinstance(setting, list):
+                for sttng in setting:
+                    cmd.append('-r')
+                    cmd.append(sttng)
+            else:
+                raise ValueError('Unsupported setting value')
+
+        if controller is not None:
+            if isinstance(controller, str) and ':' in controller:
+                # the user provided a controller:cgroup.  use it as is
+                cmd.append('-g')
+                cmd.append(controller)
+            elif isinstance(controller, str):
+                # the user provided a controller only.  use it as is
+                cmd.append('-g')
+                cmd.append(controller)
+            elif isinstance(controller, list):
+                for ctrl in controller:
+                    cmd.append('-g')
+                    cmd.append(ctrl)
+            else:
+                raise ValueError('Unsupported controller value')
+
+        if all_controllers:
+            cmd.append('-a')
+
+        if cgname is not None:
+            if isinstance(cgname, str):
+                # use the string as is
+                cmd.append(cgname)
+            elif isinstance(cgname, list):
+                for cg in cgname:
+                    cmd.append(cg)
+
+        if cghelp:
+            cmd.append('-h')
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            try:
+                ret = Run.run(cmd)
+            except RunError as re:
+                if "profiling" in re.stderr:
+                    ret = re.stdout
+                else:
+                    raise re
+
+        return ret
+
+    @staticmethod
+    def classify(config, controller, cgname, pid_list, sticky=False,
+                 cancel_sticky=False):
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgclassify'))
+        cmd.append('-g')
+        cmd.append('{}:{}'.format(controller, cgname))
+
+        if isinstance(pid_list, str):
+            cmd.append(pid_list)
+        elif isinstance(pid_list, int):
+            cmd.append(str(pid_list))
+        elif isinstance(pid_list, list):
+            for pid in pid_list:
+                cmd.append(pid)
+
+        if config.args.container:
+            config.container.run(cmd)
+        else:
+            Run.run(cmd)
+
+    @staticmethod
+    # given a stdout of cgsnapshot-like data, create a dictionary of cgroup objects
+    def snapshot_to_dict(cgsnapshot_stdout):
+        cgdict = dict()
+
+        class parsemode(Enum):
+            UNKNOWN = 0
+            GROUP = 1
+            CONTROLLER = 2
+            SETTING = 3
+            PERM = 4
+            ADMIN = 5
+            TASK = 6
+
+        mode = parsemode.UNKNOWN
+
+        for line in cgsnapshot_stdout.splitlines():
+            line = line.strip()
+
+            if mode == parsemode.UNKNOWN:
+                if line.startswith("#"):
+                    continue
+
+                elif line.startswith("group") and line.endswith("{"):
+                    cg_name = line.split()[1]
+                    if cg_name in cgdict:
+                        # We already have a cgroup with this name.  This block
+                        # of text contains the next controller for this cgroup
+                        cg = cgdict[cg_name]
+                    else:
+                        cg = Cgroup(cg_name)
+
+                    mode = parsemode.GROUP
+
+            elif mode == parsemode.GROUP:
+                if line.startswith("perm {"):
+                    mode = parsemode.PERM
+                elif line.endswith("{"):
+                    ctrl_name = line.split()[0]
+                    cg.controllers[ctrl_name] = Controller(ctrl_name)
+
+                    mode = parsemode.CONTROLLER
+                elif line.endswith("}"):
+                    # we've found the end of this group
+                    cgdict[cg_name] = cg
+
+                    mode = parsemode.UNKNOWN
+
+            elif mode == parsemode.CONTROLLER:
+                if line.endswith("\";"):
+                    # this is a setting on a single line
+                    setting = line.split("=")[0]
+                    value = line.split("=")[1]
+
+                    cg.controllers[ctrl_name].settings[setting] = value
+
+                elif line.endswith("}"):
+                    # we've found the end of this controller
+                    mode = parsemode.GROUP
+
+                else:
+                    # this is a multi-line setting
+                    setting = line.split("=")[0]
+                    value = "{}\n".format(line.split("=")[1])
+                    mode = parsemode.SETTING
+
+            elif mode == parsemode.SETTING:
+                if line.endswith("\";"):
+                    # this is the last line of the multi-line setting
+                    value += line
+
+                    cg.controllers[ctrl_name].settings[setting] = value
+                    mode = parsemode.CONTROLLER
+
+                else:
+                    value += "{}\n".format(line)
+
+            elif mode == parsemode.PERM:
+                if line.startswith("admin {"):
+                    mode = parsemode.ADMIN
+                elif line.startswith("task {"):
+                    mode = parsemode.TASK
+                elif line.endswith("}"):
+                    mode = parsemode.GROUP
+
+            elif mode == parsemode.ADMIN or mode == parsemode.TASK:
+                # todo - handle these modes
+                if line.endswith("}"):
+                    mode = parsemode.PERM
+
+        return cgdict
+
+    @staticmethod
+    def snapshot(config, controller=None):
+        cmd = list()
+        cmd.append(Cgroup.build_cmd_path('cgsnapshot'))
+        if controller is not None:
+            cmd.append(controller)
+
+        # ensure the deny list file exists
+        if config.args.container:
+            try:
+                config.container.run(['sudo', 'touch', '/etc/cgsnapshot_blacklist.conf'])
+            except RunError as re:
+                if re.ret == 0 and "unable to resolve host" in re.stderr:
+                    pass
+        else:
+            Run.run(['sudo', 'touch', '/etc/cgsnapshot_blacklist.conf'])
+
+        try:
+            if config.args.container:
+                res = config.container.run(cmd)
+            else:
+                res = Run.run(cmd)
+        except RunError as re:
+            if re.ret == 0 and \
+               "neither blacklisted nor whitelisted" in re.stderr:
+                res = re.stdout
+
+        # convert the cgsnapshot stdout to a dict of cgroup objects
+        return Cgroup.snapshot_to_dict(res)
+
+    @staticmethod
+    def set_cgrules_conf(config, line, append=True):
+        cmd = list()
+
+        cmd.append('sudo')
+        cmd.append('su')
+        cmd.append('-c')
+
+        if append:
+            redirect_str = '>>'
+        else:
+            redirect_str = '>'
+
+        subcmd = '"echo {} {} {}"'.format(line, redirect_str,
+                                          consts.CGRULES_FILE)
+        cmd.append(subcmd)
+
+        if config.args.container:
+            config.container.run(cmd, shell_bool=True)
+        else:
+            Run.run(cmd, shell_bool=True)
+
+    @staticmethod
+    def init_cgrules(config):
+        cmd = list()
+
+        cmd.append('sudo')
+        cmd.append('mkdir')
+        cmd.append('/etc/cgconfig.d')
+
+        try:
+            if config.args.container:
+                config.container.run(cmd, shell_bool=True)
+            else:
+                Run.run(cmd, shell_bool=True)
+        except:
+            # todo - check the errno to ensure the directory exists rather
+            # than receiving a different error
+            pass
+
+        cmd2 = list()
+
+        cmd2.append('sudo')
+        cmd2.append('touch')
+        cmd2.append('/etc/cgconfig.conf')
+
+        if config.args.container:
+            config.container.run(cmd2, shell_bool=True)
+        else:
+            Run.run(cmd2, shell_bool=True)
+
+    # note that this runs cgrulesengd in this process and does not fork
+    # the daemon
+    @staticmethod
+    def __run_cgrules(config):
+        cmd = list()
+
+        cmd.append('sudo')
+        cmd.append(Cgroup.build_daemon_path('cgrulesengd'))
+        cmd.append('-d')
+        cmd.append('-n')
+
+        if config.args.container:
+            raise ValueError("Running cgrules within a container is not supported")
+        else:
+            Run.run(cmd, shell_bool=True)
+
+    def start_cgrules(self, config):
+        Cgroup.init_cgrules(config)
+
+        p = mp.Process(target=Cgroup.__run_cgrules,
+                       args=(config, ))
+        p.start()
+        time.sleep(2)
+
+        self.children.append(p)
+
+    def join_children(self, config):
+        # todo - make this smarter.  this is ugly, but it works for now
+        cmd = ['sudo', 'killall', 'cgrulesengd']
+        try:
+            if config.args.container:
+                config.container.run(cmd, shell_bool=True)
+            else:
+                Run.run(cmd, shell_bool=True)
+        except:
+            # ignore any errors during the kill command.  this is belt
+            # and suspenders code
+            pass
+
+        for child in self.children:
+            child.join(1)
+
+    @staticmethod
+    def configparser(config, load_file=None, load_dir=None, dflt_usr=None,
+                     dflt_grp=None, dperm=None, fperm=None, cghelp=False,
+                     tperm=None, tasks_usr=None, tasks_grp=None):
+        """cgconfigparser equivalent method
+
+        Returns:
+        str: The stdout result of cgconfigparser
+
+        The following variants of cgconfigparser are being tested by the
+        automated functional tests:
+
+        Command                                          Test Number
+        cgconfigparser -l conf_file                              017
+        cgconfigparser -L conf_dir                               018
+        cgconfigparser -l conf_file -a usr:grp -d mode -f mode   019
+        cgconfigparser -l conf_file -s mode -t usr:grp           020
+        cgconfigparser -h                                        021
+        cgconfigparser -l improper_conf_file                     021
+        """
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgconfigparser'))
+
+        if load_file is not None:
+            cmd.append('-l')
+            cmd.append(load_file)
+
+        if load_dir is not None:
+            cmd.append('-L')
+            cmd.append(load_dir)
+
+        if dflt_usr is not None and dflt_grp is not None:
+            cmd.append('-a')
+            cmd.append('{}:{}'.format(dflt_usr, dflt_grp))
+
+        if dperm is not None:
+            cmd.append('-d')
+            cmd.append(dperm)
+
+        if fperm is not None:
+            cmd.append('-f')
+            cmd.append(fperm)
+
+        if cghelp:
+            cmd.append('-h')
+
+        if tperm is not None:
+            cmd.append('-s')
+            cmd.append(tperm)
+
+        if tasks_usr is not None and tasks_grp is not None:
+            cmd.append('-t')
+            cmd.append('{}:{}'.format(tasks_usr, tasks_grp))
+
+        if config.args.container:
+            return config.container.run(cmd)
+        else:
+            return Run.run(cmd)
+
+    @staticmethod
+    def __get_controller_mount_point_v1(ctrl_name):
+        with open('/proc/mounts', 'r') as mntf:
+            for line in mntf.readlines():
+                mnt_path = line.split()[1]
+
+                if line.split()[0] == 'cgroup':
+                    for option in line.split()[3].split(','):
+                        if option == ctrl_name:
+                            return line.split()[1]
+
+        raise IndexError("Unknown mount point for controller {}".format(ctrl_name))
+
+    @staticmethod
+    def __get_controller_mount_point_v2(ctrl_name):
+        with open('/proc/mounts', 'r') as mntf:
+            for line in mntf.readlines():
+                mnt_path = line.split()[1]
+
+                if line.split()[0] == 'cgroup2':
+                    ctrl_file = os.path.join(line.split()[1],
+                                             'cgroup.controllers')
+
+                    with open(ctrl_file, 'r') as ctrlf:
+                        controllers = ctrlf.readline()
+                        for controller in controllers.split():
+                            if controller == ctrl_name:
+                                return mnt_path
+
+        raise IndexError("Unknown mount point for controller {}".format(ctrl_name))
+
+    @staticmethod
+    def get_controller_mount_point(ctrl_name):
+        vers = CgroupVersion.get_version(ctrl_name)
+
+        if vers == CgroupVersion.CGROUP_V1:
+            return Cgroup.__get_controller_mount_point_v1(ctrl_name)
+        elif vers == CgroupVersion.CGROUP_V2:
+            return Cgroup.__get_controller_mount_point_v2(ctrl_name)
+        else:
+            raise ValueError("Unsupported cgroup version")
+
+    @staticmethod
+    def clear(config, empty=False, cghelp=False, load_file=None, load_dir=None):
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgclear'))
+
+        if empty:
+            cmd.append('-e')
+
+        if cghelp:
+            cmd.append('-h')
+
+        if load_file is not None:
+            cmd.append('-l')
+            cmd.append(load_file)
+
+        if load_dir is not None:
+            cmd.append('-L')
+            cmd.append(load_dir)
+
+        if config.args.container:
+            return config.container.run(cmd)
+        else:
+            return Run.run(cmd)
+
+    @staticmethod
+    def lssubsys(config, ls_all=False, cghelp=False, hierarchies=False,
+                 mount_points=False, all_mount_points=False):
+        cmd = list()
+
+        cmd.append(Cgroup.build_cmd_path('lssubsys'))
+
+        if ls_all:
+            cmd.append('-a')
+
+        if cghelp:
+            cmd.append('-h')
+
+        if hierarchies:
+            cmd.append('-i')
+
+        if mount_points:
+            cmd.append('-m')
+
+        if all_mount_points:
+            cmd.append('-M')
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            try:
+                ret = Run.run(cmd)
+            except RunError as re:
+                if "profiling" in re.stderr:
+                    ret = re.stdout
+                else:
+                    raise re
+
+        return ret
+
+    @staticmethod
+    def get_cgroup_mounts(config, expand_v2_mounts=True):
+        mount_list = list()
+
+        with open('/proc/mounts') as mntf:
+            for line in mntf.readlines():
+                entry = line.split()
+
+                if entry[0] != "cgroup" and entry[0] != "cgroup2":
+                    continue
+
+                mount = CgroupMount(line)
+
+                if mount.version == CgroupVersion.CGROUP_V1 or \
+                   expand_v2_mounts == False:
+                    mount_list.append(mount)
+                    continue
+
+                with open(os.path.join(mount.mount_point,
+                                       "cgroup.controllers")) as ctrlf:
+                    for line in ctrlf.readlines():
+                        for ctrl in line.split():
+                            mount_copy = copy.deepcopy(mount)
+                            mount_copy.controller = ctrl
+                            mount_list.append(mount_copy)
+
+        return mount_list
+
+    @staticmethod
+    def lscgroup(config, cghelp=False, controller=None, path=None):
+        cmd = list()
+
+        cmd.append(Cgroup.build_cmd_path('lscgroup'))
+
+        if cghelp:
+            cmd.append('-h')
+
+        if controller is not None and path is not None:
+            if isinstance(controller, list):
+                for idx, ctrl in enumerate(controller):
+                    cmd.append('-g')
+                    cmd.append('{}:{}'.format(ctrl, path[idx]))
+            elif isinstance(controller, str):
+                cmd.append('-g')
+                cmd.append('{}:{}'.format(controller, path))
+            else:
+                raise ValueError('Unsupported controller value')
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            try:
+                ret = Run.run(cmd)
+            except RunError as re:
+                if "profiling" in re.stderr:
+                    ret = re.stdout
+                else:
+                    raise re
+
+        return ret
+
+    # exec is a keyword in python, so let's name this function cgexec
+    @staticmethod
+    def cgexec(config, controller, cgname, cmdline, sticky=False,
+               cghelp=False):
+        """cgexec equivalent method
+        """
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgexec'))
+        cmd.append('-g')
+        cmd.append('{}:{}'.format(controller, cgname))
+
+        if sticky:
+            cmd.append('--sticky')
+
+        if isinstance(cmdline, str):
+            cmd.append(cmdline)
+        elif isinstance(cmdline, list):
+            for entry in cmdline:
+                cmd.append(entry)
+
+        if cghelp:
+            cmd.append('-h')
+
+        if config.args.container:
+            return config.container.run(cmd, shell_bool=True)
+        else:
+            return Run.run(cmd, shell_bool=True)
+
+    @staticmethod
+    def get_pids_in_cgroup(config, cgroup, controller):
+        mounts = Cgroup.get_cgroup_mounts(config)
+
+        for mount in mounts:
+            if mount.controller == controller:
+                proc_file = os.path.join(mount.mount_point, cgroup, "cgroup.procs")
+                cmd = ['cat', proc_file]
+
+                if config.args.container:
+                    return config.container.run(cmd, shell_bool=True)
+                else:
+                    return Run.run(cmd, shell_bool=True)
+
+        return None

--- a/tests/ftests/config.py
+++ b/tests/ftests/config.py
@@ -1,0 +1,65 @@
+#
+# Config class for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import consts
+from container import Container
+import os
+from process import Process
+import utils
+
+class Config(object):
+    def __init__(self, args, container=None):
+        self.args = args
+        self.skip_list = []
+
+        if self.args.container:
+            if container:
+                self.container = container
+            else:
+                # Use the default container settings
+                self.container = Container(name=consts.DEFAULT_CONTAINER_NAME,
+                    stop_timeout=args.timeout, arch=None,
+                    distro=args.distro, release=args.release)
+
+        self.process = Process()
+
+        self.ftest_dir = os.path.dirname(os.path.abspath(__file__))
+        self.libcg_dir = os.path.dirname(self.ftest_dir)
+
+        self.test_suite = consts.TESTS_RUN_ALL_SUITES
+        self.test_num = consts.TESTS_RUN_ALL
+        self.verbose = False
+
+    def __str__(self):
+        out_str = "Configuration\n"
+        if self.args.container:
+            out_str += utils.indent(str(self.container), 4)
+        out_str += utils.indent(str(self.process), 4)
+
+        return out_str
+
+class ConfigError(Exception):
+    def __init__(self, message):
+        super(ConfigError, self).__init__(message)
+
+    def __str__(self):
+        out_str = "ConfigError:\n\tmessage = {}".format(self.message)
+        return out_str

--- a/tests/ftests/consts.py
+++ b/tests/ftests/consts.py
@@ -1,0 +1,47 @@
+#
+# Constants for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import os
+
+DEFAULT_LOG_FILE = 'libcgroup-ftests.log'
+
+LOG_CRITICAL = 1
+LOG_WARNING = 5
+LOG_DEBUG = 8
+DEFAULT_LOG_LEVEL = 5
+
+ftest_dir = os.path.dirname(os.path.abspath(__file__))
+tests_dir = os.path.dirname(ftest_dir)
+LIBCG_MOUNT_POINT = os.path.dirname(tests_dir)
+
+DEFAULT_CONTAINER_NAME = 'TestLibcg'
+DEFAULT_CONTAINER_DISTRO = 'ubuntu'
+DEFAULT_CONTAINER_RELEASE = '22.04'
+DEFAULT_CONTAINER_ARCH = 'amd64'
+DEFAULT_CONTAINER_STOP_TIMEOUT = 5
+
+TESTS_RUN_ALL = -1
+TESTS_RUN_ALL_SUITES = "allsuites"
+TEST_PASSED = "passed"
+TEST_FAILED = "failed"
+TEST_SKIPPED = "skipped"
+
+CGRULES_FILE = "/etc/cgrules.conf"

--- a/tests/ftests/container.py
+++ b/tests/ftests/container.py
@@ -1,0 +1,191 @@
+#
+# Container class for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import consts
+import getpass
+from log import Log
+import os
+from run import Run
+
+class Container(object):
+    def __init__(self, name, stop_timeout=None, arch=None, cfg_path=None,
+                 distro=None, release=None):
+        self.name = name
+        self.privileged = True
+
+        if stop_timeout:
+            self.stop_timeout = stop_timeout
+        else:
+            self.stop_timeout = consts.DEFAULT_CONTAINER_STOP_TIMEOUT
+
+        if arch:
+            self.arch = arch
+        else:
+            self.arch = consts.DEFAULT_CONTAINER_ARCH
+
+        if distro:
+            self.distro = distro
+        else:
+            self.distro = consts.DEFAULT_CONTAINER_DISTRO
+
+        if release:
+            self.release = release
+        else:
+            self.release = consts.DEFAULT_CONTAINER_RELEASE
+
+        ftest_dir = os.path.dirname(os.path.abspath(__file__))
+        tests_dir = os.path.dirname(ftest_dir)
+        # save off the path to the libcgroup source code
+        self.libcg_dir = os.path.dirname(tests_dir)
+
+
+    def __str__(self):
+        out_str = "Container {}".format(self.name)
+        out_str += "\n\tdistro = {}".format(self.distro)
+        out_str += "\n\trelease = {}".format(self.release)
+        out_str += "\n\tarch = {}".format(self.arch)
+        out_str += "\n\tstop_timeout = {}\n".format(self.stop_timeout)
+
+        return out_str
+
+    # configure the container to meet our needs
+    def config(self):
+        ftest_dir = os.path.dirname(os.path.abspath(__file__))
+        tests_dir = os.path.dirname(ftest_dir)
+        libcg_dir = os.path.dirname(tests_dir)
+
+        # map our UID and GID to the same UID/GID in the container
+        cmd = 'printf "uid {} 1000\ngid {} 1000" | sudo lxc config set {} raw.idmap -'.format(
+              os.getuid(), os.getgid(), self.name)
+        Run.run(cmd, shell_bool=True)
+
+        # add the libcgroup root directory (where we did the build) into
+        # the container
+        cmd2 = list()
+        if self.privileged:
+            cmd2.append('sudo')
+        cmd2.append('lxc')
+        cmd2.append('config')
+        cmd2.append('device')
+        cmd2.append('add')
+        cmd2.append(self.name)
+        cmd2.append('libcgsrc') # arbitrary name of device
+        cmd2.append('disk')
+        # to appease gcov, mount the libcgroup source at the same path as we
+        # built it.  This can be worked around someday by using
+        # GCOV_PREFIX_STRIP, but that was more difficult to setup than just
+        # doing this initially
+        cmd2.append('source={}'.format(self.libcg_dir))
+        cmd2.append('path={}'.format(self.libcg_dir))
+
+        return Run.run(cmd2)
+
+    def create(self):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('init')
+
+        cmd.append('{}:{}'.format(self.distro, self.release))
+
+        cmd.append(self.name)
+
+        return Run.run(cmd)
+
+    def delete(self):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('delete')
+
+        cmd.append(self.name)
+
+        return Run.run(cmd)
+
+    def run(self, cntnr_cmd, shell_bool=False):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('exec')
+
+        cmd.append(self.name)
+
+        cmd.append('--')
+
+        # concatenate the lxc exec command with the command to be run
+        # inside the container
+        if isinstance(cntnr_cmd, str):
+            cmd.append(cntnr_cmd)
+        elif isinstance(cntnr_cmd, list):
+            cmd = cmd + cntnr_cmd
+        else:
+            raise ContainerError('Unsupported command type')
+
+        return Run.run(cmd, shell_bool=shell_bool)
+
+    def start(self):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('start')
+
+        cmd.append(self.name)
+
+        return Run.run(cmd)
+
+    def stop(self, force=True):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('stop')
+
+        cmd.append(self.name)
+
+        if force:
+            cmd.append('-f')
+        else:
+            cmd.append('--timeout')
+            cmd.append(str(self.stop_timeout))
+
+        return Run.run(cmd)
+
+class ContainerError(Exception):
+    def __init__(self, message, ret):
+        super(RunError, self).__init__(message)
+
+    def __str__(self):
+        out_str = "ContainerError:\n\tmessage = {}".format(self.message)
+        return out_str

--- a/tests/ftests/controller.py
+++ b/tests/ftests/controller.py
@@ -1,0 +1,69 @@
+#
+# Cgroup class for the libcgroup functional tests
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from log import Log
+
+class Controller(object):
+    # The controller class closely mirrors libcgroup's struct cgroup_controller
+    def __init__(self, name):
+        self.name = name
+        # self.settings maps to
+        # struct control_value *values[CG_NV_MAX];
+        self.settings = dict()
+
+    def __str__(self):
+        out_str = "Controller {}\n".format(self.name)
+
+        for setting_key in self.settings:
+            out_str += "    {} = {}\n".format(setting_key, self.settings[setting_key])
+
+        return out_str
+
+    def __eq__(self, other):
+        if not isinstance(other, Controller):
+            return False
+
+        if not self.name == other.name:
+            return False
+
+        if not self.settings == other.settings:
+            self_keys = set(self.settings.keys())
+            other_keys = set(other.settings.keys())
+
+            added = other_keys - self_keys
+            if added is not None:
+                for key in added:
+                    Log.log_critical("Other contains {} = {}".format(key, other.settings[key]))
+
+            removed = self_keys - other_keys
+            if removed is not None:
+                for key in removed:
+                    Log.log_critical("Self contains {} = {}".format(key, self.settings[key]))
+
+            common = self_keys.intersection(other_keys)
+            for key in common:
+                if self.settings[key] != other.settings[key]:
+                    Log.log_critical("self{} = {} while other{} = {}".format(
+                        key, self.settings[key], key, other.settings[key]))
+
+            return False
+
+        return True

--- a/tests/ftests/ftests-nocontainer.sh
+++ b/tests/ftests/ftests-nocontainer.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./ftests.py -l 10 -L ftests-nocontainer.log --skip 28 --no-container

--- a/tests/ftests/ftests.py
+++ b/tests/ftests/ftests.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+#
+# Main entry point for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import argparse
+from cgroup import Cgroup
+from config import Config
+import consts
+import container
+import datetime
+import log
+from log import Log
+import os
+from process import Process
+from run import Run
+import sys
+import time
+
+setup_time = 0.0
+teardown_time = 0.0
+
+def parse_args():
+    parser = argparse.ArgumentParser("Libcgroup Functional Tests")
+    parser.add_argument('-n', '--name',
+                        help='name of the container',
+                        required=False, type=str, default=None)
+    parser.add_argument('-d', '--distro',
+                        help='linux distribution to use as a template',
+                        required=False, type=str, default=None)
+    parser.add_argument('-r', '--release',
+                        help='distribution release, e.g.\'trusty\'',
+                        required=False, type=str, default=None)
+    parser.add_argument('-a', '--arch',
+                        help='processor architecture',
+                        required=False, type=str, default=None)
+    parser.add_argument('-t', '--timeout',
+                        help='wait timeout (sec) before stopping the container',
+                        required=False, type=int, default=None)
+
+    parser.add_argument('-l', '--loglevel',
+                        help='log level',
+                        required=False, type=int, default=None)
+    parser.add_argument('-L', '--logfile',
+                        help='log file',
+                        required=False, type=str, default=None)
+
+    parser.add_argument('-N', '--num',
+                        help='Test number to run.  If unspecified, all tests are run',
+                        required=False, default=consts.TESTS_RUN_ALL, type=int)
+    parser.add_argument('-S', '--skip',
+                        help='Test number(s) to skip.  If unspecified, all tests are run.'
+                        'To skip multiple tests, separate them via a \',\', e.g. \'5,7,12\'',
+                        required=False, default='', type=str)
+    parser.add_argument('-s', '--suite',
+                        help='Test suite to run, e.g. cpuset', required=False,
+                        default=consts.TESTS_RUN_ALL_SUITES, type=str)
+
+    container_parser = parser.add_mutually_exclusive_group(required=False)
+    container_parser.add_argument('--container', action='store_true',
+                        help='Run the tests in a container. '
+                        'Note that some tests cannot be run in a container.',
+                        dest='container')
+    container_parser.add_argument('--no-container', action='store_false',
+                        help='Do not run the tests in a container. '
+                        'Note that some tests are destructive and will modify your cgroup hierarchy.',
+                        dest='container')
+    parser.set_defaults(container=True)
+
+    parser.add_argument('-v', '--verbose',
+                        help='Print all information about this test run',
+                        default=True, required=False, action="store_false")
+
+    config = Config(parser.parse_args())
+
+    if config.args.skip is None or config.args.skip == '':
+        pass
+    elif config.args.skip.find(',') < 0:
+        config.skip_list.append(int(config.args.skip))
+    else:
+        # multiple tests are being skipped
+        for test_num in config.args.skip.split(','):
+            config.skip_list.append(int(test_num))
+
+    if config.args.loglevel:
+        log.log_level = config.args.loglevel
+    if config.args.logfile:
+        log.log_file = config.args.logfile
+
+    return config
+
+# this function maps the container UID to the host UID.  By doing
+# this, we can write to a bind-mounted device - and thus generate
+# code coverage data in the LXD container
+def update_host_subuid():
+    subuid_line1 = 'lxd:{}:1'.format(os.getuid())
+    subuid_line2 = 'root:{}:1'.format(os.getuid())
+    found_line1 = False
+    found_line2 = False
+
+    with open('/etc/subuid') as ufile:
+        for line in ufile.readlines():
+            if line.strip() == subuid_line1:
+                found_line1 = True
+            elif line.strip() == subuid_line2:
+                found_line2 = True
+
+    if not found_line1:
+        Run.run('sudo sh -c "echo {} >> /etc/subuid"'.format(
+                subuid_line1), shell_bool=True)
+    if not found_line2:
+        Run.run('sudo sh -c "echo {} >> /etc/subuid"'.format(
+                subuid_line2), shell_bool=True)
+
+# this function maps the container GID to the host GID.  By doing
+# this, we can write to a bind-mounted device - and thus generate
+# code coverage data in the LXD container
+def update_host_subgid():
+    subgid_line1 = 'lxd:{}:1'.format(os.getgid())
+    subgid_line2 = 'root:{}:1'.format(os.getgid())
+    found_line1 = False
+    found_line2 = False
+
+    with open('/etc/subgid') as ufile:
+        for line in ufile.readlines():
+            if line.strip() == subgid_line1:
+                found_line1 = True
+            elif line.strip() == subgid_line2:
+                found_line2 = True
+
+    if not found_line1:
+        Run.run('sudo sh -c "echo {} >> /etc/subgid"'.format(
+                subgid_line1), shell_bool=True)
+    if not found_line2:
+        Run.run('sudo sh -c "echo {} >> /etc/subgid"'.format(
+                subgid_line2), shell_bool=True)
+
+def setup(config, do_teardown=True, record_time=False):
+    global setup_time
+
+    start_time = time.time()
+    if do_teardown:
+        # belt and suspenders here.  In case a previous run wasn't properly
+        # cleaned up, let's try and clean it up here
+        try:
+            teardown(config)
+        except Exception as e:
+            # log but ignore all exceptions
+            Log.log_debug(e)
+
+    if config.args.container:
+        # this command initializes the lxd storage, networking, etc.
+        Run.run(['sudo', 'lxd', 'init', '--auto'])
+        update_host_subuid()
+        update_host_subgid()
+
+        config.container.create()
+        config.container.config()
+        config.container.start()
+
+        # add the libcgroup library to the container's ld
+        echo_cmd = ['bash', '-c', 'echo {} >> /etc/ld.so.conf.d/libcgroup.conf'.format(
+                   os.path.join(consts.LIBCG_MOUNT_POINT, 'src/.libs'))]
+        config.container.run(echo_cmd)
+        config.container.run('ldconfig')
+
+    if record_time:
+        setup_time = time.time() - start_time
+
+def run_tests(config):
+    passed_tests = []
+    failed_tests = []
+    skipped_tests = []
+    filename_max = 0
+
+    for root, dirs, filenames in os.walk(config.ftest_dir):
+        for filename in filenames:
+            if os.path.splitext(filename)[-1] != ".py":
+                # ignore non-python files
+                continue
+
+            filenum = filename.split('-')[0]
+
+            try:
+                filenum_int = int(filenum)
+            except ValueError:
+                # D'oh.  This file must not be a test.  Skip it
+                Log.log_debug('Skipping {}.  It doesn\'t start with an int'.format(
+                              filename))
+                continue
+
+            try:
+                filesuite = filename.split('-')[1]
+            except IndexError:
+                Log.log_error(
+                    'Skipping {}.  It doesn\'t conform to the filename format'.format(
+                    filename))
+                continue
+
+            if config.args.suite == consts.TESTS_RUN_ALL_SUITES or \
+               config.args.suite == filesuite:
+                if config.args.num == consts.TESTS_RUN_ALL or \
+                   config.args.num == filenum_int:
+
+                    if filenum_int in config.skip_list:
+                        continue
+
+                    if len(filename) > filename_max:
+                        filename_max = len(filename)
+
+                    test = __import__(os.path.splitext(filename)[0])
+
+                    failure_cause = None
+                    start_time = time.time()
+                    try:
+                        Log.log_debug('Running test {}.'.format(filename))
+                        [ret, failure_cause] = test.main(config)
+                    except Exception as e:
+                        # catch all exceptions.  you never know when there's
+                        # a crummy test
+                        failure_cause = e
+                        Log.log_debug(e)
+                        ret = consts.TEST_FAILED
+
+                        # if the test does cause an exception, it may not have
+                        # cleaned up after itself.  re-create the container
+                        teardown(config)
+                        setup(config, do_teardown=False)
+                    finally:
+                        run_time = time.time() - start_time
+                        if ret == consts.TEST_PASSED:
+                            passed_tests.append([filename, run_time])
+                        elif ret == consts.TEST_FAILED:
+                            failed_tests.append([filename, run_time, failure_cause])
+                        elif ret == consts.TEST_SKIPPED:
+                            skipped_tests.append([filename, run_time, failure_cause])
+                        else:
+                            raise ValueError('Unexpected ret: {}'.format(ret))
+
+    passed_cnt = len(passed_tests)
+    failed_cnt = len(failed_tests)
+    skipped_cnt = len(skipped_tests)
+
+    print("-----------------------------------------------------------------")
+    print("Test Results:")
+    date_str = datetime.datetime.now().strftime('%b %d %H:%M:%S')
+    print('\t{}{}'.format('{0: <35}'.format("Run Date:"), '{0: >15}'.format(date_str)))
+
+    test_str = "{} test(s)".format(passed_cnt)
+    print('\t{}{}'.format('{0: <35}'.format("Passed:"), '{0: >15}'.format(test_str)))
+
+    test_str = "{} test(s)".format(skipped_cnt)
+    print('\t{}{}'.format('{0: <35}'.format("Skipped:"), '{0: >15}'.format(test_str)))
+
+    test_str = "{} test(s)".format(failed_cnt)
+    print('\t{}{}'.format('{0: <35}'.format("Failed:"), '{0: >15}'.format(test_str)))
+
+    for test in failed_tests:
+        print("\t\tTest:\t\t\t\t{} - {}".format(test[0], str(test[2])))
+    print("-----------------------------------------------------------------")
+
+    global setup_time
+    global teardown_time
+    if config.args.verbose:
+        print("Timing Results:")
+        print('\t{}{}'.format('{0: <{1}}'.format("Test", filename_max), '{0: >15}'.format("Time (sec)")))
+        print('\t{}'.format('-' * (filename_max + 15))) # 15 is padding space of "Time (sec)"
+        time_str = "{0: 2.2f}".format(setup_time)
+        print('\t{}{}'.format('{0: <{1}}'.format('setup', filename_max), '{0: >15}'.format(time_str)))
+
+        all_tests = passed_tests + skipped_tests + failed_tests
+        all_tests.sort()
+        for test in all_tests:
+            time_str = "{0: 2.2f}".format(test[1])
+            print('\t{}{}'.format('{0: <{1}}'.format(test[0], filename_max), '{0: >15}'.format(time_str)))
+        time_str = "{0: 2.2f}".format(teardown_time)
+        print('\t{}{}'.format('{0: <{1}}'.format('teardown', filename_max), '{0: >15}'.format(time_str)))
+
+        total_run_time = setup_time + teardown_time
+        for test in passed_tests:
+            total_run_time += test[1]
+        for test in failed_tests:
+            total_run_time += test[1]
+        total_str = "{0: 5.2f}".format(total_run_time)
+        print('\t{}'.format('-' * (filename_max + 15)))
+        print('\t{}{}'.format('{0: <{1}}'.format("Total Run Time", filename_max), '{0: >15}'.format(total_str)))
+
+    return [passed_cnt, failed_cnt, skipped_cnt]
+
+def teardown(config, record_time=False):
+    global teardown_time
+    start_time = time.time()
+
+    config.process.join_children(config)
+
+    if config.args.container:
+        try:
+            config.container.stop()
+        except Exception as e:
+            # log but ignore all exceptions
+            Log.log_debug(e)
+        try:
+            config.container.delete()
+        except Exception as e:
+            # log but ignore all exceptions
+            Log.log_debug(e)
+
+    if record_time:
+        teardown_time = time.time() - start_time
+
+def main(config):
+    AUTOMAKE_SKIPPED = 77
+    AUTOMAKE_HARD_ERROR = 99
+    AUTOMAKE_PASSED = 0
+
+    try:
+        setup(config, record_time=True)
+        [passed_cnt, failed_cnt, skipped_cnt] = run_tests(config)
+    finally:
+        teardown(config, record_time=True)
+
+    if failed_cnt > 0:
+        return failed_cnt
+    if passed_cnt > 0:
+        return AUTOMAKE_PASSED
+    if skipped_cnt > 0:
+        return AUTOMAKE_SKIPPED
+
+    return AUTOMAKE_HARD_ERROR
+
+if __name__ == '__main__':
+    config = parse_args()
+    sys.exit(main(config))

--- a/tests/ftests/ftests.sh
+++ b/tests/ftests/ftests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./ftests.py -l 10 -L ftests.log

--- a/tests/ftests/log.py
+++ b/tests/ftests/log.py
@@ -1,0 +1,56 @@
+#
+# Log class for the libcgroup functional tests
+#
+# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import consts
+import datetime
+import log
+
+log_level = consts.DEFAULT_LOG_LEVEL
+log_file = consts.DEFAULT_LOG_FILE
+log_fd = None
+
+
+class Log(object):
+
+    @staticmethod
+    def log(msg, msg_level=consts.DEFAULT_LOG_LEVEL):
+        if log_level >= msg_level:
+            if log.log_fd is None:
+                Log.open_logfd(log.log_file)
+
+            timestamp = datetime.datetime.now().strftime('%b %d %H:%M:%S')
+            log_fd.write("{}: {}\n".format(timestamp, msg))
+
+    @staticmethod
+    def open_logfd(log_file):
+        log.log_fd = open(log_file, "a")
+
+    @staticmethod
+    def log_critical(msg):
+        Log.log("CRITICAL: {}".format(msg), consts.LOG_CRITICAL)
+
+    @staticmethod
+    def log_warning(msg):
+        Log.log("WARNING: {}".format(msg), consts.LOG_WARNING)
+
+    @staticmethod
+    def log_debug(msg):
+        Log.log("DEBUG: {}".format(msg), consts.LOG_DEBUG)

--- a/tests/ftests/process.py
+++ b/tests/ftests/process.py
@@ -1,0 +1,218 @@
+#
+# Cgroup class for the libcgroup functional tests
+#
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup
+from cgroup import CgroupVersion
+import multiprocessing as mp
+from run import Run
+from run import RunError
+import time
+
+class Process(object):
+    def __init__(self):
+        self.children = list()
+        self.children_pids = list()
+
+    def __str__(self):
+        out_str = "Process Class\n"
+        out_str += "\tchildren = {}\n".format(self.children)
+        out_str += "\tchildren_pids = {}\n".format(self.children_pids)
+
+        return out_str
+
+    @staticmethod
+    def __infinite_loop(config, sleep_time=1):
+        cmd = ['/usr/bin/perl', '-e', '\'while(1){{sleep({})}};\''.format(sleep_time)]
+
+        try:
+            if config.args.container:
+                config.container.run(cmd, shell_bool=True)
+            else:
+                Run.run(cmd, shell_bool=True)
+        except RunError as re:
+            # when the process is killed, a RunError will be thrown.  let's
+            # catch and suppress it
+            pass
+
+    @staticmethod
+    def __cgexec_infinite_loop(config, controller, cgname, sleep_time=1):
+        cmd = ['/usr/bin/perl', '-e', '\'while(1){{sleep({})}};\''.format(sleep_time)]
+
+        try:
+            Cgroup.cgexec(config, controller, cgname, cmd)
+        except RunError as re:
+            # When this process is killed, it will throw a run error.
+            # Ignore it.
+            pass
+
+    def __save_child_pid(self, config, sleep_time):
+        # get the PID of the newly spawned infinite loop
+        cmd = 'ps x | grep perl | grep "sleep({})" | awk \'{{print $1}}\''.format(sleep_time)
+
+        if config.args.container:
+            pid = config.container.run(cmd, shell_bool=True)
+        else:
+            pid = Run.run(cmd, shell_bool=True)
+
+            for _pid in pid.splitlines():
+                self.children_pids.append(_pid)
+
+            if pid.find('\n') >= 0:
+                # The second pid in the list contains the actual perl process
+                pid = pid.splitlines()[1]
+
+        if pid == "" or int(pid) <= 0:
+            raise ValueError('Failed to get the pid of the child process: {}'.format(pid))
+
+        return pid
+
+    def create_process(self, config):
+        # To allow for multiple processes to be created, each new process
+        # sleeps for a different amount of time.  This lets us uniquely find
+        # each process later in this function
+        sleep_time = len(self.children) + 1
+
+        p = mp.Process(target=Process.__infinite_loop,
+                       args=(config, sleep_time, ))
+        p.start()
+
+        # wait for the process to start.  If we don't wait, then the getpid
+        # logic below may not find the process
+        time.sleep(2)
+
+        pid = self.__save_child_pid(config, sleep_time)
+        self.children.append(p)
+
+        return pid
+
+    # Create a simple process in the requested cgroup
+    def create_process_in_cgroup(self, config, controller, cgname,
+                                 cgclassify=True):
+        if cgclassify:
+            child_pid = self.create_process(config)
+            Cgroup.classify(config, controller, cgname, child_pid)
+        else:
+            # use cgexec
+
+            # To allow for multiple processes to be created, each new process
+            # sleeps for a different amount of time.  This lets us uniquely find
+            # each process later in this function
+            sleep_time = len(self.children) + 1
+
+            p = mp.Process(target=Process.__cgexec_infinite_loop,
+                           args=(config, controller, cgname, sleep_time, ))
+            p.start()
+
+            self.children.append(p)
+
+    # The caller will block until all children are stopped.
+    def join_children(self, config):
+        for child in self.children:
+             child.join(1)
+
+        for child in self.children_pids:
+            try:
+                if config.args.container:
+                    config.container.run(['kill', child])
+                else:
+                    Run.run(['kill', child])
+            except:
+                # ignore any errors during the kill command.  this is belt
+                # and suspenders code
+                pass
+
+    @staticmethod
+    def __get_cgroup_v1(config, pid, controller):
+        cmd = list()
+
+        cmd.append('cat')
+        cmd.append('/proc/{}/cgroup'.format(pid))
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            ret = Run.run(cmd)
+
+        for line in ret.splitlines():
+            # cgroup v1 appears in /proc/{pid}/cgroup like the following:
+            # $ cat /proc/1/cgroup
+            # 12:memory:/
+            # 11:hugetlb:/
+            # 10:perf_event:/
+            # 9:rdma:/
+            # 8:devices:/
+            # 7:cpuset:/
+            # 6:blkio:/
+            # 5:cpu,cpuacct:/
+            # 4:pids:/
+            # 3:freezer:/
+            # 2:net_cls,net_prio:/
+            # 1:name=systemd:/init.scope
+            # 0::/init.scope
+            proc_controllers = line.split(':')[1]
+            if proc_controllers.find(',') >= 0:
+                for proc_controller in proc_controllers.split(','):
+                    if controller == proc_controller:
+                        return line.split(':')[2]
+            else:
+                if controller == proc_controllers:
+                    return line.split(':')[2]
+
+        raise ValueError("Could not get cgroup for pid {} and controller {}".
+                         format(pid, controller))
+
+    @staticmethod
+    def __get_cgroup_v2(config, pid, controller):
+        cmd = list()
+
+        cmd.append('cat')
+        cmd.append('/proc/{}/cgroup'.format(pid))
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            ret = Run.run(cmd)
+
+        for line in ret.splitlines():
+            # cgroup v2 appears in /proc/{pid}/cgroup like the following:
+            # $ cat /proc/1/cgroup
+            # 0::/init.scope
+            if line.find('::') < 0:
+                # we have identified this controller is cgroup v2,
+                # ignore any cgroup v1 controllers
+                continue
+
+            return line.split(':')[2]
+
+        raise ValueError("Could not get cgroup for pid {} and controller {}".
+                         format(pid, controller))
+
+    # given a PID and a cgroup controller, what cgroup is this PID a member of
+    @staticmethod
+    def get_cgroup(config, pid, controller):
+        version = CgroupVersion.get_version(controller)
+
+        if version == CgroupVersion.CGROUP_V1:
+            return Process.__get_cgroup_v1(config, pid, controller)
+        elif version == CgroupVersion.CGROUP_V2:
+            return Process.__get_cgroup_v2(config, pid, controller)
+
+        raise ValueError("get_cgroup() shouldn't reach this point")

--- a/tests/ftests/run.py
+++ b/tests/ftests/run.py
@@ -1,0 +1,75 @@
+#
+# Run class for the libcgroup functional tests
+#
+# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from log import Log
+import subprocess
+import time
+
+class Run(object):
+    @staticmethod
+    def run(command, shell_bool=False):
+        if shell_bool:
+            if isinstance(command, str):
+                # nothing to do.  command is already formatted as a string
+                pass
+            elif isinstance(command, list):
+                command = ' '.join(command)
+            else:
+                raise ValueError('Unsupported command type')
+
+        subproc = subprocess.Popen(command, shell=shell_bool,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        out, err = subproc.communicate()
+        ret = subproc.returncode
+
+        out = out.strip().decode('ascii')
+        err = err.strip().decode('ascii')
+
+        if shell_bool:
+            Log.log_debug(
+                "run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}\n\tstderr = {}".format(
+                command, ret, out, err))
+        else:
+            Log.log_debug(
+                "run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}\n\tstderr = {}".format(
+                ' '.join(command), ret, out, err))
+
+        if ret != 0 or len(err) > 0:
+            raise RunError("Command '{}' failed".format(''.join(command)),
+                           command, ret, out, err)
+
+        return out
+
+class RunError(Exception):
+    def __init__(self, message, command, ret, stdout, stderr):
+        super(RunError, self).__init__(message)
+
+        self.command = command
+        self.ret = ret
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __str__(self):
+        out_str = "RunError:\n\tcommand = {}\n\tret = {}".format(
+                  self.command, self.ret)
+        out_str += "\n\tstdout = {}\n\tstderr = {}".format(self.stdout, self.stderr)
+        return out_str

--- a/tests/ftests/utils.py
+++ b/tests/ftests/utils.py
@@ -1,0 +1,90 @@
+#
+# Utility functions for the libcgroup functional tests
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+import grp
+import os
+from run import Run
+
+# function to indent a block of text by cnt number of spaces
+def indent(in_str, cnt):
+    leading_indent = cnt * ' '
+    return ''.join(leading_indent + line for line in in_str.splitlines(True))
+
+def get_file_owner_uid(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append('\'%u\'')
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)
+
+def get_file_owner_username(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append('\'%U\'')
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)
+    return os.stat(filename).st_uid
+
+def get_file_owner_gid(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append('\'%g\'')
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)
+
+def get_file_owner_group_name(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append('\'%G\'')
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)
+
+def get_file_permissions(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append('\'%a\'')
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)

--- a/tests/get_all_controller.c
+++ b/tests/get_all_controller.c
@@ -1,0 +1,34 @@
+#include <libcgroup.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main()
+{
+	int error;
+	void *handle;
+	struct controller_data info;
+
+	error = cgroup_init();
+
+	if (error) {
+		printf("cgroup_init failed with %s\n", cgroup_strerror(error));
+		exit(1);
+	}
+
+	error = cgroup_get_all_controller_begin(&handle, &info);
+
+	while (error != ECGEOF) {
+		printf("Controller %10s %5d %5d %5d\n", info.name,
+			info.hierarchy, info.num_cgroups, info.enabled);
+		error = cgroup_get_all_controller_next(&handle, &info);
+		if (error && error != ECGEOF) {
+			printf("cgroup_get_controller_next failed with %s\n",
+							cgroup_strerror(error));
+			exit(1);
+		}
+	}
+
+	error = cgroup_get_all_controller_end(&handle);
+
+	return 0;
+}

--- a/tests/get_controller.c
+++ b/tests/get_controller.c
@@ -1,0 +1,34 @@
+#include <libcgroup.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main()
+{
+	int error;
+	void *handle;
+	struct cgroup_mount_point info;
+
+	error = cgroup_init();
+
+	if (error) {
+		printf("cgroup_init failed with %s\n", cgroup_strerror(error));
+		exit(1);
+	}
+
+	error = cgroup_get_controller_begin(&handle, &info);
+
+	while (error != ECGEOF) {
+		printf("Controller %s is mounted at %s\n", info.name,
+								info.path);
+		error = cgroup_get_controller_next(&handle, &info);
+		if (error && error != ECGEOF) {
+			printf("cgroup_get_contrller_next failed with %s",
+							cgroup_strerror(error));
+			exit(1);
+		}
+	}
+
+	error = cgroup_get_controller_end(&handle);
+
+	return 0;
+}

--- a/tests/get_mount_point.c
+++ b/tests/get_mount_point.c
@@ -1,0 +1,49 @@
+#include <libcgroup.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main()
+{
+	int ret;
+	char *mount_point;
+	char string[100];
+
+	strcpy(string, "cpu");
+
+	ret = cgroup_init();
+	if (ret) {
+		printf("cgroup_init failed with %s\n", cgroup_strerror(ret));
+		exit(3);
+	}
+
+	ret = cgroup_get_subsys_mount_point(string, &mount_point);
+	if (ret) {
+		printf("get_mount_point failed with %s\n",
+					cgroup_strerror(ret));
+		exit(3);
+	}
+
+	printf("The mount point is %s\n", mount_point);
+	free(mount_point);
+
+	strcpy(string, "obviouslynonexistsubsys");
+
+	ret = cgroup_get_subsys_mount_point(string, &mount_point);
+
+	if (!ret) {
+		printf("get_mount_point failed as it got a "
+					"non existant subsys\n");
+		exit(3);
+	}
+
+	if (ret == ECGROUPNOTEXIST) {
+		printf("get_mount_point worked as expected\n");
+		return 0;
+	}
+
+	printf("get_mount_point failed with %s\n", cgroup_strerror(ret));
+
+	return 3;
+}

--- a/tests/get_procs.c
+++ b/tests/get_procs.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <libcgroup.h>
+#include <stdlib.h>
+
+/*
+ * Assumes the cgroup is already mounted at /cgroup/memory/a
+ *
+ * Assumes some processes are already in the cgroup
+ *
+ * Assumes it is the memory controller is mounted in at that
+ * point
+ */
+int main()
+{
+	int size;
+	pid_t *pids;
+	int ret;
+	int i;
+
+	ret = cgroup_init();
+	if (ret) {
+		printf("FAIL: cgroup_init failed with %s\n", cgroup_strerror(ret));
+		exit(3);
+	}
+
+	ret = cgroup_get_procs("a", "memory", &pids, &size);
+	if (ret) {
+		printf("FAIL: cgroup_get_procs failed with %s\n", cgroup_strerror(ret));
+		exit(3);
+	}
+
+	for (i = 0; i < size; i++)
+		printf("%u\n", pids[i]);
+
+	return 0;
+}

--- a/tests/get_variable_names.c
+++ b/tests/get_variable_names.c
@@ -1,0 +1,59 @@
+#include <libcgroup.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../src/libcgroup-internal.h"
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	int i, j;
+	int count;
+	char *name;
+	struct cgroup_controller *group_controller = NULL;
+	struct cgroup *group = NULL;
+	char group_name[] = "/";
+
+	if (argc < 2) {
+		printf("no list of groups provided\n");
+		return -1;
+	}
+
+	ret = cgroup_init();
+
+	if (ret) {
+		printf("cgroup_init failed with %s\n", cgroup_strerror(ret));
+		exit(1);
+	}
+
+	group = cgroup_new_cgroup(group_name);
+	if (group == NULL) {
+		printf("cannot create group '%s'\n", group_name);
+		return -1;
+	}
+
+	ret = cgroup_get_cgroup(group);
+	if (ret != 0) {
+		printf("cannot read group '%s': %s\n",
+			group_name, cgroup_strerror(ret));
+	}
+
+	for (i = 1; i < argc; i++) {
+
+		group_controller = cgroup_get_controller(group, argv[i]);
+		if (group_controller == NULL) {
+			printf("cannot find controller "\
+			    "'%s' in group '%s'\n", argv[i], group_name);
+			ret = -1;
+			continue;
+		}
+		count = cgroup_get_value_name_count(group_controller);
+		for (j = 0; j < count; j++) {
+			name = cgroup_get_value_name(group_controller, j);
+			if (name != NULL)
+				printf("%s \n", name);
+		}
+	}
+
+	return ret;
+}

--- a/tests/gunit/.gitignore
+++ b/tests/gunit/.gitignore
@@ -1,0 +1,6 @@
+*.log
+*.o
+*.trs
+
+gtest
+libgtest.la

--- a/tests/gunit/001-path.cpp
+++ b/tests/gunit/001-path.cpp
@@ -1,0 +1,177 @@
+/**
+ * libcgroup googletest for cg_build_path()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class BuildPathV1Test : public ::testing::Test {
+	protected:
+
+	/**
+	 * Setup this test case
+	 *
+	 * This test case calls cg_build_path() to generate various
+	 * cgroup paths.  The SetUp() routine creates a simple mount
+	 * table that can be used to verify cg_build_path() behavior.
+	 *
+	 * cg_mount_table for this test is as follows:
+	 *	name		mount_point			index
+	 *	-----------------------------------------------------
+	 *	controller0	/sys/fs/cgroup/controller0	0
+	 *	controller1	/sys/fs/cgroup/controller1	1
+	 *	controller2	/sys/fs/cgroup/controller2	2
+	 *	controller3	/sys/fs/cgroup/controller3	3
+	 *	controller4	/sys/fs/cgroup/controller4	4
+	 *	controller5	/sys/fs/cgroup/controller5	5
+	 *
+	 * Note that controllers 1 and 5 are also given namespaces
+	 */
+	void SetUp() override {
+		char NAMESPACE1[] = "ns1";
+		char NAMESPACE5[] = "ns5";
+		const int ENTRY_CNT = 6;
+		int i, ret;
+
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(cg_namespace_table, 0,
+			CG_CONTROLLER_MAX * sizeof(cg_namespace_table[0]));
+
+		// Populate the mount table
+		for (i = 0; i < ENTRY_CNT; i++) {
+			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+				 "controller%d", i);
+			cg_mount_table[i].index = i;
+
+			ret = snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
+				 "/sys/fs/cgroup/%s", cg_mount_table[i].name);
+			ASSERT_LT(ret, sizeof(cg_mount_table[i].mount.path));
+
+			cg_mount_table[i].mount.next = NULL;
+		}
+
+		// Give a couple of the entries a namespace as well
+		cg_namespace_table[1] =	NAMESPACE1;
+		cg_namespace_table[5] =	NAMESPACE5;
+	}
+};
+
+/**
+ * No matching controller test
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMismatch test name
+ *
+ * This test will walk through the entire controller mount table
+ * and fail to find a match.
+ * https://github.com/libcgroup/libcgroup/blob/62f76650db84c0a25f76ece3a79d9d16a1e9f931/src/api.c#L1300
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMismatch)
+{
+	char *name = NULL;
+	char path[FILENAME_MAX];
+	/* type intentionally _does not_ match any controllers */
+	char type[] = "FOO";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, NULL);
+}
+
+/**
+ * Matching controller test
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMatch test name
+ *
+ * This test finds a matching controller in the mount table.  Both the
+ * namespace and the cgroup name are NULL.
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatch)
+{
+	char *name = NULL;
+	char path[FILENAME_MAX];
+	char type[] = "controller0";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, "/sys/fs/cgroup/controller0/");
+}
+
+/**
+ * Matching controller test with a cgroup name
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMatchWithName test name
+ *
+ * This test finds a matching controller in the mount table.  The
+ * namespace is NULL, but a valid cgroup name is provided.  This
+ * exercises the `if (name)` statement
+ * https://github.com/libcgroup/libcgroup/blob/62f76650db84c0a25f76ece3a79d9d16a1e9f931/src/api.c#L1289
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatchWithName)
+{
+	char name[] = "TomsCgroup1";
+	char path[FILENAME_MAX];
+	char type[] = "controller3";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, "/sys/fs/cgroup/controller3/TomsCgroup1/");
+}
+
+/**
+ * Matching controller test with a namespace
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMatchWithNs test name
+ *
+ * This test finds a matching controller in the mount table.  The
+ * namespace is valid, but the cgroup name is NULL.  This exercises
+ * exercises the `if (cg_namespace_table[i])` statement
+ * https://github.com/libcgroup/libcgroup/blob/62f76650db84c0a25f76ece3a79d9d16a1e9f931/src/api.c#L1278
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatchWithNs)
+{
+	char *name = NULL;
+	char path[FILENAME_MAX];
+	char type[] = "controller1";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, "/sys/fs/cgroup/controller1/ns1/");
+}
+
+/**
+ * Matching controller test with a namespace and a cgroup name
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMatchWithNameAndNs test name
+ *
+ * This test finds a matching controller in the mount table.  Both the
+ * namespace and the cgroup name are valid.  This exercises both if
+ * statements in cg_build_path_locked().
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatchWithNameAndNs)
+{
+	char name[] = "TomsCgroup2";
+	char path[FILENAME_MAX];
+	char type[] = "controller5";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, "/sys/fs/cgroup/controller5/ns5/TomsCgroup2/");
+}

--- a/tests/gunit/002-cgroup_parse_rules_options.cpp
+++ b/tests/gunit/002-cgroup_parse_rules_options.cpp
@@ -1,0 +1,105 @@
+/**
+ * libcgroup googletest for cgroup_parse_rules_options()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class ParseRulesOptionsTest : public ::testing::Test {
+};
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_Ignore)
+{
+	struct cgroup_rule rule;
+	char options[] = "ignore";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(rule.is_ignore, true);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_IgnoreWithComma)
+{
+	struct cgroup_rule rule;
+	char options[] = "ignore,";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(rule.is_ignore, true);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_InvalidOption)
+{
+	struct cgroup_rule rule;
+	char options[] = "ignoretypo";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, -EINVAL);
+	ASSERT_EQ(rule.is_ignore, false);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_InvalidOption2)
+{
+	struct cgroup_rule rule;
+	char options[] = "ignore,foobar";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, -EINVAL);
+	ASSERT_EQ(rule.is_ignore, true);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_EmptyOptions)
+{
+	struct cgroup_rule rule;
+	char options[] = "";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, -EINVAL);
+	ASSERT_EQ(rule.is_ignore, false);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_NullOptions)
+{
+	struct cgroup_rule rule;
+	char *options = NULL;
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, -EINVAL);
+	ASSERT_EQ(rule.is_ignore, false);
+}

--- a/tests/gunit/003-cg_get_cgroups_from_proc_cgroups.cpp
+++ b/tests/gunit/003-cg_get_cgroups_from_proc_cgroups.cpp
@@ -1,0 +1,175 @@
+/**
+ * libcgroup googletest for cg_get_cgroups_from_proc_cgroups()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class GetCgroupsFromProcCgroupsTest : public ::testing::Test {
+};
+
+static void CreateCgroupProcFile(const char * const contents)
+{
+	FILE *f;
+
+	f = fopen(TEST_PROC_PID_CGROUP_FILE, "w");
+	ASSERT_NE(f, nullptr);
+
+	fprintf(f, "%s", contents);
+	fclose(f);
+}
+
+
+TEST_F(GetCgroupsFromProcCgroupsTest, ReadSingleLine)
+{
+#undef LIST_LEN
+#define LIST_LEN 3
+	char contents[] =
+		"5:pids:/user.slice/user-1000.slice/session-1.scope\n";
+	char *controller_list[LIST_LEN];
+	char *cgroup_list[LIST_LEN];
+	pid_t pid = 1234;
+	int ret, i;
+
+	for (i = 0; i < LIST_LEN; i++) {
+		controller_list[i] = NULL;
+		cgroup_list[i] = NULL;
+	}
+
+	CreateCgroupProcFile(contents);
+
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
+			controller_list, LIST_LEN);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(controller_list[0], "pids");
+	ASSERT_STREQ(cgroup_list[0],
+		     "user.slice/user-1000.slice/session-1.scope");
+}
+
+TEST_F(GetCgroupsFromProcCgroupsTest, ReadSingleLine2)
+{
+#undef LIST_LEN
+#define LIST_LEN 1
+	char contents[] =
+		"5:cpu,cpuacct:/\n";
+	char *controller_list[LIST_LEN];
+	char *cgroup_list[LIST_LEN];
+	pid_t pid = 1234;
+	int ret, i;
+
+	for (i = 0; i < LIST_LEN; i++) {
+		controller_list[i] = NULL;
+		cgroup_list[i] = NULL;
+	}
+
+	CreateCgroupProcFile(contents);
+
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
+			controller_list, LIST_LEN);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(controller_list[0], "cpu,cpuacct");
+	ASSERT_STREQ(cgroup_list[0], "/");
+}
+
+TEST_F(GetCgroupsFromProcCgroupsTest, ReadEmptyController)
+{
+#undef LIST_LEN
+#define LIST_LEN 1
+	char contents[] =
+		"0::/user.slice/user-1000.slice/session-1.scope\n";
+	char *controller_list[LIST_LEN];
+	char *cgroup_list[LIST_LEN];
+	pid_t pid = 1234;
+	int ret, i;
+
+	for (i = 0; i < LIST_LEN; i++) {
+		controller_list[i] = NULL;
+		cgroup_list[i] = NULL;
+	}
+
+	CreateCgroupProcFile(contents);
+
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
+			controller_list, LIST_LEN);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(controller_list[0], nullptr);
+	ASSERT_EQ(cgroup_list[0], nullptr);
+}
+
+TEST_F(GetCgroupsFromProcCgroupsTest, ReadExampleFile)
+{
+	char contents[] =
+		"12:memory:/user/johndoe/0\n"
+		"11:perf_event:/\n"
+		"10:rdma:/\n"
+		"9:blkio:/user.slice\n"
+		"8:cpu,cpuacct:/myCgroup\n"
+		"7:freezer:/user/johndoe/0\n"
+		"6:net_cls,net_prio:/\n"
+		"5:pids:/user.slice/user-1000.slice/session-1.scope\n"
+		"4:devices:/user.slice\n"
+		"3:cpuset:/\n"
+		"2:hugetlb:/\n"
+		"1:name=systemd:/user.slice/user-1000.slice/session-1.scope\n"
+		"0::/user.slice/user-1000.slice/session-1.scope\n";
+	char *controller_list[MAX_MNT_ELEMENTS];
+	char *cgroup_list[MAX_MNT_ELEMENTS];
+	pid_t pid = 5678;
+	int ret, i;
+
+	for (i = 0; i < MAX_MNT_ELEMENTS; i++) {
+		controller_list[i] = NULL;
+		cgroup_list[i] = NULL;
+	}
+
+	CreateCgroupProcFile(contents);
+
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
+			controller_list, MAX_MNT_ELEMENTS);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(controller_list[0], "memory");
+	ASSERT_STREQ(cgroup_list[0], "user/johndoe/0");
+	ASSERT_STREQ(controller_list[1], "perf_event");
+	ASSERT_STREQ(cgroup_list[1], "/");
+	ASSERT_STREQ(controller_list[2], "rdma");
+	ASSERT_STREQ(cgroup_list[2], "/");
+	ASSERT_STREQ(controller_list[3], "blkio");
+	ASSERT_STREQ(cgroup_list[3], "user.slice");
+	ASSERT_STREQ(controller_list[4], "cpu,cpuacct");
+	ASSERT_STREQ(cgroup_list[4], "myCgroup");
+	ASSERT_STREQ(controller_list[5], "freezer");
+	ASSERT_STREQ(cgroup_list[5], "user/johndoe/0");
+	ASSERT_STREQ(controller_list[6], "net_cls,net_prio");
+	ASSERT_STREQ(cgroup_list[6], "/");
+	ASSERT_STREQ(controller_list[7], "pids");
+	ASSERT_STREQ(cgroup_list[7], "user.slice/user-1000.slice/session-1.scope");
+	ASSERT_STREQ(controller_list[8], "devices");
+	ASSERT_STREQ(cgroup_list[8], "user.slice");
+	ASSERT_STREQ(controller_list[9], "cpuset");
+	ASSERT_STREQ(cgroup_list[9], "/");
+	ASSERT_STREQ(controller_list[10], "hugetlb");
+	ASSERT_STREQ(cgroup_list[10], "/");
+	ASSERT_STREQ(controller_list[11], "name=systemd");
+	ASSERT_STREQ(cgroup_list[11], "user.slice/user-1000.slice/session-1.scope");
+
+	ASSERT_EQ(controller_list[12], nullptr);
+	ASSERT_EQ(cgroup_list[12], nullptr);
+}

--- a/tests/gunit/004-cgroup_compare_ignore_rule.cpp
+++ b/tests/gunit/004-cgroup_compare_ignore_rule.cpp
@@ -1,0 +1,384 @@
+/**
+ * libcgroup googletest for cgroup_compare_ignore_rule()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class CgroupCompareIgnoreRuleTest : public ::testing::Test {
+};
+
+static void CreateCgroupProcFile(const char * const contents)
+{
+	FILE *f;
+
+	f = fopen(TEST_PROC_PID_CGROUP_FILE, "w");
+	ASSERT_NE(f, nullptr);
+
+	fprintf(f, "%s", contents);
+	fclose(f);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, NotAnIgnore)
+{
+	char procname[] = "myprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 1234;
+	bool ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, SimpleMatch)
+{
+	char proc_file_contents[] =
+		"7:cpuacct:/SimpleMatchCgroup";
+	char rule_controller[] = "cpuacct";
+	char procname[] = "procfoo";
+	struct cgroup_rule rule;
+	pid_t pid = 2345;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "SimpleMatchCgroup");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, CgroupsDontMatch)
+{
+	char proc_file_contents[] =
+		"2:cpuacct:CloseButNotQuite";
+	char rule_controller[] = "cpuacct";
+	char procname[] = "procfoo2";
+	struct cgroup_rule rule;
+	pid_t pid = 4567;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "CloseButNotQuit");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, ControllersDontMatch)
+{
+	char proc_file_contents[] =
+		"5:memory:MyCgroup";
+	char rule_controller[] = "cpuacct";
+	char procname[] = "procfoo3";
+	struct cgroup_rule rule;
+	pid_t pid = 5678;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "MyCgroup");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, CombinedControllers)
+{
+	char proc_file_contents[] =
+		"13:cpu,cpuacct:/containercg";
+	char rule_controller[] = "cpuacct";
+	char procname[] = "docker";
+	struct cgroup_rule rule = {0};
+	pid_t pid = 6789;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	rule.controllers[1] = NULL;
+	sprintf(rule.destination, "containercg");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, MatchChildFolder)
+{
+	char proc_file_contents[] =
+		"7:cpuset:/parentcg/childcg/grandchildcg";
+	char rule_controller[] = "cpuset";
+	char procname[] = "childprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 7890;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "parentcg/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, MatchGrandchildFolder)
+{
+	char proc_file_contents[] =
+		"1:hugetlb:/parentcg/childcg/grandchildcg";
+	char rule_controller[] = "hugetlb";
+	char procname[] = "granchildprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 8901;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "parentcg/childcg/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+/**
+ * This test is designed to highlight the case where the user has not put a
+ * trailing slash at the end of the rule's destination.  By design, this will
+ * cause the rule to match a wide variety of cases.
+ *
+ * For example, given the rule destination of "Folder".  The following
+ * behavior would be observed:
+ *	Process Location	Matches the rule?
+ *	Folder			Yes
+ *	Folders			Yes
+ *	Folder/AnotherFolder	Yes
+ *	Folder2			Yes
+ *	Folder3/ChildFolder	Yes
+ *	Folde			No
+ */
+TEST_F(CgroupCompareIgnoreRuleTest, MatchSimilarChildFolder)
+{
+	char proc_file_contents[] =
+		"1:hugetlb:/parentcg/childcg2";
+	char rule_controller[] = "hugetlb";
+	char procname[] = "granchildprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 8901;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "parentcg/childcg");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, RealWorldMatch)
+{
+	char proc_file_contents[] =
+		"12:memory:/user/johndoe/0\n"
+		"11:perf_event:/\n"
+		"10:rdma:/\n"
+		"9:blkio:/user.slice\n"
+		"8:cpu,cpuacct:/myCgroup\n"
+		"7:freezer:/user/johndoe/0\n"
+		"6:net_cls,net_prio:/\n"
+		"5:pids:/user.slice/user-1000.slice/session-1.scope\n"
+		"4:devices:/user.slice\n"
+		"3:cpuset:/\n"
+		"2:hugetlb:/\n"
+		"1:name=systemd:/user.slice/user-1000.slice/session-1.scope\n"
+		"0::/user.slice/user-1000.slice/session-1.scope\n";
+	char rule_controller[] = "cpu";
+	char procname[] = "granchildprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 8901;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "myCgroup/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, RealWorldNoMatch)
+{
+	char proc_file_contents[] =
+		"12:memory:/user/johndoe/0\n"
+		"11:perf_event:/\n"
+		"10:rdma:/\n"
+		"9:blkio:/user.slice\n"
+		"8:cpu,cpuacct:/myCgroup\n"
+		"7:freezer:/user/johndoe/0\n"
+		"6:net_cls,net_prio:/NetCgroup\n"
+		"5:pids:/user.slice/user-1000.slice/session-1.scope\n"
+		"4:devices:/user.slice\n"
+		"3:cpuset:/\n"
+		"2:hugetlb:/\n"
+		"1:name=systemd:/user.slice/user-1000.slice/session-1.scope\n"
+		"0::/user.slice/user-1000.slice/session-1.scope\n";
+	char rule_controller[] = "net_cls";
+	char procname[] = "NotMatching";
+	struct cgroup_rule rule;
+	pid_t pid = 9012;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "NetCgroup2");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, SimilarFolderNoMatch)
+{
+	char proc_file_contents[] =
+		"4:memory:/folder1";
+	char rule_controller[] = "memory";
+	char procname[] = "childprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 2345;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "folder/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, RootDestinationMatch)
+{
+	char proc_file_contents[] =
+		"2:freezer:/";
+	char rule_controller[] = "freezer";
+	char procname[] = "ANewProcess";
+	struct cgroup_rule rule;
+	pid_t pid = 3456;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, RootDestinationNoMatch)
+{
+	char proc_file_contents[] =
+		"2:freezer:/somerandomcg";
+	char rule_controller[] = "freezer";
+	char procname[] = "ANewProcess";
+	struct cgroup_rule rule;
+	pid_t pid = 3456;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, WildcardProcnameSimpleMatch)
+{
+	char proc_file_contents[] =
+		"7:cpuacct:/MatchCgroup";
+	char rule_controller[] = "cpuacct";
+	char rule_procname[] = "ssh*";
+	char procname[] = "sshd";
+	struct cgroup_rule rule;
+	pid_t pid = 1234;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = rule_procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "MatchCgroup");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, WildcardProcnameNoMatch)
+{
+	char proc_file_contents[] =
+		"7:cpuacct:/AnotherCgroup";
+	char rule_controller[] = "cpuacct";
+	char rule_procname[] = "httpd*";
+	char procname[] = "httpx";
+	struct cgroup_rule rule;
+	pid_t pid = 1234;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = rule_procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "AnotherCgroup");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}

--- a/tests/gunit/005-cgroup_compare_wildcard_procname.cpp
+++ b/tests/gunit/005-cgroup_compare_wildcard_procname.cpp
@@ -1,0 +1,97 @@
+/**
+ * libcgroup googletest for cgroup_compare_wildcard_procname()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class ProcnameWildcardTest : public ::testing::Test {
+};
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_NoAsterisk)
+{
+	char rule_procname[] = "systemd";
+	char procname[] = "bash";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskNoMatch)
+{
+	char rule_procname[] = "BobIsYour*";
+	char procname[] = "Linda";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskMatch)
+{
+	char rule_procname[] = "HelloWorl*";
+	char procname[] = "HelloWorld";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskNoMatch2)
+{
+	char rule_procname[] = "HelloW*";
+	char procname[] = "Hello";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskMatchExactly)
+{
+	char rule_procname[] = "strace*";
+	char procname[] = "strace";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_NoAsteriskMatchExactly)
+{
+	char rule_procname[] = "systemd-cgls";
+	char procname[] = "systemd-cgls";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskFirstChar)
+{
+	char rule_procname[] = "*";
+	char procname[] = "tomcat";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, true);
+}

--- a/tests/gunit/006-cgroup_get_cgroup.cpp
+++ b/tests/gunit/006-cgroup_get_cgroup.cpp
@@ -1,0 +1,272 @@
+/**
+ * libcgroup googletest for cgroup_get_cgroup()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <bits/stdc++.h>
+#include <string>
+#include <vector>
+using namespace std;
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+#include "libcgroup-internal.h"
+
+#define MAX_NAMES 5
+
+enum ctrl_enum {
+	CTRL_CPU,
+	CTRL_FREEZER,
+	CTRL_MEMORY,
+	CTRL_CPUSET,
+	CTRL_NAMESPACES,
+	CTRL_NETNS,
+
+	CTRL_CNT
+};
+
+static const char * const PARENT_DIR = "test006cgroup";
+
+static const char * const CONTROLLERS[] = {
+	"cpu",
+	"freezer",
+	"memory",
+	"cpuset",
+	"namespaces",
+	"netns",
+};
+static const int CONTROLLERS_CNT =
+	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+
+static const char * const NAMES[][MAX_NAMES] = {
+	{"tasks", "cpu.shares", "cpu.weight", "cpu.foo", NULL},
+	{"tasks", NULL, NULL, NULL, NULL},
+	{"tasks", "memory.limit_in_bytes", "memory.memsw.limit_in_bytes", NULL, NULL},
+	{"tasks", "cpuset.exclusive", "cpuset.foo", "cpuset.bar", "cpuset.x"},
+	{"tasks", "namespaces.blah", NULL, NULL, NULL},
+	{"tasks", "netns.foo", "netns.bar", "netns.baz", NULL},
+};
+static const int NAMES_CNT = sizeof(NAMES) / sizeof(NAMES[0]);
+
+static const char * const VALUES[][MAX_NAMES] = {
+	{"1234", "512", "100", "abc123", NULL},
+	{"2345\n3456", NULL, NULL, NULL, NULL},
+	{"456\n678\n890", "8675309", "1024000", NULL, NULL},
+	{"\0", "1", "limit=32412039", "9223372036854771712", "partition"},
+	{"59832", "The Quick Brown Fox", NULL, NULL, NULL},
+	{"987\n654", "root", "/sys/fs", "0xdeadbeef", NULL},
+};
+static const int VALUES_CNT = sizeof(VALUES) / sizeof(VALUES[0]);
+
+static const char * const CG_NAME = "tomcatcg";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+class CgroupGetCgroupTest : public ::testing::Test {
+	protected:
+
+	void CreateNames(const char * const names[],
+			 const char * const values[],
+			 const char * const ctrl_name)
+	{
+		char tmp_path[FILENAME_MAX];
+		FILE *f;
+		int i;
+
+		for (i = 0; i < NAMES_CNT; i++) {
+			if (names[i] == NULL)
+				break;
+
+			memset(tmp_path, 0, sizeof(tmp_path));
+			snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s/%s",
+				 PARENT_DIR, ctrl_name, CG_NAME, names[i]);
+
+			f = fopen(tmp_path, "w");
+			ASSERT_NE(f, nullptr);
+
+			fprintf(f, "%s", values[i]);
+			fclose(f);
+		}
+	}
+
+	void SetUp() override
+	{
+		char tmp_path[FILENAME_MAX];
+		int i, j, names_len, ret;
+
+		ASSERT_EQ(NAMES_CNT, CONTROLLERS_CNT);
+		ASSERT_EQ(NAMES_CNT, VALUES_CNT);
+
+		ret = cgroup_init();
+		ASSERT_EQ(ret, 0);
+
+		ret = mkdir(PARENT_DIR, MODE);
+		ASSERT_EQ(ret, 0);
+
+		/*
+		 * Artificially populate the mount table with local
+		 * directories
+		 */
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
+
+		for (i = 0; i < CONTROLLERS_CNT; i++) {
+			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+				 "%s", CONTROLLERS[i]);
+			snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
+				 "%s/%s", PARENT_DIR, CONTROLLERS[i]);
+			cg_mount_table[i].version = CGROUP_V1;
+
+			ret = mkdir(cg_mount_table[i].mount.path, MODE);
+			ASSERT_EQ(ret, 0);
+
+			/*
+			 * arbitrarily don't make the cgroup directory in
+			 * the freezer controller
+			 */
+			if (i == CTRL_FREEZER)
+				continue;
+
+			memset(tmp_path, 0, sizeof(tmp_path));
+			snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s",
+				 PARENT_DIR, CONTROLLERS[i], CG_NAME);
+			ret = mkdir(tmp_path, MODE);
+			ASSERT_EQ(ret, 0);
+
+			CreateNames(NAMES[i], VALUES[i], CONTROLLERS[i]);
+		}
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override
+	{
+		int ret = 0;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+static void vectorize_cg(const struct cgroup * const cg,
+			 vector<string>& cg_vec)
+{
+	const char *cgname, *cgcname, *value;
+	int i, j;
+
+	for (i = 0; i < cg->index; i++) {
+		for (j = 0; j < cg->controller[i]->index; j++) {
+			string cgname(cg->name);
+			string cgcname(cg->controller[i]->name);
+			string name(cg->controller[i]->values[j]->name);
+			string value(cg->controller[i]->values[j]->value);
+
+			cg_vec.push_back(cgcname + "+" + cgname + "+" +
+					 name + "+" + value);
+		}
+	}
+
+	sort(cg_vec.begin(), cg_vec.end());
+}
+
+static void vectorize_testdata(vector<string>& test_vec)
+{
+	string cgname(CG_NAME);
+	int i, j;
+
+	for (i = 0; i < CTRL_CNT; i++) {
+		for (j = 0; j < MAX_NAMES; j++) {
+			if (NAMES[i][j] == NULL)
+				continue;
+
+			if (strcmp(NAMES[i][j], "tasks") == 0)
+				/*
+				 * The tasks files isn't listed by
+				 * cgroup_get_cgroup()
+				 */
+				continue;
+
+			string cgcname(CONTROLLERS[i]);
+			string name(NAMES[i][j]);
+			string value(VALUES[i][j]);
+
+			test_vec.push_back(cgcname + "+" + cgname + "+" +
+					   name + "+" + value);
+		}
+	}
+
+	sort(test_vec.begin(), test_vec.end());
+}
+
+TEST_F(CgroupGetCgroupTest, CgroupGetCgroup1)
+{
+	vector<string> cg_vec, test_vec;
+	struct cgroup *cg = NULL;
+	int ret;
+
+	cg = cgroup_new_cgroup(CG_NAME);
+	ASSERT_NE(cg, nullptr);
+
+	ret = cgroup_get_cgroup(cg);
+	ASSERT_EQ(ret, 0);
+
+	vectorize_cg(cg, cg_vec);
+	vectorize_testdata(test_vec);
+
+	ASSERT_EQ(cg_vec, test_vec);
+
+	if (cg)
+		free(cg);
+}
+
+/*
+ * This test must be last because it makes destructive changes to the cgroup hierarchy
+ */
+TEST_F(CgroupGetCgroupTest, CgroupGetCgroup_NoTasksFile)
+{
+	char tmp_path[FILENAME_MAX];
+	struct cgroup *cg = NULL;
+	int ret;
+
+	snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s/tasks",
+		 PARENT_DIR, CONTROLLERS[CONTROLLERS_CNT - 1], CG_NAME);
+	ret = rmrf(tmp_path);
+	ASSERT_EQ(ret, 0);
+
+	cg = cgroup_new_cgroup(CG_NAME);
+	ASSERT_NE(cg, nullptr);
+
+	ret = cgroup_get_cgroup(cg);
+	ASSERT_EQ(ret, ECGOTHER);
+
+	if (cg)
+		free(cg);
+}

--- a/tests/gunit/007-cgroup_process_v1_mount.cpp
+++ b/tests/gunit/007-cgroup_process_v1_mount.cpp
@@ -1,0 +1,94 @@
+/**
+ * libcgroup googletest for cgroup_process_v1_mnt()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <mntent.h>
+
+#include "gtest/gtest.h"
+#include "libcgroup-internal.h"
+
+static int mnt_tbl_idx = 0;
+
+class CgroupProcessV1MntTest : public ::testing::Test {
+};
+
+TEST_F(CgroupProcessV1MntTest, AddV1Mount)
+{
+	char *controllers[] = {"cpu", "memory", NULL};
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup",
+		.mnt_dir = "/sys/fs/cgroup/memory",
+		.mnt_type = "cgroup",
+		.mnt_opts = "rw,nosuid,nodev,noexec,relatime,seclabel,memory",
+	};
+	int ret;
+
+	ret = cgroup_process_v1_mnt(controllers, &ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 1);
+	ASSERT_STREQ(cg_mount_table[0].name, "memory");
+	ASSERT_STREQ(cg_mount_table[0].mount.path, ent.mnt_dir);
+}
+
+/* The AddV1Mount() test above added the memory controller to the
+ * cg_mount_table[].  Now let's add another mount point of the
+ * memory controller to test the duplicate mount handling
+ */
+TEST_F(CgroupProcessV1MntTest, AddV1Mount_Duplicate)
+{
+	char *controllers[] = {"cpu", "cpuset", "memory", NULL};
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup",
+		.mnt_dir = "/cgroup/memory",
+		.mnt_type = "cgroup",
+		.mnt_opts = "rw,nosuid,nodev,noexec,relatime,seclabel,memory",
+	};
+	int ret;
+
+	ASSERT_EQ(NULL, cg_mount_table[0].mount.next);
+
+	ret = cgroup_process_v1_mnt(controllers, &ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 1);
+	ASSERT_STREQ(cg_mount_table[0].mount.next->path, ent.mnt_dir);
+}
+
+TEST_F(CgroupProcessV1MntTest, AddV1NamedMount)
+{
+	char *controllers[] = {"cpu", "memory", "systemd", NULL};
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup",
+		.mnt_dir = "/sys/fs/cgroup/systemd",
+		.mnt_type = "cgroup",
+		.mnt_opts = "rw,nosuid,nodev,noexec,relatime,seclabel,name=systemd",
+	};
+	int ret;
+
+	ret = cgroup_process_v1_mnt(controllers, &ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 1);
+	ASSERT_STREQ(cg_mount_table[0].name, "memory");
+	/* The systemd hierarchy should not be mounted due to it being
+	 * excluded by the OPAQUE_HIERARCHY option
+	 */
+}

--- a/tests/gunit/008-cgroup_process_v2_mount.cpp
+++ b/tests/gunit/008-cgroup_process_v2_mount.cpp
@@ -1,0 +1,200 @@
+/**
+ * libcgroup googletest for cgroup_process_v2_mnt()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <ftw.h>
+#include <mntent.h>
+
+#include "gtest/gtest.h"
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test008cgroup";
+static const char * const PARENT2_DIR = "test008cgroup2";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+static const char * const CONTROLLERS[] = {
+	"cpuset",
+	"cpu",
+	"io",
+	"memory",
+	"pids",
+	"rdma",
+};
+static const int CONTROLLERS_CNT =
+	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+
+static int mnt_tbl_idx = 0;
+
+class CgroupProcessV2MntTest : public ::testing::Test {
+	protected:
+
+	void CreateHierarchy(const char * const dir)
+	{
+		char tmp_path[FILENAME_MAX];
+		int i, ret;
+		FILE *f;
+
+		ret = mkdir(dir, MODE);
+		ASSERT_EQ(ret, 0);
+
+		memset(tmp_path, 0, sizeof(tmp_path));
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.controllers",
+			 dir);
+
+		f = fopen(tmp_path, "w");
+		ASSERT_NE(f, nullptr);
+
+		for (i = 0; i < CONTROLLERS_CNT; i++)
+			fprintf(f, "%s ", CONTROLLERS[i]);
+
+		fclose(f);
+	}
+
+	void SetUp() override
+	{
+		char tmp_path[FILENAME_MAX];
+		int i, ret;
+		FILE *f;
+
+		CreateHierarchy(PARENT_DIR);
+
+		/* make another directory to test the duplicate logic */
+		CreateHierarchy(PARENT2_DIR);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override
+	{
+		int ret = 0;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+
+		ret = rmrf(PARENT2_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(CgroupProcessV2MntTest, AddV2Mount)
+{
+	char *mnt_dir = strdup(PARENT_DIR);
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup2",
+		.mnt_dir = mnt_dir,
+		.mnt_type = "cgroup2",
+		.mnt_opts = "rw,relatime,seclabel",
+	};
+	int ret;
+
+	ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 6);
+	ASSERT_STREQ(cg_mount_table[0].name, "cpuset");
+	ASSERT_STREQ(cg_mount_table[1].name, "cpu");
+	ASSERT_STREQ(cg_mount_table[2].name, "io");
+	ASSERT_STREQ(cg_mount_table[3].name, "memory");
+	ASSERT_STREQ(cg_mount_table[4].name, "pids");
+	ASSERT_STREQ(cg_mount_table[5].name, "rdma");
+
+	ASSERT_STREQ(cg_mount_table[0].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[1].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[2].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[3].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[4].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[5].mount.path, ent.mnt_dir);
+}
+
+TEST_F(CgroupProcessV2MntTest, AddV2Mount_Duplicate)
+{
+	char *mnt_dir = strdup(PARENT2_DIR);
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup2",
+		.mnt_dir = mnt_dir,
+		.mnt_type = "cgroup2",
+		.mnt_opts = "rw,relatime,seclabel",
+	};
+	int ret;
+
+	ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 6);
+	ASSERT_STREQ(cg_mount_table[0].name, "cpuset");
+	ASSERT_STREQ(cg_mount_table[1].name, "cpu");
+	ASSERT_STREQ(cg_mount_table[2].name, "io");
+	ASSERT_STREQ(cg_mount_table[3].name, "memory");
+	ASSERT_STREQ(cg_mount_table[4].name, "pids");
+	ASSERT_STREQ(cg_mount_table[5].name, "rdma");
+
+	ASSERT_STREQ(cg_mount_table[0].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[1].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[2].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[3].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[4].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[5].mount.next->path, ent.mnt_dir);
+}
+
+/*
+ * This test must be last because it makes destructive changes to the cgroup hierarchy
+ */
+TEST_F(CgroupProcessV2MntTest, EmptyControllersFile)
+{
+	char tmp_path[FILENAME_MAX];
+	char *mnt_dir = strdup(PARENT_DIR);
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup2",
+		.mnt_dir = mnt_dir,
+		.mnt_type = "cgroup2",
+		.mnt_opts = "rw,relatime,seclabel",
+	};
+	FILE *f;
+	int ret;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.controllers",
+		 PARENT_DIR);
+
+	/* clear the cgroup.controllers file */
+	f = fopen(tmp_path, "w");
+	ASSERT_NE(f, nullptr);
+	fclose(f);
+
+	/* reset the mount table count */
+	mnt_tbl_idx = 0;
+
+	ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, ECGEOF);
+	ASSERT_EQ(mnt_tbl_idx, 0);
+}

--- a/tests/gunit/009-cgroup_set_values_recursive.cpp
+++ b/tests/gunit/009-cgroup_set_values_recursive.cpp
@@ -1,0 +1,136 @@
+/**
+ * libcgroup googletest for cgroup_set_values_recursive()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test009cgroup/";
+
+static const char * const NAMES[] = {
+	"cpu.weight",
+	"cpu.weight.nice",
+	"cpu.foo",
+	"cpu.bar"
+};
+static const int NAMES_CNT = sizeof(NAMES) / sizeof(NAMES[0]);
+
+static const char * const VALUES[] = {
+	"999",
+	"15",
+	"random",
+	"data"
+};
+static const int VALUES_CNT = sizeof(VALUES) / sizeof(VALUES[0]);
+
+
+class SetValuesRecursiveTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override {
+		char tmp_path[FILENAME_MAX];
+		int ret, i;
+		FILE *f;
+
+		ASSERT_EQ(NAMES_CNT, VALUES_CNT);
+
+		ret = mkdir(PARENT_DIR, S_IRWXU | S_IRWXG | S_IRWXO);
+		ASSERT_EQ(ret, 0);
+
+		for (i = 0; i < NAMES_CNT; i++) {
+			memset(tmp_path, 0, sizeof(tmp_path));
+			ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+				       PARENT_DIR, NAMES[i]);
+			ASSERT_GT(ret, 0);
+
+			f = fopen(tmp_path, "w");
+			fclose(f);
+		}
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override {
+		int ret;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(SetValuesRecursiveTest, SuccessfulSetValues)
+{
+	char tmp_path[FILENAME_MAX], buf[4092];
+	struct cgroup_controller ctrlr = {0};
+	int ret, i;
+	char *val;
+	FILE *f;
+
+	ret = snprintf(ctrlr.name, FILENAME_MAX - 1, "cpu");
+	ASSERT_GT(ret, 0);
+
+	for (i = 0; i < NAMES_CNT; i++) {
+		ctrlr.values[i] = (struct control_value *)calloc(1,
+					sizeof(struct control_value));
+		ASSERT_NE(ctrlr.values[i], nullptr);
+
+		strncpy(ctrlr.values[i]->name, NAMES[i], FILENAME_MAX);
+		strncpy(ctrlr.values[i]->value, VALUES[i],
+			CG_CONTROL_VALUE_MAX);
+		if (i == 0)
+			ctrlr.values[i]->dirty = true;
+		else
+			ctrlr.values[i]->dirty = false;
+		ctrlr.index++;
+	}
+
+	ret = cgroup_set_values_recursive(PARENT_DIR, &ctrlr, true);
+	ASSERT_EQ(ret, 0);
+
+	for (i = 0; i < NAMES_CNT; i++) {
+		memset(tmp_path, 0, sizeof(tmp_path));
+		ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+			       PARENT_DIR, NAMES[i]);
+		ASSERT_GT(ret, 0);
+
+		f = fopen(tmp_path, "r");
+		ASSERT_NE(f, nullptr);
+
+		val = fgets(buf, sizeof(buf), f);
+		ASSERT_NE(val, nullptr);
+		ASSERT_STREQ(buf, VALUES[i]);
+		fclose(f);
+	}
+}

--- a/tests/gunit/010-cgroup_chown_chmod_tasks.cpp
+++ b/tests/gunit/010-cgroup_chown_chmod_tasks.cpp
@@ -1,0 +1,96 @@
+/**
+ * libcgroup googletest for cgroup_chown_chmod_tasks()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test010cgroup";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+class ChownChmodTasksTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override {
+		char tasks_path[FILENAME_MAX];
+		int ret;
+		FILE *f;
+
+		ret = mkdir(PARENT_DIR, MODE);
+		ASSERT_EQ(ret, 0);
+
+		memset(tasks_path, 0, sizeof(tasks_path));
+		ret = snprintf(tasks_path, FILENAME_MAX - 1, "%s/tasks",
+			       PARENT_DIR);
+		ASSERT_GT(ret, 0);
+
+		f = fopen(tasks_path, "w");
+		fclose(f);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override {
+		int ret;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(ChownChmodTasksTest, SuccessfulChownChmod)
+{
+	mode_t mode = S_IRUSR | S_IWUSR | S_IWGRP | S_IROTH;
+	char tasks_path[FILENAME_MAX];
+	uid_t uid = getuid();
+	gid_t gid = getgid();
+	struct stat statbuf;
+	int ret;
+
+	ret = cgroup_chown_chmod_tasks(PARENT_DIR, uid, gid, mode);
+	ASSERT_EQ(ret, 0);
+
+	memset(tasks_path, 0, sizeof(tasks_path));
+	ret = snprintf(tasks_path, FILENAME_MAX - 1, "%s/tasks",
+		       PARENT_DIR);
+	ASSERT_GT(ret, 0);
+
+	ret = stat(tasks_path, &statbuf);
+	ASSERT_EQ(ret, 0);
+
+	ASSERT_EQ(statbuf.st_uid, uid);
+	ASSERT_EQ(statbuf.st_gid, gid);
+	ASSERT_EQ(statbuf.st_mode & 0777, mode);
+}

--- a/tests/gunit/011-cgroupv2_subtree_control.cpp
+++ b/tests/gunit/011-cgroupv2_subtree_control.cpp
@@ -1,0 +1,125 @@
+/**
+ * libcgroup googletest for cgroupv2_subtree_control()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test011cgroup/";
+static const char * const SUBTREE_FILE = "cgroup.subtree_control";
+
+
+class SubtreeControlTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override {
+		char tmp_path[FILENAME_MAX];
+		int ret, i;
+		FILE *f;
+
+		ret = mkdir(PARENT_DIR, S_IRWXU | S_IRWXG | S_IRWXO);
+		ASSERT_EQ(ret, 0);
+
+		memset(tmp_path, 0, sizeof(tmp_path));
+		ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+			       PARENT_DIR, SUBTREE_FILE);
+		ASSERT_GT(ret, 0);
+
+		f = fopen(tmp_path, "w");
+		fclose(f);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf) {
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override {
+		int ret;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(SubtreeControlTest, AddController)
+{
+	char tmp_path[FILENAME_MAX], buf[4092];
+	char ctrlr_name[] = "cpu";
+	int ret;
+	FILE *f;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+		       PARENT_DIR, SUBTREE_FILE);
+	ASSERT_GT(ret, 0);
+
+	/* erase the contents of the file */
+	f = fopen(tmp_path, "w");
+	fclose(f);
+
+	ret = cgroupv2_subtree_control(PARENT_DIR, ctrlr_name, true);
+	ASSERT_EQ(ret, 0);
+
+	f = fopen(tmp_path, "r");
+	ASSERT_NE(f, nullptr);
+
+	while (fgets(buf, sizeof(buf), f))
+		ASSERT_STREQ(buf, "+cpu");
+	fclose(f);
+}
+
+TEST_F(SubtreeControlTest, RemoveController)
+{
+	char tmp_path[FILENAME_MAX], buf[4092];
+	char ctrlr_name[] = "memory";
+	int ret;
+	FILE *f;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+		       PARENT_DIR, SUBTREE_FILE);
+	ASSERT_GT(ret, 0);
+
+	/* erase the contents of the file */
+	f = fopen(tmp_path, "w");
+	fclose(f);
+
+	ret = cgroupv2_subtree_control(PARENT_DIR, ctrlr_name, false);
+	ASSERT_EQ(ret, 0);
+
+	f = fopen(tmp_path, "r");
+	ASSERT_NE(f, nullptr);
+
+	while (fgets(buf, sizeof(buf), f))
+		ASSERT_STREQ(buf, "-memory");
+	fclose(f);
+}

--- a/tests/gunit/012-cgroup_create_cgroup.cpp
+++ b/tests/gunit/012-cgroup_create_cgroup.cpp
@@ -1,0 +1,232 @@
+/**
+ * libcgroup googletest for cgroup_create_cgroup()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <dirent.h>
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test012cgroup";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+static const char * const CONTROLLERS[] = {
+	"cpu",
+	"freezer",
+	"memory",
+	"cpuset",
+	"namespaces",
+	"netns",
+};
+static const int CONTROLLERS_CNT =
+	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+
+static cg_version_t VERSIONS[] = {
+	CGROUP_V1,
+	CGROUP_V2,
+	CGROUP_V2,
+	CGROUP_V1,
+	CGROUP_V1,
+	CGROUP_V2,
+};
+static const int VERSIONS_CNT =
+	sizeof(VERSIONS) / sizeof(VERSIONS[0]);
+
+class CgroupCreateCgroupTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override
+	{
+		char tmp_path[FILENAME_MAX];
+		int ret, i;
+		FILE *f;
+
+		ASSERT_EQ(VERSIONS_CNT, CONTROLLERS_CNT);
+
+		ret = mkdir(PARENT_DIR, MODE);
+		ASSERT_EQ(ret, 0);
+
+		/*
+		 * Artificially populate the mount table with local
+		 * directories
+		 */
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
+
+		for (i = 0; i < CONTROLLERS_CNT; i++) {
+			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+				 "%s", CONTROLLERS[i]);
+			cg_mount_table[i].version = VERSIONS[i];
+
+			switch (VERSIONS[i]) {
+			case CGROUP_V1:
+				snprintf(cg_mount_table[i].mount.path,
+					 FILENAME_MAX, "%s/%s", PARENT_DIR,
+					 CONTROLLERS[i]);
+
+				ret = mkdir(cg_mount_table[i].mount.path, MODE);
+				ASSERT_EQ(ret, 0);
+				break;
+			case CGROUP_V2:
+				snprintf(cg_mount_table[i].mount.path,
+					 FILENAME_MAX, "%s", PARENT_DIR);
+
+				memset(tmp_path, 0, sizeof(tmp_path));
+				snprintf(tmp_path, FILENAME_MAX - 1,
+					 "%s/cgroup.subtree_control",
+					 PARENT_DIR);
+
+				f = fopen(tmp_path, "w");
+				ASSERT_NE(f, nullptr);
+				fclose(f);
+				break;
+			default:
+				/* we shouldn't get here.  fail the test */
+				ASSERT_TRUE(false);
+			}
+		}
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override
+	{
+		int ret = 0;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+static void verify_cgroup_created(const char * const cg_name,
+				  const char * const ctrl)
+{
+	char tmp_path[FILENAME_MAX];
+	DIR *dir;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+
+	if (ctrl)
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s",
+			 PARENT_DIR, ctrl, cg_name);
+	else
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s",
+			 PARENT_DIR, cg_name);
+
+	dir = opendir(tmp_path);
+	ASSERT_NE(dir, nullptr);
+	closedir(dir);
+}
+
+static void verify_subtree_contents(const char * const expected)
+{
+	char tmp_path[FILENAME_MAX], buf[4092];
+	FILE *f;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.subtree_control",
+		 PARENT_DIR);
+	f = fopen(tmp_path, "r");
+	ASSERT_NE(f, nullptr);
+
+	while (fgets(buf, sizeof(buf), f))
+		ASSERT_STREQ(buf, expected);
+	fclose(f);
+}
+
+TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1)
+{
+	struct cgroup_controller *ctrl;
+	struct cgroup *cg = NULL;
+	const char * const ctrl_name = "cpu";
+	const char * const cg_name = "MyV1Cgroup";
+	int ret;
+
+	cg = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cg, nullptr);
+
+	ctrl = cgroup_add_controller(cg, ctrl_name);
+	ASSERT_NE(ctrl, nullptr);
+
+	ret = cgroup_create_cgroup(cg, 1);
+	ASSERT_EQ(ret, 0);
+
+	verify_cgroup_created(cg_name, ctrl_name);
+}
+
+TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV2)
+{
+	struct cgroup_controller *ctrl;
+	struct cgroup *cg = NULL;
+	const char * const ctrl_name = "freezer";
+	const char * const cg_name = "MyV2Cgroup";
+	int ret;
+
+	cg = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cg, nullptr);
+
+	ctrl = cgroup_add_controller(cg, ctrl_name);
+	ASSERT_NE(ctrl, nullptr);
+
+	ret = cgroup_create_cgroup(cg, 0);
+	ASSERT_EQ(ret, 0);
+
+	verify_cgroup_created(cg_name, NULL);
+	verify_subtree_contents("+freezer");
+}
+
+TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1AndV2)
+{
+	struct cgroup_controller *ctrl;
+	struct cgroup *cg = NULL;
+	const char * const ctrl1_name = "memory";
+	const char * const ctrl2_name = "cpuset";
+	const char * const cg_name = "MyV1AndV2Cgroup";
+	int ret;
+
+	cg = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cg, nullptr);
+
+	ctrl = cgroup_add_controller(cg, ctrl1_name);
+	ASSERT_NE(ctrl, nullptr);
+	ctrl = NULL;
+	ctrl = cgroup_add_controller(cg, ctrl2_name);
+	ASSERT_NE(ctrl, nullptr);
+
+	ret = cgroup_create_cgroup(cg, 1);
+	ASSERT_EQ(ret, 0);
+
+	verify_cgroup_created(cg_name, NULL);
+	verify_cgroup_created(cg_name, ctrl2_name);
+	verify_subtree_contents("+memory");
+}

--- a/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
+++ b/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
@@ -1,0 +1,162 @@
+/**
+ * libcgroup googletest for cgroup_build_tasks_procs_path()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class BuildTasksProcPathTest : public ::testing::Test {
+	protected:
+
+	/**
+	 * Setup this test case
+	 *
+	 * This test case calls cg_build_path() to generate various
+	 * cgroup paths.  The SetUp() routine creates a simple mount
+	 * table that can be used to verify cg_build_path() behavior.
+	 *
+	 * cg_mount_table for this test is as follows:
+	 *	name		mount_point		   index  version
+	 *	----------------------------------------------------------
+	 *	controller0	/sys/fs/cgroup/controller0     0      UNK
+	 *	controller1	/sys/fs/cgroup/controller1     1        2
+	 *	controller2	/sys/fs/cgroup/controller2     2        1
+	 *	controller3	/sys/fs/cgroup/controller3     3        2
+	 *	controller4	/sys/fs/cgroup/controller4     4        1
+	 *	controller5	/sys/fs/cgroup/controller5     5        2
+	 *
+	 * Note that controllers 1 and 4 are also given namespaces
+	 */
+	void SetUp() override {
+		char NAMESPACE1[] = "ns1";
+		char NAMESPACE4[] = "ns4";
+		const int ENTRY_CNT = 6;
+		int i, ret;
+
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(cg_namespace_table, 0,
+			CG_CONTROLLER_MAX * sizeof(cg_namespace_table[0]));
+
+		// Populate the mount table
+		for (i = 0; i < ENTRY_CNT; i++) {
+			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+				 "controller%d", i);
+			cg_mount_table[i].index = i;
+
+			ret = snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
+				 "/sys/fs/cgroup/%s", cg_mount_table[i].name);
+			ASSERT_LT(ret, sizeof(cg_mount_table[i].mount.path));
+
+			cg_mount_table[i].mount.next = NULL;
+
+			if (i == 0)
+				cg_mount_table[i].version = CGROUP_UNK;
+			else
+				cg_mount_table[i].version =
+					(cg_version_t)((i % 2) + 1);
+		}
+
+		// Give a couple of the entries a namespace as well
+		cg_namespace_table[1] =	NAMESPACE1;
+		cg_namespace_table[4] =	NAMESPACE4;
+	}
+};
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_ControllerNotFound)
+{
+	char ctrlname[] = "InvalidCtrlr";
+	char path[FILENAME_MAX];
+	char cgname[] = "foo";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, ECGOTHER);
+	ASSERT_STREQ(path, "\0");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_UnknownCgVersion)
+{
+	char ctrlname[] = "controller0";
+	char path[FILENAME_MAX];
+	char cgname[] = "bar";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, ECGOTHER);
+	ASSERT_STREQ(path, "\0");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1)
+{
+	char ctrlname[] = "controller2";
+	char path[FILENAME_MAX];
+	char cgname[] = "Container7";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(path, "/sys/fs/cgroup/controller2/Container7/tasks");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2)
+{
+	char ctrlname[] = "controller3";
+	struct cgroup_controller ctrlr = {0};
+	char path[FILENAME_MAX];
+	char cgname[] = "tomcat";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(path, "/sys/fs/cgroup/controller3/tomcat/cgroup.procs");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1WithNs)
+{
+	char ctrlname[] = "controller4";
+	struct cgroup_controller ctrlr = {0};
+	char path[FILENAME_MAX];
+	char cgname[] = "database12";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(path, "/sys/fs/cgroup/controller4/ns4/database12/tasks");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2WithNs)
+{
+	char ctrlname[] = "controller1";
+	struct cgroup_controller ctrlr = {0};
+	char path[FILENAME_MAX];
+	char cgname[] = "server";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(path, "/sys/fs/cgroup/controller1/ns1/server/cgroup.procs");
+}

--- a/tests/gunit/014-cgroupv2_get_subtree_control.cpp
+++ b/tests/gunit/014-cgroupv2_get_subtree_control.cpp
@@ -1,0 +1,170 @@
+/**
+ * libcgroup googletest for cgroupv2_get_subtree_control()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <fcntl.h>
+#include <ftw.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test013cgroup/";
+static const char * const SUBTREE_FILE = "cgroup.subtree_control";
+
+
+class GetSubtreeControlTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override {
+		char tmp_path[FILENAME_MAX];
+		int ret, i;
+		FILE *f;
+
+		ret = mkdir(PARENT_DIR, S_IRWXU | S_IRWXG | S_IRWXO);
+		ASSERT_EQ(ret, 0);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf) {
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override {
+		int ret;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+static void write_subtree_file(const char * const contents, ssize_t len)
+{
+	char tmp_path[FILENAME_MAX];
+	ssize_t bytes_written;
+	int ret, fd;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+		       PARENT_DIR, SUBTREE_FILE);
+	ASSERT_GT(ret, 0);
+
+	fd = open(tmp_path, O_WRONLY | O_TRUNC | O_CREAT, S_IRWXU | S_IRWXG);
+	ASSERT_GT(fd, 0);
+
+	bytes_written = write(fd, contents, len);
+	ASSERT_EQ(bytes_written, len);
+	close(fd);
+}
+
+TEST_F(GetSubtreeControlTest, SingleControllerEnabled)
+{
+	char ctrlr_name[] = "cpu";
+	char subtree_contents[] = "cpu\n";
+	bool enabled = false;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(enabled, true);
+}
+
+TEST_F(GetSubtreeControlTest, SingleControllerNoMatch)
+{
+	char ctrlr_name[] = "cpu";
+	char subtree_contents[] = "cpuset\n";
+	bool enabled = true;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, ECGROUPNOTMOUNTED);
+	ASSERT_EQ(enabled, false);
+}
+
+TEST_F(GetSubtreeControlTest, SingleControllerNoMatch2)
+{
+	char ctrlr_name[] = "cpuset";
+	char subtree_contents[] = "cpu\n";
+	bool enabled = true;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, ECGROUPNOTMOUNTED);
+	ASSERT_EQ(enabled, false);
+}
+
+TEST_F(GetSubtreeControlTest, MultipleControllersEnabled)
+{
+	char ctrlr_name[] = "cpu";
+	char subtree_contents[] = "cpu cpuset io memory pids\n";
+	bool enabled = false;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(enabled, true);
+}
+
+TEST_F(GetSubtreeControlTest, MultipleControllersEnabled2)
+{
+	char ctrlr_name[] = "pids";
+	char subtree_contents[] = "cpu cpuset io memory pids\n";
+	bool enabled = false;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(enabled, true);
+}
+
+TEST_F(GetSubtreeControlTest, MultipleControllersNoMatch)
+{
+	char ctrlr_name[] = "network";
+	char subtree_contents[] = "cpu cpuset io memory pids\n";
+	bool enabled = true;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, ECGROUPNOTMOUNTED);
+	ASSERT_EQ(enabled, false);
+}

--- a/tests/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/tests/gunit/015-cgroupv2_controller_enabled.cpp
@@ -1,0 +1,185 @@
+/**
+ * libcgroup googletest for cgroupv2_controller_enabled()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <ftw.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test015cgroup";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+static const char * const CHILD_DIRS[] = {
+	"test1-v1cgroup",
+	"test2-rootcgroup",
+	"test3-ctrlrenabled",
+	"test4-ctrlrdisabled",
+};
+static const int CHILD_DIRS_CNT =
+	sizeof(CHILD_DIRS) / sizeof(CHILD_DIRS[0]);
+
+static const char * const CONTROLLERS[] = {
+	"cpu",
+	"cpuset",
+	"io",
+	"memory",
+	"net_cls",
+	"pids",
+};
+static const int CONTROLLERS_CNT =
+	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+
+static const enum cg_version_t VERSIONS[] = {
+	CGROUP_V2,
+	CGROUP_V1,
+	CGROUP_V2,
+	CGROUP_V2,
+	CGROUP_V2,
+	CGROUP_V2,
+};
+static const int VERSIONS_CNT =
+	sizeof(VERSIONS) / sizeof(VERSIONS[0]);
+
+class CgroupV2ControllerEnabled : public ::testing::Test {
+	protected:
+
+	void InitChildDir(const char dirname[])
+	{
+		char tmp_path[FILENAME_MAX] = {0};
+		int ret;
+
+		/* create the directory */
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s",
+			 PARENT_DIR, dirname);
+		ret = mkdir(tmp_path, MODE);
+		ASSERT_EQ(ret, 0);
+	}
+
+	void InitMountTable(void)
+	{
+		char tmp_path[FILENAME_MAX] = {0};
+		int ret, i;
+		FILE *f;
+
+		ASSERT_EQ(VERSIONS_CNT, CONTROLLERS_CNT);
+
+		snprintf(tmp_path, FILENAME_MAX - 1,
+			 "%s/cgroup.subtree_control", PARENT_DIR);
+
+		f = fopen(tmp_path, "w");
+		ASSERT_NE(f, nullptr);
+		fprintf(f, "cpu io memory pids\n");
+		fclose(f);
+
+		/*
+		 * Artificially populate the mount table with local
+		 * directories
+		 */
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
+
+		for (i = 0; i < CONTROLLERS_CNT; i++) {
+			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+				 "%s", CONTROLLERS[i]);
+			snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
+				 "%s", PARENT_DIR);
+			cg_mount_table[i].version = VERSIONS[i];
+		}
+	}
+
+	void SetUp() override
+	{
+		int ret, i;
+
+		ret = mkdir(PARENT_DIR, MODE);
+		ASSERT_EQ(ret, 0);
+
+		InitMountTable();
+
+		for (i = 0; i < CHILD_DIRS_CNT; i++)
+			InitChildDir(CHILD_DIRS[i]);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override
+	{
+		int ret = 0;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(CgroupV2ControllerEnabled, CgroupV1Controller)
+{
+	char ctrlr_name[] = "cpuset";
+	char cg_name[] = "foo";
+	int ret;
+
+	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ASSERT_EQ(ret, 0);
+}
+
+TEST_F(CgroupV2ControllerEnabled, RootCgroup)
+{
+	char ctrlr_name[] = "cpu";
+	char cg_name[] = "/";
+	int ret;
+
+	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ASSERT_EQ(ret, 0);
+}
+
+TEST_F(CgroupV2ControllerEnabled, ControllerEnabled)
+{
+	char ctrlr_name[] = "pids";
+	char cg_name[] = "test3-ctrlrenabled";
+	int ret;
+
+	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ASSERT_EQ(ret, 0);
+}
+
+TEST_F(CgroupV2ControllerEnabled, ControllerDisabled)
+{
+	char ctrlr_name[] = "net_cls";
+	char cg_name[] = "test4-ctrlrdisabled";
+	int ret;
+
+	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ASSERT_EQ(ret, ECGROUPNOTMOUNTED);
+}

--- a/tests/gunit/016-cgset_parse_r_flag.cpp
+++ b/tests/gunit/016-cgset_parse_r_flag.cpp
@@ -1,0 +1,52 @@
+/**
+ * libcgroup googletest for parse_r_flag() in cgset
+ *
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+#include "tools-common.h"
+
+static const char * const PARENT_DIR = "test016cgset/";
+
+static const char * const NAME = "io.max";
+static const char * const VALUE = "\"8:16 wbps=1024\"";
+
+class CgsetParseRFlagTest : public ::testing::Test {
+};
+
+TEST_F(CgsetParseRFlagTest, EqualCharInValue)
+{
+	struct control_value name_value;
+	char name_value_str[4092];
+	int ret;
+
+	ret = snprintf(name_value_str, sizeof(name_value_str) -1,
+		       "%s=%s", NAME, VALUE);
+	ASSERT_GT(ret, 0);
+
+	ret = parse_r_flag("cgset", name_value_str, &name_value);
+	ASSERT_EQ(ret, 0);
+
+	ASSERT_STREQ(name_value.name, NAME);
+	ASSERT_STREQ(name_value.value, VALUE);
+}

--- a/tests/gunit/Makefile.am
+++ b/tests/gunit/Makefile.am
@@ -1,0 +1,60 @@
+#
+# libcgroup googletests Makefile.am
+#
+# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+AM_CPPFLAGS = -I$(top_srcdir)/include \
+	      -I$(top_srcdir)/src \
+	      -I$(top_srcdir)/src/tools \
+	      -I$(top_builddir)/googletest/googletest/include \
+	      -I$(top_builddir)/googletest/googletest \
+	      -std=c++11 \
+	      -Wno-write-strings \
+	      -DSTATIC= \
+	      -DUNIT_TEST
+LDADD = $(top_builddir)/src/.libs/libcgroupfortesting.la \
+	$(top_builddir)/src/tools/.libs/libcgset.la
+
+EXTRA_DIST = $(top_srcdir)/googletest/googletest/libgtest.so \
+	     $(top_srcdir)/googletest/googletest/libgtest_main.so \
+	     $(top_srcdir)/googletest/googletest/include \
+	     libcgroup_unittest.map
+
+check_PROGRAMS = gtest
+TESTS = gtest
+
+gtest_SOURCES = gtest.cpp \
+		001-path.cpp \
+		002-cgroup_parse_rules_options.cpp \
+		003-cg_get_cgroups_from_proc_cgroups.cpp \
+		004-cgroup_compare_ignore_rule.cpp \
+		005-cgroup_compare_wildcard_procname.cpp \
+		006-cgroup_get_cgroup.cpp \
+		007-cgroup_process_v1_mount.cpp \
+		008-cgroup_process_v2_mount.cpp \
+		009-cgroup_set_values_recursive.cpp \
+		010-cgroup_chown_chmod_tasks.cpp \
+		011-cgroupv2_subtree_control.cpp \
+		012-cgroup_create_cgroup.cpp \
+		013-cgroup_build_tasks_procs_path.cpp \
+		014-cgroupv2_get_subtree_control.cpp \
+		015-cgroupv2_controller_enabled.cpp \
+		016-cgset_parse_r_flag.cpp
+gtest_LDFLAGS = -L$(top_builddir)/googletest/googletest -l:libgtest.so \
+		-rpath $(abs_top_builddir)/googletest/googletest

--- a/tests/gunit/gtest.cpp
+++ b/tests/gunit/gtest.cpp
@@ -1,0 +1,29 @@
+/**
+ * libcgroup googletest main entry point
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/gunit/libcgroup_unittest.map
+++ b/tests/gunit/libcgroup_unittest.map
@@ -1,0 +1,130 @@
+CGROUP_0.32 {
+global:
+	cgroup_init;
+	cgroup_attach_task;
+	cgroup_modify_cgroup;
+	cgroup_create_cgroup;
+	cgroup_delete_cgroup;
+	cgroup_attach_task_pid;
+	cgroup_get_cgroup;
+	cgroup_create_cgroup_from_parent;
+	cgroup_copy_cgroup;
+	cgroup_change_cgroup_uid_gid;
+	cgroup_change_cgroup_path;
+	cgroup_new_cgroup;
+	cgroup_add_controller;
+	cgroup_free;
+	cgroup_free_controllers;
+	cgroup_add_value_string;
+	cgroup_add_value_int64;
+	cgroup_add_value_uint64;
+	cgroup_add_value_bool;
+	cgroup_compare_cgroup;
+	cgroup_compare_controllers;
+	cgroup_set_uid_gid;
+	cgroup_get_uid_gid;
+	cgroup_get_value_string;
+	cgroup_set_value_string;
+	cgroup_get_value_int64;
+	cgroup_set_value_int64;
+	cgroup_get_value_uint64;
+	cgroup_set_value_uint64;
+	cgroup_get_value_bool;
+	cgroup_set_value_bool;
+	cgroup_change_cgroup_uid_gid_flags;
+	cgroup_print_rules_config;
+	cgroup_reload_cached_rules;
+	cgroup_init_rules_cache;
+	cgroup_get_current_controller_path;
+	cgroup_config_load_config;
+	*;
+};
+
+CGROUP_0.32.1 {
+global:
+	cgroup_strerror;
+} CGROUP_0.32;
+
+CGROUP_0.33 {
+global:
+	cgroup_get_last_errno;
+	cgroup_walk_tree_begin;
+	cgroup_walk_tree_next;
+	cgroup_walk_tree_end;
+} CGROUP_0.32.1;
+
+CGROUP_0.34 {
+global:
+	cgroup_get_task_begin;
+	cgroup_get_task_end;
+	cgroup_get_task_next;
+	cgroup_read_stats_begin;
+	cgroup_read_stats_next;
+	cgroup_read_stats_end;
+	cgroup_walk_tree_set_flags;
+	cgroup_get_controller_end;
+	cgroup_get_controller_next;
+	cgroup_get_controller_begin;
+	cgroup_unload_cgroups;
+	cgroup_get_controller;
+	cgroup_get_uid_gid_from_procfs;
+	cgroup_get_subsys_mount_point;
+	cgroup_get_procname_from_procfs;
+	cgroup_register_unchanged_process;
+	cgroup_change_cgroup_flags;
+} CGROUP_0.33;
+
+CGROUP_0.35 {
+global:
+	create_cgroup_from_name_value_pairs;
+	cgroup_delete_cgroup_ext;
+	cgroup_get_all_controller_begin;
+	cgroup_get_all_controller_next;
+	cgroup_get_all_controller_end;
+	cgroup_get_value_name_count;
+	cgroup_get_value_name;
+} CGROUP_0.34;
+
+CGROUP_0.36 {
+} CGROUP_0.35;
+
+CGROUP_0.37 {
+	cgroup_get_procs;
+	cgroup_read_value_begin;
+	cgroup_read_value_next;
+	cgroup_read_value_end;
+	cg_chmod_recursive;
+} CGROUP_0.36;
+
+CGROUP_0.38 {
+       cgroup_get_subsys_mount_point_begin;
+       cgroup_get_subsys_mount_point_next;
+       cgroup_get_subsys_mount_point_end;
+       cgroup_set_permissions;
+       cgroup_config_unload_config;
+       cgroup_config_set_default;
+} CGROUP_0.37;
+
+CGROUP_0.39 {
+	cgroup_reload_cached_templates;
+	cgroup_init_templates_cache;
+	cgroup_config_create_template_group;
+	cgroup_change_all_cgroups;
+	cgroup_set_logger;
+	cgroup_set_default_logger;
+	cgroup_set_loglevel;
+	cgroup_log;
+	cgroup_parse_log_level_str;
+} CGROUP_0.38;
+
+CGROUP_0.40 {
+	cgroup_templates_cache_set_source_files;
+	cgroup_load_templates_cache_from_files;
+} CGROUP_0.39;
+
+CGROUP_0.41 {
+} CGROUP_0.40;
+
+CGROUP_0.42 {
+	cgroup_add_all_controllers;
+} CGROUP_0.41;

--- a/tests/libcg_ba.cpp
+++ b/tests/libcg_ba.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright IBM Corporation. 2007
+ *
+ * Author:	Balbir Singh <balbir@linux.vnet.ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Basic acceptance test for libcgroup - Written one late night by Balbir Singh
+ */
+using namespace std;
+
+#include <string>
+#include <stdexcept>
+#include <iostream>
+#include <libcgroup.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <grp.h>
+
+#include "../config.h"
+
+#ifdef CGROUP_DBG
+#define cgroup_dbg(p...)	printf(p...)
+#else
+#define cgroup_dbg(p...)	do {} while (0)
+#endif
+
+namespace cgtest {
+
+class cg {
+private:
+public:
+	cg();
+	~cg()
+	{ }
+	struct cgroup *makenode(const string &name, const string &task_uid,
+			const string &task_gid, const string &control_uid,
+			const string &control_gid);
+	struct cgroup *makenodefromparent(const string &name);
+};
+
+cg::cg(void)
+{
+	int ret;
+
+	ret = cgroup_init();
+	if (ret)
+		throw logic_error("Control Group Initialization failed..."
+				"Please check that cgroups are mounted and\n"
+				"at a single place");
+}
+
+struct cgroup *cg::makenode(const string &name, const string &task_uid,
+		const string &task_gid, const string &control_uid,
+		const string &control_gid)
+{
+	uid_t tuid, cuid;
+	gid_t tgid, cgid;
+	char *cgroup_name;
+	struct cgroup *ccg;
+	struct cgroup_controller *cpu, *cpuacct;
+	struct passwd *passwd;
+	struct group *grp;
+	int ret;
+
+	passwd = getpwnam(task_uid.c_str());
+	if (!passwd)
+		return NULL;
+	tuid = passwd->pw_uid;
+
+	grp = getgrnam(task_gid.c_str());
+	if (!grp)
+		return NULL;
+	tgid = grp->gr_gid;
+
+	passwd = getpwnam(control_uid.c_str());
+	if (!passwd)
+		return NULL;
+	cuid = passwd->pw_uid;
+
+	grp = getgrnam(control_gid.c_str());
+	if (!grp)
+		return NULL;
+	cgid = grp->gr_gid;
+
+	cgroup_dbg("tuid %d, tgid %d, cuid %d, cgid %d\n", tuid, tgid, cuid, cgid);
+
+	cgroup_name = (char *) malloc(name.length());
+	strncpy(cgroup_name, name.c_str(), name.length() + 1);
+
+	ccg = cgroup_new_cgroup(cgroup_name);
+	cgroup_set_uid_gid(ccg, tuid, tgid, cuid, cgid);
+	cpu = cgroup_add_controller(ccg, "cpu");
+	cgroup_add_value_uint64(cpu, "cpu.shares", 2048);
+	cpuacct = cgroup_add_controller(ccg, "cpuacct");
+	cgroup_add_value_uint64(cpuacct, "cpuacct.usage", 0);
+
+
+	ret = cgroup_create_cgroup(ccg, 1);
+	if (ret) {
+		cout << "cg create group failed " << errno << endl;
+		ret = cgroup_delete_cgroup(ccg, 1);
+		if (ret)
+			cout << "cg delete group failed " << errno << endl;
+	}
+	return ccg;
+}
+
+struct cgroup *cg::makenodefromparent(const string &name)
+{
+	char *cgroup_name;
+	struct cgroup *ccg;
+	int ret;
+
+	cgroup_name = (char *) malloc(name.length());
+	memset(cgroup_name, '\0', name.length());
+	strcpy(cgroup_name, name.c_str());
+
+	ccg = cgroup_new_cgroup(cgroup_name);
+	ret = cgroup_create_cgroup_from_parent(ccg, 1);
+	if (ret) {
+		cout << "cg create group failed " << errno << endl;
+		ret = cgroup_delete_cgroup(ccg, 1);
+		if (ret)
+			cout << "cg delete group failed " << errno << endl;
+	}
+	return ccg;
+}
+
+} // namespace
+
+using namespace cgtest;
+int main(int argc, char *argv[])
+{
+	try {
+		cg *app = new cg();
+		struct cgroup *ccg, *ccg_child1, *ccg_child2;
+		ccg = app->makenode("database", "root", "root", "balbir",
+					"balbir");
+		ccg_child1 = app->makenodefromparent("mysql");
+		ccg_child2 = app->makenodefromparent("mysql/db1");
+		cgroup_free(&ccg);
+		cgroup_free(&ccg_child1);
+		cgroup_free(&ccg_child2);
+		delete app;
+	} catch (exception &e) {
+		cout << e.what() << endl;
+		exit(1);
+	}
+	return 0;
+}

--- a/tests/libcgrouptest.h
+++ b/tests/libcgrouptest.h
@@ -1,0 +1,158 @@
+
+/*
+ * Copyright IBM Corporation. 2008
+ *
+ * Author:	Sudhir Kumar <skumar@linux.vnet.ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description: This file is the header file for libcgroup test programs.
+ */
+
+#ifndef __LIBCGROUPTEST_H
+#define __LIBCGROUPTEST_H
+
+#include <errno.h>
+#include <fcntl.h>
+#include <mntent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <libcgroup.h>
+#include "../config.h"
+#include <unistd.h>
+#include <inttypes.h>
+
+#define SIZE 100	/* Max size of a message to be printed */
+#define NUM_MSGS 20	/* Number of such messsages */
+#define PASS 1		/* test passed */
+#define FAIL 0		/* test failed */
+
+enum cgroup_mount_t {
+	FS_NOT_MOUNTED,
+	FS_MOUNTED,
+	FS_MULTI_MOUNTED,
+};
+
+enum controller_t {
+	CPU,
+	MEMORY,
+	CPUSET,
+	/* Add new controllers here */
+};
+
+enum cgroup_control_val_t {
+	BOOL,
+	INT64,
+	UINT64,
+	STRING,
+};
+
+enum info_message_t {
+	NULLGRP,
+	COMMONGRP,
+	NOTCRTDGRP,
+	SAMEGRP,
+	TASKINGRP,
+	TASKNOTINGRP,
+	TASKNOTINANYGRP,
+	GRPINFS,
+	GRPNOTINFS,
+	GRPINBOTHCTLS,
+	GRPNOTIN2NDCTL,
+	GRPNOTIN1STCTL,
+	GRPMODINBOTHCTLS,
+	GRPNOTMODIN2NDCTL,
+	GRPNOTMODINANYCTL,
+	GRPDELETEDINFS,
+	GRPNOTDELETEDINFS,
+	GRPNOTDELETEDGLOBALY,
+	NOMESSAGE,
+};
+
+/* Keep a single struct of all ids */
+struct uid_gid_t {
+	uid_t control_uid;
+	gid_t control_gid;
+	uid_t tasks_uid;
+	gid_t tasks_gid;
+};
+
+/* Keep a single struct of all control values */
+struct cntl_val_t {
+	int64_t val_int64;
+	u_int64_t val_uint64;
+	bool val_bool;
+	/* size worth of 100 digit num is fair enough */
+	char val_string[100];	/* string value of control parameter */
+};
+
+extern int cpu, memory;
+
+/* The set of verbose messages useful to the user */
+extern char info[NUM_MSGS][SIZE];
+
+/* this variable is never modified */
+extern int fs_mounted;
+
+/* The mountpoints as received from script
+ * We use mountpoint for single mount.
+ * For multimount we use mountpoint and mountpoint2.
+ */
+extern char mountpoint[], mountpoint2[];
+
+/* Functions to test each API */
+void test_cgroup_init(int retcode, int i);
+void test_cgroup_attach_task(int retcode, struct cgroup *cgroup1,
+		const char *group1, const char *group2, pid_t pid,
+		int k, int i);
+struct cgroup *create_new_cgroup_ds(int ctl, const char *grpname,
+	 int value_type, struct cntl_val_t cval, struct uid_gid_t ids, int i);
+void test_cgroup_create_cgroup(int retcode, struct cgroup *cgrp,
+		 const char *name, int common, int mpnt, int ign, int i);
+void test_cgroup_delete_cgroup(int retcode, struct cgroup *cgrp,
+		 const char *name, int common, int mpnt, int ign, int i);
+void test_cgroup_modify_cgroup(int retcode, struct cgroup *cgrp,
+		 const char *name, int which_ctl, int ctl1, int ctl2,
+						 int value_type, int i);
+void test_cgroup_get_cgroup(int ctl1, int ctl2, struct uid_gid_t ids, int i);
+/* API test functions end here */
+
+void test_cgroup_compare_cgroup(int ctl1, int ctl2, int i);
+void test_cgroup_add_free_controller(int i);
+void is_subsystem_enabled(const char *name, int *exist);
+int group_exist(char *path_group);
+int set_controller(int controller, char *controller_name,
+						 char *control_file);
+int group_modified(char *path_control_file, int value_type,
+						 struct cntl_val_t cval);
+int add_control_value(struct cgroup_controller *newcontroller,
+	 char *control_file, char *wr, int value_type, struct cntl_val_t cval);
+struct cgroup *new_cgroup(char *group, char *controller_name,
+	 char *control_file, int value_type, struct cntl_val_t cval,
+					 struct uid_gid_t ids, int i);
+int check_fsmounted(int multimnt);
+int check_task(char *tasksfile, pid_t pid);
+/* function to print messages in better format */
+void message(int num, int pass, const char *api,
+						 int ret, char *extra);
+void build_path(char *target, char *mountpoint,
+				 const char *group, const char *file);
+pid_t cgrouptest_gettid();
+
+#ifdef CGROUP_DEBUG
+#define cgroup_dbg(p...)	printf(p)
+#else
+#define cgroup_dbg(p...)	do {} while (0);
+#endif
+
+#endif

--- a/tests/libcgrouptest01.c
+++ b/tests/libcgrouptest01.c
@@ -1,0 +1,756 @@
+/*
+ * Copyright IBM Corporation. 2008
+ *
+ * Author:	Sudhir Kumar <skumar@linux.vnet.ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description: This file contains the test code for testing libcgroup apis.
+ */
+
+#include "libcgrouptest.h"
+#include <errno.h>
+
+int cpu, memory;
+int fs_mounted;
+/* We use mountpoint for single mount.
+ * For multimount we use mountpoint and mountpoint2.
+ */
+char mountpoint[FILENAME_MAX], mountpoint2[FILENAME_MAX];
+
+int main(int argc, char *argv[])
+{
+	int retval;
+	struct uid_gid_t ids = {0}; /* Set default control permissions */
+
+	struct cntl_val_t cval;
+	cval.val_int64 = 200000;
+	cval.val_uint64 = 200000;
+	cval.val_bool = 1;
+	strcpy(cval.val_string, "200000");
+
+	struct cgroup *cgroup1, *cgroup2, *cgroup3, *nullcgroup = NULL;
+	struct cgroup_controller *sec_controller;
+	/* In case of multimount for readability we use the controller name
+	 * before the cgroup structure name */
+	struct cgroup *ctl1_cgroup1, *ctl2_cgroup1, *ctl2_cgroup2;
+	struct cgroup *mod_ctl1_cgroup1, *mod_ctl2_cgroup1, *mod_common_cgroup;
+	struct cgroup *common_cgroup;
+	char controller_name[FILENAME_MAX], control_file[FILENAME_MAX];
+	char path_control_file[FILENAME_MAX];
+
+	/* Get controllers name from script */
+	int ctl1 = CPU, ctl2 = MEMORY;
+
+	if ((argc < 2) || (argc > 6) || (atoi(argv[1]) < 0)) {
+		printf("ERROR: Wrong no of parameters recieved from script\n");
+		printf("Exiting the libcgroup testset\n");
+		exit(1);
+	}
+	fs_mounted = atoi(argv[1]);
+	cgroup_dbg("C:DBG: fs_mounted as recieved from script=%d\n",
+								fs_mounted);
+	/* All possible controller will be element of an enum */
+	if (fs_mounted) {
+		ctl1 = atoi(argv[2]);
+		ctl2 = atoi(argv[3]);
+		strncpy(mountpoint, argv[4], sizeof(mountpoint) - 1);
+		cgroup_dbg("C:DBG: mountpoint1 as recieved from script=%s\n",
+								 mountpoint);
+		if (fs_mounted == FS_MULTI_MOUNTED) {
+			strncpy(mountpoint2, argv[5], sizeof(mountpoint2) - 1);
+			cgroup_dbg("C:DBG: mountpoint2 as recieved from "
+					"script=%s\n", mountpoint2);
+		}
+
+	}
+
+	/*
+	 * check if one of the supported controllers is cpu or memory
+	 */
+	is_subsystem_enabled("cpu", &cpu);
+	is_subsystem_enabled("memory", &memory);
+	if (cpu == 0 && memory == 0) {
+		fprintf(stderr, "none of cpu and memory controllers"
+						" is enabled in kernel\n");
+		fprintf(stderr, "Exiting the libcgroup testcases......\n");
+		exit(1);
+	}
+
+	/*
+	 * Testsets: Testcases are broadly devided into 3 categories based on
+	 * filesystem(fs) mount scenario. fs not mounted, fs mounted, fs multi
+	 * mounted. Call different apis in these different scenarios.
+	 */
+
+	switch (fs_mounted) {
+
+	case FS_NOT_MOUNTED:
+
+		/*
+		 * Test01: call cgroup_init() and check return values
+		 * Exp outcome: error ECGROUPNOTMOUNTED
+		 */
+
+		test_cgroup_init(ECGROUPNOTMOUNTED, 1);
+
+		/*
+		 * Test02: call cgroup_attach_task() with null group
+		 * Exp outcome: error non zero return value
+		 */
+
+		test_cgroup_attach_task(ECGROUPNOTINITIALIZED, nullcgroup,
+						 NULL, NULL, 0, NULLGRP, 2);
+
+		/*
+		 * Test03: Create a valid cgroup ds and check all return values
+		 * Exp outcome: no error
+		 */
+
+		cgroup1 = create_new_cgroup_ds(0, "group1",
+						 STRING, cval, ids, 3);
+
+		/*
+		 * Test04: Then Call cgroup_create_cgroup() with this valid grp
+		 * Exp outcome: non zero return value
+		 */
+		test_cgroup_create_cgroup(ECGROUPNOTINITIALIZED, cgroup1,
+							 "group1", 0, 1, 1, 4);
+
+		/*
+		 * Test05: delete cgroup
+		 * Exp outcome: non zero return value but what ?
+		 */
+		test_cgroup_delete_cgroup(ECGROUPNOTINITIALIZED, cgroup1,
+							 "group1", 0, 1, 1, 5);
+
+		/*
+		 * Test06: Check if cgroup_create_cgroup() handles a NULL cgroup
+		 * Exp outcome: error ECGROUPNOTALLOWED
+		 */
+		test_cgroup_create_cgroup(ECGROUPNOTINITIALIZED, nullcgroup,
+							 "group1", 0, 1, 1, 6);
+
+		/*
+		 * Test07: delete nullcgroup
+		 */
+		test_cgroup_delete_cgroup(ECGROUPNOTINITIALIZED, nullcgroup,
+							 "group1", 0, 1, 1, 7);
+		/* Test08: test the wrapper */
+		test_cgroup_add_free_controller(8);
+
+		cgroup_free(&nullcgroup);
+		cgroup_free(&cgroup1);
+
+		break;
+
+	case FS_MOUNTED:
+
+		/* Do a sanity check if cgroup fs is mounted */
+		if (check_fsmounted(0)) {
+			printf("Sanity check fails. cgroup fs not mounted\n");
+			printf("Exiting without running this set of tests\n");
+			exit(1);
+		}
+
+		/*
+		 * Test01: call cgroup_attach_task() with null group
+		 * without calling cgroup_init(). We can check other apis too.
+		 * Exp outcome: error ECGROUPNOTINITIALIZED
+		 */
+
+		test_cgroup_attach_task(ECGROUPNOTINITIALIZED, nullcgroup,
+						 NULL, NULL, 0, NULLGRP, 1);
+
+		/*
+		 * Test02: call cgroup_init() and check return values
+		 * Exp outcome:  no error. return value 0
+		 */
+
+		test_cgroup_init(0, 2);
+
+		/*
+		 * Test03: Call cgroup_attach_task() with null group and check
+		 * if return values are correct. If yes check if task exists in
+		 * root group tasks file
+		 * TODO: This test needs some modification in script
+		 * Exp outcome: current task should be attached to root group
+		 */
+
+		test_cgroup_attach_task(0, nullcgroup, NULL, NULL, 0,
+							 NULLGRP, 3);
+		/*
+		 * Test04: Call cgroup_attach_task_pid() with null group
+		 * and invalid pid
+		 * Exp outcome: error
+		 */
+		retval = cgroup_attach_task_pid(nullcgroup, -1);
+		if (retval != 0)
+			message(4, PASS, "attach_task_pid()", retval,
+							 info[NOMESSAGE]);
+		else
+			message(4, FAIL, "attach_task_pid()", retval,
+							 info[NOMESSAGE]);
+
+		/*
+		 * Test05: Create a valid cgroup structure
+		 * Exp outcome: no error. 0 return value
+		 */
+		cgroup1 = create_new_cgroup_ds(ctl1, "group1",
+							 STRING, cval, ids, 5);
+		if (!cgroup1) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Trying with second controller\n");
+			cgroup1 = create_new_cgroup_ds(ctl2, "group1", STRING,
+								cval, ids, 5);
+			if (!cgroup1) {
+				fprintf(stderr, "Failed to create cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+				exit(1);
+			}
+		}
+
+		/*
+		 * Test06: Then Call cgroup_create_cgroup() with this group
+		 * Exp outcome: zero return value
+		 */
+		test_cgroup_create_cgroup(0, cgroup1, "group1", 0, 1, 1, 6);
+
+		/*
+		 * Test07: Call cgroup_attach_task() with valid cgroup and check
+		 * if return values are correct. If yes check if task exists in
+		 * that group's tasks file
+		 * Exp outcome: current task should be attached to that group
+		 */
+
+		test_cgroup_attach_task(0, cgroup1, "group1", NULL,
+							 0, NOMESSAGE, 7);
+
+		/*
+		 * Test08: modify cgroup with the same cgroup
+		 * Exp outcome: zero return value. No change.
+		 */
+		set_controller(ctl1, controller_name, control_file);
+		build_path(path_control_file, mountpoint,
+						 "group1", control_file);
+		strncpy(cval.val_string, "260000", sizeof(cval.val_string));
+		retval = cgroup_modify_cgroup(cgroup1);
+		/* Check if the values are changed. cval contains orig values */
+		if (!retval && !group_modified(path_control_file, STRING, cval))
+			message(8, PASS, "modify_cgroup()", retval,
+							 info[SAMEGRP]);
+		else
+			message(8, FAIL, "modify_cgroup()", retval,
+							 info[SAMEGRP]);
+
+		/*
+		 * Create another valid cgroup structure with same group
+		 * to modify the existing group
+		 */
+		cgroup2 = create_new_cgroup_ds(ctl1, "group1",
+						 STRING, cval, ids, 9);
+		if (!cgroup2) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Trying with second controller\n");
+			cgroup2 = create_new_cgroup_ds(ctl2, "group1",
+							 STRING, cval, ids, 9);
+			if (!cgroup2) {
+				fprintf(stderr, "Failed to create cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+				exit(1);
+			}
+		}
+
+		/*
+		 * Test10: modify cgroup with this new cgroup
+		 * Exp outcome: zero return value
+		 * Drawback: In case of first attempt failure above for
+		 * create_new_cgroup_ds(), this test will fail
+		 */
+		test_cgroup_modify_cgroup(0, cgroup2, "group1",
+					 1, ctl1, ctl2, STRING, 10);
+
+		/*
+		 * Test11: modify cgroup with the null cgroup
+		 * Exp outcome: zero return value.
+		 */
+
+		test_cgroup_modify_cgroup(ECGROUPNOTALLOWED, nullcgroup,
+					 "group1", 1, ctl1, ctl2, STRING, 11);
+
+		/*
+		 * Create another valid cgroup structure with diff controller
+		 * to modify the existing group
+		 */
+		cval.val_int64 = 262144;
+		cgroup3 = create_new_cgroup_ds(ctl2, "group1",
+						 INT64, cval, ids, 12);
+		if (!cgroup3) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+			exit(1);
+		}
+
+		/*
+		 * Test13: modify existing group with this cgroup
+		 * Exp outcome: zero return value
+		 */
+		test_cgroup_modify_cgroup(0, cgroup3, "group1",
+						 2, ctl1, ctl2, INT64, 13);
+
+		/* Test14: Test cgroup_get_cgroup() api
+		 * The group group1 has been created and modified in the
+		 * filesystem. Read it using the api and check if the values
+		 * are correct as we know all the control values now.
+		 * WARN: If any of the previous api fails and control reaches
+		 * here, this api also will fail. Also the test function assumes
+		 * that "group1" exists in fs. So call cgroup_create_cgroup()
+		 * with "group1" named group before calling this test function.
+		 */
+		test_cgroup_get_cgroup(ctl1, ctl2, ids, 14);
+
+		/*
+		 * Test16: delete cgroup
+		 * Exp outcome: zero return value
+		 */
+		test_cgroup_delete_cgroup(0, cgroup1, "group1", 0, 1, 1, 16);
+
+		/*
+		 * Test16: Check if cgroup_create_cgroup() handles a NULL cgroup
+		 * Exp outcome: error ECGROUPNOTALLOWED
+		 */
+		test_cgroup_create_cgroup(ECGROUPNOTALLOWED, nullcgroup,
+							 "group1", 0, 1, 1, 17);
+
+		/*
+		 * Test16: delete nullcgroup
+		 */
+		test_cgroup_delete_cgroup(ECGROUPNOTALLOWED, NULL,
+							 "group1", 0, 1, 1, 18);
+
+		/* Test17: Test the wrapper to compare cgroup
+		 * Create 2 cgroups and test it
+		 */
+		test_cgroup_compare_cgroup(ctl1, ctl2, 19);
+
+		cgroup_free(&nullcgroup);
+		cgroup_free(&cgroup1);
+		cgroup_free(&cgroup2);
+		cgroup_free(&cgroup3);
+
+		break;
+
+	case FS_MULTI_MOUNTED:
+
+		/* Do a sanity check if cgroup fs is multi mounted */
+		if (check_fsmounted(1)) {
+			printf("Sanity check fails. cgroup fs is not multi "
+				"mounted. Exiting without running this set "
+					"of testcases\n");
+			exit(1);
+		}
+
+		/*
+		 * Test01: call apis and check return values
+		 * Exp outcome:
+		 */
+
+		/*
+		 * Scenario 1: cgroup fs is multi mounted
+		 * Exp outcome: no error. 0 return value
+		 */
+
+		test_cgroup_init(0, 1);
+
+		/*
+		 * Test02: Call cgroup_attach_task() with null group and check
+		 * if return values are correct. If yes check if task exists in
+		 * root group tasks file for each controller
+		 * TODO: This test needs some modification in script
+		 * Exp outcome: current task should be attached to root groups
+		 */
+
+		test_cgroup_attach_task(0, nullcgroup, NULL, NULL,
+							 0, NULLGRP, 2);
+
+		/*
+		 * Test03: Create a valid cgroup structure
+		 * Exp outcome: no error. 0 return value
+		 */
+		ctl1_cgroup1 = create_new_cgroup_ds(ctl1, "ctl1_group1",
+							 STRING, cval, ids, 3);
+		if (!ctl1_cgroup1) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+			exit(1);
+		}
+
+		/*
+		 * Test04: Then Call cgroup_create_cgroup() with this valid grp
+		 * Exp outcome: zero return value
+		 */
+		test_cgroup_create_cgroup(0, ctl1_cgroup1,
+						 "ctl1_group1", 0, 1, 1, 4);
+
+		/*
+		 * Test05: Create a valid cgroup structure
+		 * Exp outcome: no error. 0 return value
+		 */
+		ctl2_cgroup1 = create_new_cgroup_ds(ctl2, "ctl2_group1",
+							 STRING, cval, ids, 5);
+		if (!ctl2_cgroup1) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+			exit(1);
+		}
+
+		/*
+		 * Test06: Then Call cgroup_create_cgroup() with this valid grp
+		 * Exp outcome: zero return value
+		 */
+		test_cgroup_create_cgroup(0, ctl2_cgroup1,
+						 "ctl2_group1", 0, 2, 1, 6);
+
+		/*
+		 * Test07: Call cgroup_create_cgroup() with the same group
+		 * Exp outcome: zero return value as the latest changes in api
+		 */
+		test_cgroup_create_cgroup(0, ctl2_cgroup1,
+						 "ctl2_group1", 0, 2, 1, 7);
+
+		/*
+		 * Test06: Call cgroup_attach_task() with a group with ctl1
+		 * controller and check if return values are correct. If yes
+		 * check if task exists in that group under only ctl1 controller
+		 * hierarchy and in the root group under other controllers
+		 * hierarchy.
+		 */
+
+		test_cgroup_attach_task(0, ctl1_cgroup1, "ctl1_group1",
+						 NULL, 0, NOMESSAGE, 8);
+
+		/*
+		 * Test07: Call cgroup_attach_task() with a group with ctl2
+		 * controller and check if return values are correct. If yes
+		 * check if task exists in the groups under both controller's
+		 * hierarchy.
+		 */
+
+		test_cgroup_attach_task(0, ctl2_cgroup1, "ctl1_group1",
+					 "ctl2_group1", 0, NOMESSAGE, 9);
+
+		/*
+		 * Test: Create a valid cgroup structure
+		 * Exp outcome: no error. 0 return value
+		 */
+		ctl2_cgroup2 = create_new_cgroup_ds(ctl2, "ctl2_group2",
+							 STRING, cval, ids, 10);
+		if (!ctl2_cgroup2) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+			exit(1);
+		}
+
+		/*
+		 * Test08: Try to attach a task to this non existing group.
+		 * Group does not exist in fs so should return ECGROUPNOTEXIST
+		 */
+
+		test_cgroup_attach_task(ECGROUPNOTEXIST, ctl2_cgroup2,
+					 NULL, NULL, 0, NOTCRTDGRP, 11);
+
+		/*
+		 * Create another valid cgroup structure with same group name
+		 * to modify the existing group ctl1_group1
+		 * Exp outcome: no error. 0 return value
+		 */
+		mod_ctl1_cgroup1 = create_new_cgroup_ds(ctl1, "ctl1_group1",
+							 STRING, cval, ids, 12);
+		if (!mod_ctl1_cgroup1) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+			exit(1);
+		}
+
+		/*
+		 * Test09: modify existing cgroup with this new cgroup
+		 * Exp outcome: zero return value and control value modified
+		 */
+		test_cgroup_modify_cgroup(0, mod_ctl1_cgroup1, "ctl1_group1",
+						 1, ctl1, ctl2, STRING, 13);
+
+		/*
+		 * Create another valid cgroup structure with same group name
+		 * to modify the existing group ctl2_group1
+		 * Exp outcome: no error. 0 return value
+		 */
+		mod_ctl2_cgroup1 = create_new_cgroup_ds(ctl2, "ctl2_group1",
+							 STRING, cval, ids, 14);
+		if (!mod_ctl2_cgroup1) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+			exit(1);
+		}
+
+		/*
+		 * Test10: modify existing cgroup with this new cgroup
+		 * Exp outcome: zero return value and control value modified
+		 */
+		test_cgroup_modify_cgroup(0, mod_ctl2_cgroup1, "ctl2_group1",
+						 2, ctl1, ctl2, STRING, 15);
+
+		/*
+		 * Test11: delete cgroups
+		 * Exp outcome: zero return value
+		 */
+		test_cgroup_delete_cgroup(0, ctl1_cgroup1,
+						 "ctl1_group1", 0, 1, 1, 16);
+
+		/*
+		 * Test09: delete other cgroups too
+		 * Exp outcome: zero return value
+		 */
+		test_cgroup_delete_cgroup(0, ctl2_cgroup1,
+						 "ctl2_group1", 0, 1, 1, 17);
+
+		/*
+		 * Test15: Create a valid cgroup structure
+		 * which has multiple controllers
+		 * Exp outcome: no error. 0 return value
+		 */
+		common_cgroup = create_new_cgroup_ds(ctl1, "commongroup",
+							 STRING, cval, ids, 18);
+		if (!common_cgroup) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+			exit(1);
+		}
+
+		/* Add one more controller to the cgroup */
+		/* This also needs to be a function.. will do?? */
+		retval = set_controller(ctl2, controller_name, control_file);
+		if (retval) {
+			fprintf(stderr, "Setting controller failled "
+				" Exiting without running further testcases\n");
+			exit(1);
+		}
+		if (!cgroup_add_controller(common_cgroup, controller_name)) {
+			message(15, FAIL, "add_controller()", retval,
+							 info[NOMESSAGE]);
+			fprintf(stderr, "Adding second controller failled "
+				" Exiting without running further testcases\n");
+			exit(1);
+		}
+
+		/*
+		 * Test11: Then Call cgroup_create_cgroup() with this valid grp
+		 * Exp outcome: zero return value
+		 */
+		test_cgroup_create_cgroup(0, common_cgroup,
+						 "commongroup", 1, 2, 1, 19);
+
+		/*
+		 * Test12: Call cgroup_attach_task() with this common group
+		 * and check if return values are correct. If yes check if
+		 * task exists in the group under both controller's hierarchy
+		 */
+
+		test_cgroup_attach_task(0, common_cgroup, "commongroup",
+					 "commongroup", 0, COMMONGRP, 20);
+
+		/*
+		 * Test18: Create a valid cgroup structure to modify the
+		 * commongroup which is under multiple controllers
+		 * Exp outcome: no error. 0 return value
+		 */
+		mod_common_cgroup = create_new_cgroup_ds(ctl1, "commongroup",
+							 STRING, cval, ids, 21);
+		if (!common_cgroup) {
+			fprintf(stderr, "Failed to create new cgroup ds. "
+					"Tests dependent on this structure "
+					"will fail. So exiting...\n");
+			exit(1);
+		}
+
+		/* Add one more controller to the cgroup */
+		/* This also needs to be a function.. will do?? */
+		retval = set_controller(ctl2, controller_name, control_file);
+		if (retval) {
+			fprintf(stderr, "Setting controller failled "
+				" Exiting without running further testcases\n");
+			exit(1);
+		}
+		sec_controller = cgroup_add_controller(mod_common_cgroup,
+							 controller_name);
+		if (!sec_controller) {
+			message(18, FAIL, "add_controller()", retval,
+							 info[NOMESSAGE]);
+			fprintf(stderr, "Adding second controller failled "
+				" Exiting without running further testcases\n");
+			exit(1);
+		}
+
+		strncpy(cval.val_string, "7000064", sizeof(cval.val_string));
+		retval = cgroup_add_value_string(sec_controller,
+						 control_file, cval.val_string);
+		if (retval)
+			printf("The cgroup_modify_cgroup() test will fail\n");
+
+		/*
+		 * Test14: modify existing cgroup with this new cgroup
+		 * Exp outcome: zero return value and control value modified
+		 */
+		test_cgroup_modify_cgroup(0, mod_common_cgroup, "commongroup",
+						 0, ctl1, ctl2, STRING, 22);
+
+		/*
+		 * Test15: delete this common cgroup
+		 * Exp outcome: zero return value
+		 */
+		test_cgroup_delete_cgroup(0, common_cgroup,
+						 "commongroup", 1, 2, 1, 23);
+		test_cgroup_get_cgroup(ctl1, ctl2, ids, 24);
+
+		/* Free the cgroup structures */
+		cgroup_free(&nullcgroup);
+		cgroup_free(&ctl1_cgroup1);
+		cgroup_free(&ctl2_cgroup1);
+		cgroup_free(&ctl2_cgroup2);
+
+		break;
+
+	default:
+		fprintf(stderr, "ERROR: Wrong parameters recieved from script. \
+						Exiting tests\n");
+		exit(1);
+		break;
+	}
+	return 0;
+}
+
+void test_cgroup_modify_cgroup(int retcode, struct cgroup *cgrp,
+			 const char *name, int which_ctl, int ctl1,
+					 int ctl2, int value_type, int i)
+{
+	int retval;
+	struct cntl_val_t cval = {0, 0, 0, "1000"};
+	char path1_control_file[FILENAME_MAX], path2_control_file[FILENAME_MAX];
+	char controller_name[FILENAME_MAX], control_file[FILENAME_MAX];
+
+	/* Check, In case some error is expected due to a negative scenario */
+	if (retcode) {
+		retval = cgroup_modify_cgroup(cgrp);
+		if (retval == retcode)
+			message(i, PASS, "modify_cgroup()", retval,
+							 info[NOMESSAGE]);
+		else
+			message(i, FAIL, "modify_cgroup()", retval,
+							 info[NOMESSAGE]);
+
+		return;
+	}
+
+	/* Now there is no error and it is a genuine call */
+	retval = cgroup_modify_cgroup(cgrp);
+	if (retval) {
+		message(i, FAIL, "modify_cgroup()", retval,  info[NOMESSAGE]);
+		return;
+	}
+
+	/* Let us now check if the group modified in file system */
+	switch (which_ctl) { /* group modified under which controllers */
+
+	case 1: /* group is modified under ctl1 which is always
+		 * mounted at mountpoint in both cases */
+		set_controller(ctl1, controller_name, control_file);
+		build_path(path1_control_file, mountpoint, name, control_file);
+		/* this approach will be changed in coming patches */
+		strncpy(cval.val_string, "260000", sizeof(cval.val_string));
+
+		if (!group_modified(path1_control_file, value_type, cval))
+			message(i, PASS, "modify_cgroup()", retval,
+							 info[NOMESSAGE]);
+		else
+			message(i, FAIL, "modify_cgroup()", retval,
+							 info[NOMESSAGE]);
+
+		break;
+	case 2: /* group is modified under ctl2 which may be
+		 * mounted at mountpoint or mountpoint2 */
+		set_controller(ctl2, controller_name, control_file);
+
+		if (fs_mounted == FS_MOUNTED)	/* group under mountpoint */
+			build_path(path2_control_file, mountpoint,
+						 name, control_file);
+		else	/* group under mountpoint2 */
+			build_path(path2_control_file, mountpoint2,
+						 name, control_file);
+
+		/* this approach will be changed in coming patches */
+		strncpy(cval.val_string, "7000064", sizeof(cval.val_string));
+		cval.val_int64 = 262144;
+		if (!group_modified(path2_control_file, value_type, cval))
+			message(i, PASS, "modify_cgroup()", retval,
+							 info[NOMESSAGE]);
+		else
+			message(i, FAIL, "modify_cgroup()", retval,
+							 info[NOMESSAGE]);
+
+		break;
+	case 0:
+		/* ctl1 is always mounted at mountpoint */
+		set_controller(ctl1, controller_name, control_file);
+		build_path(path1_control_file, mountpoint,
+						 name, control_file);
+		/* ctl2 may be mounted at mountpoint or mountpoint2 depending
+		 * on single or multiple mount case */
+		if (fs_mounted == FS_MOUNTED) {	/* group under mountpoint */
+			set_controller(ctl2, controller_name, control_file);
+			build_path(path2_control_file, mountpoint,
+						 name, control_file);
+		} else {	/* group under mountpoint2 */
+			set_controller(ctl2, controller_name, control_file);
+			build_path(path2_control_file, mountpoint2,
+						 name, control_file);
+		}
+		/* this approach will be changed in coming patches */
+		strncpy(cval.val_string, "260000", sizeof(cval.val_string));
+		if (!group_modified(path1_control_file, value_type, cval)) {
+			strncpy(cval.val_string, "7000064",
+						 sizeof(cval.val_string));
+			if (!group_modified(path2_control_file,
+							 value_type, cval))
+				message(i, PASS, "modify_cgroup()",
+					 retval, info[GRPMODINBOTHCTLS]);
+			else
+				message(i, FAIL, "modify_cgroup()",
+					 retval, info[GRPNOTMODIN2NDCTL]);
+		} else {
+			message(i, FAIL, "modify_cgroup()", retval,
+						 info[GRPNOTMODINANYCTL]);
+		}
+
+		break;
+	default:
+		printf("Wrong controller parameter received....\n");
+		message(i, FAIL, "modify_cgroup()", retval, info[NOMESSAGE]);
+		break;
+	}
+
+	return;
+}

--- a/tests/logger.c
+++ b/tests/logger.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright Red Hat Inc., 2012
+ *
+ * Author:	Jan Safranek <jsafrane@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description: This file contains the test code for libcgroup logging.
+ */
+
+#include "config.h"
+#include "libcgroup.h"
+#include "../src/libcgroup-internal.h"
+#include <string.h>
+#include <stdlib.h>
+
+static void mylogger(void *userdata, int loglevel, const char *fmt, va_list ap)
+{
+	printf("custom: ");
+	vprintf(fmt, ap);
+}
+
+int main(int argc, char **argv)
+{
+	int custom = 0;
+	int loglevel = -1;
+	int i;
+
+	for (i = 1; i < argc; i++) {
+		if (strcmp("custom", argv[i]) == 0)
+			custom = 1;
+		else
+			loglevel = atoi(argv[i]);
+	}
+
+	if (custom)
+		cgroup_set_logger(mylogger, loglevel, NULL);
+	else
+		cgroup_set_default_logger(loglevel);
+
+	cgroup_dbg("DEBUG message\n");
+	cgroup_info("INFO message\n");
+	cgroup_warn("WARNING message\n");
+	cgroup_err("ERROR message\n");
+
+	return 0;
+}

--- a/tests/logger.sh
+++ b/tests/logger.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Test various log levels
+
+export LOGFILE=
+export RET=0
+unset CGROUP_LOGLEVEL
+
+function run_logger()
+{
+	LOGFILE=`mktemp`
+	echo "Running CGROUP_LOGLEVEL=$CGROUP_LOGLEVEL logger $* >$LOGFILE"
+	./logger $* >$LOGFILE
+}
+
+function assert_grep()
+{
+	if ! grep "$@" <$LOGFILE >/dev/null; then
+		echo "Error: expecting $* in output"
+		RET=1
+	fi
+}
+
+function assert_not_grep()
+{
+	if grep "$@" <$LOGFILE >/dev/null; then
+		echo "Error: unexptected $* in output"
+		RET=1
+	fi
+}
+
+# CGROUP_LOGLEVEL is case-insensitive
+CGROUP_LOGLEVEL=DeBuG run_logger -1
+assert_grep "^DEBUG message"
+assert_grep "^INFO message"
+assert_grep "^WARNING message"
+assert_grep "^ERROR message"
+rm $LOGFILE
+
+# missing CGROUP_LOGLEVEL leads to ERRORs only
+run_logger -1
+assert_not_grep "^DEBUG message"
+assert_not_grep "^INFO message"
+assert_not_grep "^WARNING message"
+assert_grep "^ERROR message"
+rm $LOGFILE
+
+# wrong CGROUP_LOGLEVEL leads to ERRORs only
+CGROUP_LOGLEVEL=xyz run_logger -1
+assert_not_grep "^DEBUG message"
+assert_not_grep "^INFO message"
+assert_not_grep "^WARNING message"
+assert_grep "^ERROR message"
+rm $LOGFILE
+
+# numeric CGROUP_LOGLEVEL
+CGROUP_LOGLEVEL=3 run_logger -1
+assert_not_grep "^DEBUG message"
+assert_grep "^INFO message"
+assert_grep "^WARNING message"
+assert_grep "^ERROR message"
+rm $LOGFILE
+
+# errors only CGROUP_LOGLEVEL
+CGROUP_LOGLEVEL=ERROR run_logger -1
+assert_not_grep "^DEBUG message"
+assert_not_grep "^INFO message"
+assert_not_grep "^WARNING message"
+assert_grep "^ERROR message"
+rm $LOGFILE
+
+# no CGROUP_LOGLEVEL -> DEBUG
+run_logger 4
+assert_grep "^DEBUG message"
+assert_grep "^INFO message"
+assert_grep "^WARNING message"
+assert_grep "^ERROR message"
+rm $LOGFILE
+
+# no CGROUP_LOGLEVEL -> INFO
+run_logger 3
+assert_not_grep "^DEBUG message"
+assert_grep "^INFO message"
+assert_grep "^WARNING message"
+assert_grep "^ERROR message"
+rm $LOGFILE
+
+# no CGROUP_LOGLEVEL -> WARN
+run_logger 2
+assert_not_grep "^DEBUG message"
+assert_not_grep "^INFO message"
+assert_grep "^WARNING message"
+assert_grep "^ERROR message"
+rm $LOGFILE
+
+# no CGROUP_LOGLEVEL -> ERROR
+run_logger 1
+assert_not_grep "^DEBUG message"
+assert_not_grep "^INFO message"
+assert_not_grep "^WARNING message"
+assert_grep "^ERROR message"
+rm $LOGFILE
+
+# no CGROUP_LOGLEVEL -> nothing
+run_logger 0
+assert_not_grep "^DEBUG message"
+assert_not_grep "^INFO message"
+assert_not_grep "^WARNING message"
+assert_not_grep "^ERROR message"
+rm $LOGFILE
+
+
+# custom logger -> DEBUG
+run_logger custom 4
+assert_grep "^custom: DEBUG message"
+assert_grep "^custom: INFO message"
+assert_grep "^custom: WARNING message"
+assert_grep "^custom: ERROR message"
+rm $LOGFILE
+
+# custom logger -> INFO
+run_logger custom 3
+assert_not_grep "^custom: DEBUG message"
+assert_grep "^custom: INFO message"
+assert_grep "^custom: WARNING message"
+assert_grep "^custom: ERROR message"
+rm $LOGFILE
+
+# custom logger -> WARN
+run_logger custom 2
+assert_not_grep "^custom: DEBUG message"
+assert_not_grep "^custom: INFO message"
+assert_grep "^custom: WARNING message"
+assert_grep "^custom: ERROR message"
+rm $LOGFILE
+
+exit $RET
+

--- a/tests/proctest.c
+++ b/tests/proctest.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright NEC Soft Ltd. 2009
+ *
+ * Author:	Ken'ichi Ohmichi <oomichi@mxs.nes.nec.co.jp>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "../src/libcgroup-internal.h"
+
+int main(int argc, char *argv[])
+{
+	int i;
+	int ret;
+	pid_t pid;
+	uid_t uid;
+	gid_t gid;
+	char *procname;
+
+	if (argc < 2) {
+		printf("Specify process-id.\n");
+		return 1;
+	}
+	printf("  Pid  |        Process name              |  Uid  |  Gid  \n");
+	printf("-------+----------------------------------+-------+-------\n");
+
+	for (i = 1; i < argc; i++) {
+		pid = atoi(argv[i]);
+
+		ret = cgroup_get_uid_gid_from_procfs(pid, &uid, &gid);
+		if (ret) {
+			printf("%6d | ret = %d\n", pid, ret);
+			continue;
+		}
+		ret = cgroup_get_procname_from_procfs(pid, &procname);
+		if (ret) {
+			printf("%6d | ret = %d\n", pid, ret);
+			continue;
+		}
+		printf("%6d | %32s | %5d | %5d\n", pid, procname, uid, gid);
+		free(procname);
+	}
+	return 0;
+}

--- a/tests/read_stats.c
+++ b/tests/read_stats.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+#include <libcgroup.h>
+
+int read_stats(char *path, char *controller)
+{
+	int ret;
+	void *handle;
+	struct cgroup_stat stat;
+
+	ret = cgroup_read_stats_begin(controller, path,  &handle, &stat);
+
+	if (ret != 0) {
+		fprintf(stderr, "stats read failed\n");
+		return -1;
+	}
+
+	printf("Stats for %s:\n", path);
+	printf("%s: %s", stat.name, stat.value);
+
+	while ((ret = cgroup_read_stats_next(&handle, &stat)) !=
+			ECGEOF) {
+		printf("%s: %s", stat.name, stat.value);
+	}
+
+	cgroup_read_stats_end(&handle);
+	printf("\n");
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	char *controller;
+	void *handle;
+	struct cgroup_file_info info;
+	int lvl;
+	char cgroup_path[FILENAME_MAX];
+	int root_len;
+
+	if (argc < 2) {
+		fprintf(stderr, "Usage %s: <controller name>\n",
+			argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	controller = argv[1];
+
+	ret = cgroup_init();
+	if (ret != 0) {
+		fprintf(stderr, "init failed\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ret = cgroup_walk_tree_begin(controller, "/", 0, &handle, &info, &lvl);
+
+	if (ret != 0) {
+		fprintf(stderr, "Walk failed\n");
+		exit(EXIT_FAILURE);
+	}
+
+	root_len = strlen(info.full_path) - 1;
+	strncpy(cgroup_path, info.path, FILENAME_MAX - 1);
+	ret = read_stats(cgroup_path, controller);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+
+	while ((ret = cgroup_walk_tree_next(0, &handle, &info, lvl)) !=
+			ECGEOF) {
+		if (info.type != CGROUP_FILE_TYPE_DIR)
+			continue;
+		strncpy(cgroup_path, info.full_path + root_len, FILENAME_MAX - 1);
+		strcat(cgroup_path, "/");
+		ret = read_stats(cgroup_path, controller);
+		if (ret < 0)
+			exit(EXIT_FAILURE);
+	}
+	cgroup_walk_tree_end(&handle);
+
+	return EXIT_SUCCESS;
+}

--- a/tests/runlibcgrouptest.sh.in
+++ b/tests/runlibcgrouptest.sh.in
@@ -1,0 +1,444 @@
+#!/bin/bash
+# usage ./runlibcgrouptest.sh
+# Copyright IBM Corporation. 2008
+#
+# Author:	Sudhir Kumar <skumar@linux.vnet.ibm.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it would be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# Description: This script runs the the basic tests for testing libcgroup apis.
+#
+
+# TODO path to config.h have to be set properly
+OPAQUE_HIERARCHY=`grep "OPAQUE_HIERARCHY" @abs_top_srcdir@/config.h |\
+	 cut -d" " -f3 | sed  's|\"||g'`
+DEBUG=false;		# for debug messages
+FS_MOUNTED=0;		# 0 for not mounted, 1 for mounted, 2 for multimounted
+MOUNTPOINT=/dev/cgroup_controllers;	# Just to initialize
+TARGET=/dev/cgroup_controllers;
+CONTROLLERS=cpu,memory;
+NUM_MOUNT=1;		# Number of places to be mounted on
+MULTIMOUNT=false;	# mounted at one point only
+NUM_CTLRS=0;		# num of controllers supported
+CTLR1="";
+CTLR2="";
+CPU="";
+MEMORY="";
+SKIP_TEST=77
+RET=0
+
+declare -a allcontrollers;
+declare -a targets;
+
+debug()
+{
+	# Function parameter is the string to print out
+	if $DEBUG
+	then
+		echo SH:DBG: $1;
+	fi
+}
+
+check_mount_fs ()
+{
+	local NUM_MOUNT=0;
+	CGROUP=`cat /proc/mounts|grep -w ^cgroup|tr -s [:space:]|cut -d" " -f3`;
+
+	# get first word in case of multiple mounts
+	CGROUP=`echo $CGROUP|cut -d" " -f1`;
+
+	debug "check_mount_fs(): CGROUP is $CGROUP";
+	if [ "$CGROUP" = "cgroup" ]
+	then
+		NUM_MOUNT=`cat /proc/mounts|grep -w ^cgroup|wc -l`;
+		debug "check_mount_fs(): fs mounted at $NUM_MOUNT places";
+
+		if [ $NUM_MOUNT -eq 1 ]
+		then
+			FS_MOUNTED=1;
+		else
+			# Any number of mounts is multi mount
+			FS_MOUNTED=2;
+		fi;
+		return 0;	# True
+	else
+		FS_MOUNTED=0;
+		return 1;	# false
+	fi
+}
+
+umount_fs ()
+{
+	PROC_ENTRY_NUMBER=`cat /proc/mounts|grep ^cgroup | wc -l`;
+	NUMBER=1;
+	#go and remove all ot opaque mount points
+	while [ $PROC_ENTRY_NUMBER -ge $NUMBER ]
+	do
+		# Get $NUMBER-th mountpoint in case of multiple mount
+		PROC_ENTRY=`cat /proc/mounts|grep ^cgroup|\
+				tr -s [:space:]|cut -d" " -f2 |\
+				head -n$NUMBER | tail -n1`;
+		# if the hierarchy is opaque skip to next item
+		if [ -n "$OPAQUE_HIERARCHY" ]
+		then
+			# find whether is the NUMBER-th item opaque
+			PROC_ENTRY_OPT=`cat /proc/mounts|grep ^cgroup|\
+				tr -s [:space:]|cut -d" " -f4 |\
+				head -n$NUMBER | tail -n1`;
+			echo $PROC_ENTRY_OPT | grep $OPAQUE_HIERARCHY
+			# if yes skip it to the next item
+			if [ $? -eq 0 ]
+			then
+				let NUMBER=$NUMBER+1
+				continue
+			fi;
+		fi;
+		# remove the item
+		if [ ! -z "$PROC_ENTRY" ]
+		then
+			TARGET=$PROC_ENTRY;
+			# Need to take care of running tasks in any group ??
+			rmdir $TARGET/* 2> /dev/null ;
+			umount $TARGET;
+			rmdir  $TARGET;
+			debug "umounted $TARGET";
+		fi;
+		# go to the next item
+		let NUMBER=$NUMBER+1
+	done;
+	FS_MOUNTED=0;
+	TARGET=/dev/cgroup_controllers;	#??
+	echo "Cleanup done";
+}
+
+# Put all the supported controllers in an array
+# We have the priority for cpu and memory controller. So prefer to mount
+# them if they exist
+get_all_controllers()
+{
+	while [ 1 ]; do
+		read line || break;
+		if ! echo $line | grep -q ^#
+		then
+			allcontrollers[$NUM_CTLRS]=`echo $line | cut -d" " -f1`;
+			if [ ${allcontrollers[$NUM_CTLRS]} == "cpu" ]; then
+				CPU="cpu";
+			elif [ ${allcontrollers[$NUM_CTLRS]} == "memory" ]; then
+				MEMORY="memory";
+			fi;
+			debug "controller: ${allcontrollers[$NUM_CTLRS]}";
+			NUM_CTLRS=`expr $NUM_CTLRS + 1`;
+		fi
+	done < /proc/cgroups;
+	debug "Total controllers $NUM_CTLRS";
+}
+
+# Get a second controller other than cpu or memory
+get_second_controller()
+{
+	local i=0;
+	while [ $i -lt $NUM_CTLRS ]
+	do
+		if [ "${allcontrollers[$i]}" != "cpu" ] &&
+				 [ "${allcontrollers[$i]}" != "memory" ]
+		then
+			CTLR2=${allcontrollers[$i]};
+			return 0;
+		fi;
+	i=`expr $i + 1`;
+	done;
+}
+
+# Check if kernel is not having any of the controllers enabled
+no_controllers()
+{
+	# prefer if cpu and memory controller are enabled
+	if [ ! -z $CPU ] && [ ! -z $MEMORY ]
+	then
+		CONTROLLERS=$CPU,$MEMORY ;
+		CTLR1=$CPU;
+		CTLR2=$MEMORY;
+		debug "first controller is $CTLR1";
+		debug "second controller is $CTLR2";
+		return 1;	# false
+	elif [ ! -z $CPU ]
+	then
+		CONTROLLERS=$CPU ;
+		CTLR1=$CPU;
+		get_second_controller;
+		debug "first controller is $CTLR1";
+		debug "second controller is $CTLR2";
+		return 1;	# false
+	elif [ ! -z $MEMORY ]
+	then
+		CONTROLLERS=$MEMORY ;
+		CTLR1=$MEMORY;
+		get_second_controller;
+		debug "first controller is $CTLR1";
+		debug "second controller is $CTLR2";
+		return 1;	# false
+	fi;
+	# Kernel has neither cpu nor memory controller enabled. So there is
+	# no point in running the testcases. At least one of them should be
+	# supported.(or should I run testcases with controllers such as
+	#  ns, devices etc? Thoughts???)
+	if [ $NUM_CTLRS -lt 2 ]
+	then
+		echo "Kernel needs to have 2 controllers enabled";
+		echo "Recompile your kernel with at least 2 controllers"
+		echo "Exiting the tests.....";
+		exit $SKIP_TEST;
+	fi;
+
+	return 0;	# true
+}
+
+
+mount_fs ()
+{
+	local NUM_MOUNT=0;	# On how many places to mount on
+	local CUR_MOUNT=1;
+	FS_MOUNTED=0;
+
+	# Check if kernel has controllers enabled
+	if no_controllers
+	then
+		echo "Kernel has none of cpu/memory controllers enabled";
+		echo "Recompile your kernel with at least one of these enabled"
+		echo "Exiting the tests.....";
+		exit $SKIP_TEST;
+	fi;
+
+	# At least one Controller is enabled. So proceed further.
+	if [ -z $1 ]
+	then
+		echo "WARN: No parameter passed to function mount_fs";
+		echo "taking default as 0....So not mounting cgroup fs";
+	else
+		NUM_MOUNT=$1;
+		debug "mount_fs fs will be mounted on $NUM_MOUNT places";
+	fi;
+
+	# create so many directories i.e. mountpoints
+	while [ $NUM_MOUNT -ge $CUR_MOUNT ]
+	do
+		NEWTARGET="$TARGET-$CUR_MOUNT";
+		if [ -e $NEWTARGET ]
+		then
+			echo "WARN: $NEWTARGET already exist..overwriting";
+			check_mount_fs;	# Possibly fs might be mounted on it
+			if [ $FS_MOUNTED -gt 0 ]
+			then
+				umount_fs;
+			else
+				rmdir $NEWTARGET ;
+			fi;
+		fi;
+		mkdir $NEWTARGET;
+
+		# In case of multimount, mount controllers at diff points
+		if $MULTIMOUNT ; then
+			if [ $CTLR1 ] && [ $CTLR2 ] ; then
+				if [ $CUR_MOUNT -eq 1 ] ; then
+					CONTROLLERS=$CTLR1;
+				else
+					CONTROLLERS=$CTLR2;
+				fi;
+			else
+				echo "Only 1 controler enabled in kernel";
+				echo "So not running multiple mount testcases";
+				exit $SKIP_TEST;
+			fi;
+		fi;
+
+		mount -t cgroup -o $CONTROLLERS cgroup $NEWTARGET;
+		if [ $? -ne 0 ]
+		then
+			echo "ERROR: in mounting cgroup fs on $NEWTARGET."
+			echo "Exiting test";
+			umount_fs;
+			exit -1;
+		fi;
+		target[$CUR_MOUNT]=$NEWTARGET;
+		CUR_MOUNT=`expr $CUR_MOUNT + 1`;
+		FS_MOUNTED=`expr $FS_MOUNTED + 1`;
+
+		# Group created earlier may again be visible if not cleaned.
+		# So clean them all
+		if [ -e $NEWTARGET/group1 ] # first group that is created
+		then
+			# Need to handle if tasks are running in them
+			rmdir $NEWTARGET/group*
+			echo "WARN: Earlier groups found and removed...";
+		fi;
+
+		debug "$CONTROLLERS controllers mounted on $NEWTARGET  directory"
+	done;
+
+	if [ $FS_MOUNTED -gt 2 ]
+	then
+		FS_MOUNTED=2;
+	fi;
+
+}
+
+get_ctl_num()
+{
+	ctl1=$1;
+	ctl2=$2;
+	if [ -z $ctl1 ] || [ -z $ctl2 ]; then
+		echo "Null controller passed to function get_ctl_num"
+		echo "Exiting the testcases....."
+	fi
+
+	# Add any new controller developed here
+	declare -a ctl_list;
+	# Following list has to be in sync with enums in header
+	ctl_list[0]="cpu";
+	ctl_list[1]="memory";
+	ctl_list[2]="cpuset";
+
+	local i=0;
+	while [ ! -z ${ctl_list[$i]} ]; do
+		if [ "${ctl_list[$i]}" == "$ctl1" ]; then
+			ctl1=$i;
+		fi;
+
+		if [ "${ctl_list[$i]}" == "$ctl2" ]; then
+			ctl2=$i;
+		fi;
+	i=`expr $i + 1`;
+	done;
+}
+
+runtest()
+{
+	MOUNT_INFO=$1;
+	TEST_EXEC=$2;
+	if [ -f $TEST_EXEC ]
+	then
+		./$TEST_EXEC $MOUNT_INFO $ctl1 $ctl2 ${target[1]} ${target[2]};
+		if [ $? -ne 0 ]
+		then
+			echo Error in running ./$TEST_EXEC
+			echo Exiting tests.
+		else
+			PID=$!;
+		fi;
+	else
+		echo Sources not compiled. please run make;
+	fi
+}
+
+###############################
+# Main starts here
+	# Check if kernel has controllers support
+	if [ -e /proc/cgroups ]
+	then
+		get_all_controllers;
+	else
+		echo "Your Kernel seems to be too old. Plz recompile your"
+		echo "Kernel with cgroups and appropriate controllers enabled"
+		echo " Exiting the testcases...."
+		exit $SKIP_TEST;
+	fi;
+
+	MY_ID=`id -u`
+	if [ $MY_ID -ne 0 ]; then
+		echo "Only root can start this script."
+		echo " Exiting the testcase..."
+		exit $SKIP_TEST
+	fi
+
+# TestSet01: Run tests without mounting cgroup filesystem
+	echo;
+	echo Running first set of testcases;
+	echo ==============================
+	FS_MOUNTED=0;
+	FILE=libcgrouptest01;
+	check_mount_fs;
+	# unmount fs if already mounted
+	if [ $FS_MOUNTED -ne 0 ]
+	then
+		umount_fs;
+	fi;
+	debug "FS_MOUNTED = $FS_MOUNTED"
+	runtest $FS_MOUNTED $FILE
+
+	wait $PID;
+	RC=$?;
+	if [ $RC -ne 0 ]
+	then
+		echo Test binary $FILE exited abnormaly with return value $RC;
+		# Do not exit here. Failure in this case does not imply
+		# failure in other cases also
+		RET=$RC
+	fi;
+
+# TestSet02: Run tests with mounting cgroup filesystem
+	echo;
+	echo Running second set of testcases;
+	echo ==============================
+	FILE=libcgrouptest01;
+	check_mount_fs;
+	# mount fs at one point if not already mounted or multimounted
+	NUM_MOUNT=1;
+	if [ $FS_MOUNTED -eq 0 ]
+	then
+		mount_fs $NUM_MOUNT;
+	elif [ $FS_MOUNTED -gt 1 ]
+	then
+		umount_fs;
+		mount_fs $NUM_MOUNT;
+	fi;
+	debug "FS_MOUNTED = $FS_MOUNTED"
+	get_ctl_num $CTLR1 $CTLR2;
+	runtest $FS_MOUNTED $FILE
+
+	wait $PID;
+	RC=$?;
+	if [ $RC -ne 0 ]
+	then
+		echo Test binary $FILE exited abnormaly with return value $RC;
+		RET=$RC
+	fi;
+	umount_fs;
+
+
+# TestSet03: Run tests with mounting cgroup filesystem at multiple points
+	echo;
+	echo Running third set of testcases;
+	echo ==============================
+	FILE=libcgrouptest01;
+	check_mount_fs;
+	# mount fs at multiple points
+	MULTIMOUNT=true;
+	NUM_MOUNT=2;
+	if [ $FS_MOUNTED -eq 0 ]
+	then
+		mount_fs $NUM_MOUNT;
+	elif [ $FS_MOUNTED -eq 1 ]
+	then
+		umount_fs;
+		mount_fs $NUM_MOUNT;
+	fi;
+	debug "FS_MOUNTED = $FS_MOUNTED"
+	get_ctl_num $CTLR1 $CTLR2;
+	runtest $FS_MOUNTED $FILE
+
+	wait $PID;
+	RC=$?;
+	if [ $RC -ne 0 ]
+	then
+		echo Test binary $FILE exited abnormaly with return value $RC;
+		RET=$RC
+	fi;
+	umount_fs;
+
+	exit $RET;

--- a/tests/setuid.c
+++ b/tests/setuid.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright Red Hat Inc. 2008
+ *
+ * Author:      Steve Olivieri <sjo@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <grp.h>
+#include <errno.h>
+#include <string.h>
+
+/* 
+ * This is just a simple program for changing a UID or a GID.  Comment out
+ * whichever block you don't want to use.
+ */
+int main(int argc, char *argv[])
+{
+	/* User data */
+	struct passwd *pwd;
+
+	/* UID of user */
+	uid_t uid;
+
+	/* Return codes */
+	int ret = 0;
+
+	if (argc < 2) {
+		printf("Usage: %s <uid_value> \n", argv[0]);
+		goto finished;
+	}
+
+	pwd = getpwnam(argv[1]);
+	if (!pwd) {
+		fprintf(stderr, "getpwnam() failed: %s\n",
+				strerror(errno));
+		ret = -errno;
+		goto finished;
+	}
+	uid = pwd->pw_uid;
+	fprintf(stdout, "Setting UID to %s (%d).\n", pwd->pw_name, uid);
+	if ((ret = setuid(uid))) {
+		fprintf(stderr, "Call to setuid() failed with error: %s\n",
+				strerror(errno));
+		ret = -errno;
+		goto finished;
+	}
+
+//	while(1) {
+//		grp = getgrnam("root");
+//		gid = grp->gr_gid;
+//		fprintf(stdout, "Setting GID to %s (%d).\n",
+//				grp->gr_name, gid);
+//		if ((ret = setgid(gid))) {
+//			fprintf(stderr, "Call to setgid() failed with error:"
+//					" %s\n", strerror(errno));
+//			ret = -errno;
+//			goto finished;
+//		}
+//	}
+
+	while (1) {
+		usleep(3000000);
+	}
+
+finished:
+	return ret;
+}

--- a/tests/test_functions.c
+++ b/tests/test_functions.c
@@ -1,0 +1,927 @@
+/*
+ * Copyright IBM Corporation. 2008
+ *
+ * Author:	Sudhir Kumar <skumar@linux.vnet.ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description: This file contains the functions for testing libcgroup apis.
+ */
+
+#include "libcgrouptest.h"
+
+/* The messages that may be useful to the user */
+char info[][SIZE] = {
+	" Parameter nullcgroup\n", 			/* NULLGRP */
+	" Parameter commoncgroup\n",			/* COMMONGRP */
+	" Parameter not created group\n",		/* NOTCRTDGRP */
+	" Parameter same cgroup\n",			/* SAMEGRP */
+	" Task found in group/s\n",			/* TASKINGRP */
+	" Task not found in group/s\n",			/* TASKNOTINGRP */
+	" Task not found in all groups\n",		/* TASKNOTINANYGRP */
+	" group found in filesystem\n",			/* GRPINFS */
+	" group not found in filesystem\n",		/* GRPNOTINFS */
+	" group found under both controllers\n",	/* GRPINBOTHCTLS */
+	" group not found under second controller\n",	/* GRPNOTIN2NDCTL */
+	" group not found under first controller\n",	/* GRPNOTIN1STCTL */
+	" group modified under both controllers\n",	/* GRPMODINBOTHCTLS */
+	" group not modified under second controller\n",/* GRPNOTMODIN2NDCTL */
+	" group not modified under any controller\n",	/* GRPNOTMODINANYCTL */
+	" Group deleted from filesystem\n",		/* GRPDELETEDINFS */
+	" Group not deleted from filesystem\n",		/* GRPNOTDELETEDINFS */
+	" Group not deleted globally\n",		/* GRPNOTDELETEDGLOBALY */
+	/* In case there is no extra info messages to be printed */
+	"\n",						/* NOMESSAGE */
+};
+
+/**
+ * Tests the cgroup_init_cgroup() api under different scenarios
+ * @param retcode error code in case any error is expected from api
+ * @param i the test number
+ */
+void test_cgroup_init(int retcode, int i)
+{
+	int retval;
+
+	retval = cgroup_init();
+	if (retval == retcode)
+		message(i, PASS, "init()\t", retval, info[NOMESSAGE]);
+	else
+		message(i, FAIL, "init()",  retval, info[NOMESSAGE]);
+}
+
+/**
+ * Tests the cgroup_attach_cgroup() api under different scenarios
+ * @param retcode error code in case any error is expected from api
+ * @param cgrp the group to assign the task to
+ * @param group1 the name of the group under first (single) mountpoint
+ * @param group2 the name of the group under 2nd moutpoint for multimount
+ * @param i the test number
+ * @param k the message enum number to print the useful message
+ */
+void test_cgroup_attach_task(int retcode, struct cgroup *cgrp,
+	 const char *group1, const char *group2, pid_t pid, int k, int i)
+{
+	int retval;
+	char tasksfile[FILENAME_MAX], tasksfile2[FILENAME_MAX];
+	/* Check, In case some error is expected due to a negative scenario */
+	if (retcode) {
+		if (pid)
+			retval = cgroup_attach_task_pid(cgrp, pid);
+		else
+			retval = cgroup_attach_task(cgrp);
+
+		if (retval == retcode)
+			message(i, PASS, "attach_task()", retval, info[k]);
+		else
+			message(i, FAIL, "attach_task()", retval, info[k]);
+
+		return;
+	}
+
+	/* Now there is no error and it is a genuine call */
+	if (pid)
+		retval = cgroup_attach_task_pid(cgrp, pid);
+	else
+		retval = cgroup_attach_task(cgrp);
+
+	/* API returned success, so perform check */
+	if (retval == 0) {
+		build_path(tasksfile, mountpoint,
+					 group1, "tasks");
+
+		if (check_task(tasksfile, 0)) {
+			if (fs_mounted == 2) {
+				/* multiple mounts */
+				build_path(tasksfile2, mountpoint2,
+							 group2, "tasks");
+				if (check_task(tasksfile2, 0)) {
+					message(i, PASS, "attach_task()",
+						 retval, info[TASKINGRP]);
+				} else {
+					message(i, FAIL, "attach_task()",
+						 retval, info[TASKNOTINANYGRP]);
+				}
+			} else {
+				/* single mount */
+				message(i, PASS, "attach_task()",
+						 retval, info[TASKINGRP]);
+			}
+		} else {
+			message(i, FAIL, "attach_task()", retval,
+							 info[TASKNOTINGRP]);
+		}
+	} else {
+		message(i, FAIL, "attach_task()", retval, (char *)"\n");
+	}
+}
+
+/**
+ * This function creates a cgroup data structure
+ * This function is a bit ugly for now and need to be changed
+ * @param ctl the controller under which group is to be created
+ * @param grpname the name of the group
+ * @param value_type which value out of four types
+ * @param struct cval the control value structure
+ * @param struct ids the permissions struct
+ * @param the test number
+ */
+struct cgroup *create_new_cgroup_ds(int ctl, const char *grpname,
+	 int value_type, struct cntl_val_t cval, struct uid_gid_t ids, int i)
+{
+	int retval;
+	char group[FILENAME_MAX];
+	char controller_name[FILENAME_MAX], control_file[FILENAME_MAX];
+
+	strncpy(group, grpname, sizeof(group) - 1);
+	retval = set_controller(ctl, controller_name, control_file);
+	if (retval) {
+		fprintf(stderr, "Setting controller failled\n");
+		return NULL;
+	}
+
+	switch (ctl) {
+		/* control values are controller specific, so will be set
+		 * accordingly from the config file */
+	case CPU:
+		strncpy(cval.val_string, "260000", sizeof(cval.val_string));
+		break;
+
+	case MEMORY:
+		strncpy(cval.val_string, "7000064", sizeof(cval.val_string));
+		break;
+
+	/* To be added for other controllers */
+	default:
+		printf("Invalid controller name passed. Setting control value"
+					" failed. Dependent tests may fail\n");
+		return NULL;
+		break;
+	}
+
+	return new_cgroup(group, controller_name, control_file,
+						 value_type, cval, ids, i);
+}
+
+/**
+ * Tests the cgroup_create_cgroup() api under different scenarios
+ * @param retcode error code in case any error is expected from api
+ * @param cgrp the group to be created
+ * @param name the name of the group
+ * @param common to test if group will be created under one or both mountpoints
+ * @param mpnt to test if group under mountpoint or mountpoint2
+ * @param ign parameter for api if to ignore the ownership
+ * @param the test number
+ */
+void test_cgroup_create_cgroup(int retcode, struct cgroup *cgrp,
+			 const char *name, int common, int mpnt, int ign, int i)
+{
+	int retval;
+	char path1_group[FILENAME_MAX], path2_group[FILENAME_MAX];
+	/* Check, In case some error is expected due to a negative scenario */
+	if (retcode) {
+		retval = cgroup_create_cgroup(cgrp, ign);
+		if (retval == retcode)
+			message(i, PASS, "create_cgroup()", retval,
+							 info[NOMESSAGE]);
+		else
+			message(i, FAIL, "create_cgroup()", retval,
+							 info[NOMESSAGE]);
+
+		return;
+	}
+
+	/* Now there is no error and it is a genuine call */
+	retval = cgroup_create_cgroup(cgrp, ign);
+	if (retval) {
+		message(i, FAIL, "create_cgroup()", retval,  info[NOMESSAGE]);
+		return;
+	}
+
+	/* Let us now check if the group exist in file system */
+	if (!common) {
+		/* group only under one mountpoint */
+		if (mpnt == 1)
+			/* group under mountpoint */
+			build_path(path1_group, mountpoint, name, NULL);
+		else
+			/* group under mountpoint2 */
+			build_path(path1_group, mountpoint2, name, NULL);
+
+		if (group_exist(path1_group) == 0)
+			message(i, PASS, "create_cgroup()", retval,
+							 info[GRPINFS]);
+		else
+			message(i, FAIL, "create_cgroup()", retval,
+							 info[GRPNOTINFS]);
+
+	 /* group under both mountpoints */
+	} else {
+		/* check if the group exists under both controllers */
+		build_path(path1_group, mountpoint, name, NULL);
+		if (group_exist(path1_group) == 0) {
+			build_path(path2_group, mountpoint2, name, NULL);
+
+			if (group_exist(path2_group) == 0)
+				message(i, PASS, "create_cgroup()",
+						 retval, info[GRPINBOTHCTLS]);
+			else
+				message(i, FAIL, "create_cgroup()",
+						 retval, info[GRPNOTIN2NDCTL]);
+		} else {
+			message(i, FAIL, "create_cgroup()", retval,
+							 info[GRPNOTIN1STCTL]);
+		}
+	}
+
+	return;
+}
+
+/**
+ * Tests the cgroup_delete_cgroup() api under different scenarios
+ * @param retcode error code in case any error is expected from api
+ * @param cgrp the group to be deleted
+ * @param name the name of the group
+ * @param common to test if group was created under one or both mountpoints
+ * @param mpnt to test if group under mountpoint or mountpoint2
+ * @param ign parameter for api if to ignore the ownership
+ * @param the test number
+ */
+void test_cgroup_delete_cgroup(int retcode, struct cgroup *cgrp,
+			 const char *name, int common, int mpnt, int ign, int i)
+{
+	int retval;
+	char path1_group[FILENAME_MAX], path2_group[FILENAME_MAX];
+	/* Check, In case some error is expected due to a negative scenario */
+	if (retcode) {
+		retval = cgroup_delete_cgroup(cgrp, ign);
+		if (retval == retcode)
+			message(i, PASS, "delete_cgroup()", retval,
+							 info[NOMESSAGE]);
+		else
+			message(i, FAIL, "delete_cgroup()", retval,
+							 info[NOMESSAGE]);
+
+		return;
+	}
+
+	/* Now there is no error and it is a genuine call */
+	retval = cgroup_delete_cgroup(cgrp, ign);
+	if (retval) {
+		message(i, FAIL, "delete_cgroup()", retval,  info[NOMESSAGE]);
+		return;
+	}
+
+	/* Let us now check if the group has been deleted from file system */
+	if (!common) {
+		/* check only under one mountpoint */
+		if (mpnt == 1)
+			/* check group under mountpoint */
+			build_path(path1_group, mountpoint, name, NULL);
+		else
+			/* check group under mountpoint2 */
+			build_path(path1_group, mountpoint2, name, NULL);
+
+		if (group_exist(path1_group) == ENOENT)
+			message(i, PASS, "delete_cgroup()", retval,
+						 info[GRPDELETEDINFS]);
+		else
+			message(i, FAIL, "delete_cgroup()", retval,
+						 info[GRPNOTDELETEDINFS]);
+
+	} else {
+		/* check group under both mountpoints */
+		/* Check if the group deleted under both mountpoints */
+		build_path(path1_group, mountpoint, name, NULL);
+		if (group_exist(path1_group) == ENOENT) {
+			build_path(path2_group, mountpoint2, name, NULL);
+
+			if (group_exist(path2_group) == ENOENT)
+				message(i, PASS, "delete_cgroup()",
+						 retval, info[GRPDELETEDINFS]);
+			else
+				message(i, FAIL, "delete_cgroup()",
+					 retval, info[GRPNOTDELETEDGLOBALY]);
+		} else {
+			message(i, FAIL, "delete_cgroup()", retval,
+						 info[GRPNOTDELETEDINFS]);
+		}
+	}
+
+}
+
+/**
+ * The function tests if the given controller is enabled in kernel
+ * @param name the name of the controller to be checked
+ * @param exist set to 1 if the controller exists
+ */
+void is_subsystem_enabled(const char *name, int *exist)
+{
+	int hierarchy, num_cgroups, enabled;
+	FILE *fd;
+	char subsys_name[FILENAME_MAX];
+
+	fd = fopen("/proc/cgroups", "r");
+	if (!fd)
+		return;
+
+	while (!feof(fd)) {
+		fscanf(fd, "%s, %d, %d, %d", subsys_name,
+					 &hierarchy, &num_cgroups, &enabled);
+		if (strncmp(name, subsys_name, sizeof(*name)) == 0)
+			*exist = 1;
+	}
+
+	fclose(fd);
+}
+
+/**
+ * This function tests if the given group exists in filesystem
+ * @param path_group path to the group to be tested for existence
+ */
+int group_exist(char *path_group)
+{
+	struct stat statbuf;
+	if (stat(path_group, &statbuf) == -1) {
+		/* Group deleted. OK */
+		if (errno == ENOENT)
+			return ENOENT;
+		/* There is some other failure */
+		printf("stat failed, return code is %d\n", errno);
+		return -1;
+	}
+
+	if (S_ISDIR(statbuf.st_mode))
+		return 0;
+	else
+		return -1;
+}
+
+/**
+ * Sets the controller name and control file name
+ * @param controller the enum for the name of the controller
+ * @param controller_name name of the controller
+ * @param control_file corresponding control file
+ */
+int set_controller(int controller, char *controller_name, char *control_file)
+{
+	switch (controller) {
+	case MEMORY:
+		if (memory == 0)
+			return 1;
+
+		strncpy(controller_name, "memory", FILENAME_MAX);
+		strncpy(control_file, "memory.limit_in_bytes", FILENAME_MAX);
+		return 0;
+		break;
+
+	case CPU:
+		if (cpu == 0)
+			return 1;
+
+		strncpy(controller_name, "cpu", FILENAME_MAX);
+		strncpy(control_file, "cpu.shares", FILENAME_MAX);
+		return 0;
+		break;
+
+	case CPUSET:
+		strncpy(controller_name, "cpuset", FILENAME_MAX);
+		strncpy(control_file, "cpuset.cpus", FILENAME_MAX);
+		return 0;
+		break;
+		/* Future controllers can be added here */
+
+	default:
+		printf("Invalid controller name passed. Setting controller"
+					" failed. Dependent tests may fail\n");
+		return 1;
+		break;
+	}
+}
+
+/**
+ * Tests if a group has been modified
+ * @param path_control_file path to the control file of the controller
+ * @param value_type which value out of four types
+ * @param struct cval the control value structure
+ */
+int group_modified(char *path_control_file, int value_type,
+						 struct cntl_val_t cval)
+{
+	bool bool_val;
+	int64_t int64_val;
+	u_int64_t uint64_val;
+	/* 100 char looks ok for a control value as string */
+	char string_val[100];
+	FILE *fd;
+	int error = 1;
+	int aux;
+
+	fd = fopen(path_control_file, "r");
+	if (!fd) {
+		fprintf(stderr, "Error in opening %s\n", path_control_file);
+		fprintf(stderr, "Skipping modified values check....\n");
+		return 1;
+	}
+
+	switch (value_type) {
+
+	case BOOL:
+		fscanf(fd, "%d", &aux);
+		bool_val = aux;
+		if (bool_val == cval.val_bool)
+			error = 0;
+		break;
+	case INT64:
+		fscanf(fd, "%" SCNi64, &int64_val);
+		if (int64_val == cval.val_int64)
+			error = 0;
+		break;
+	case UINT64:
+		fscanf(fd, "%" SCNu64, &uint64_val);
+		if (uint64_val == cval.val_uint64)
+			error = 0;
+		break;
+	case STRING:
+		fscanf(fd, "%s", string_val);
+		if (!strncmp(string_val, cval.val_string, strlen(string_val)))
+			error = 0;
+		break;
+	default:
+		fprintf(stderr, "Wrong value_type passed "
+						"in group_modified()\n");
+		fprintf(stderr, "Skipping modified values check....\n");
+		/* Can not report test result as failure */
+		error = 0;
+		break;
+	}
+
+	fclose(fd);
+	return error;
+}
+
+/**
+ * Adds the control value to a controller using wrapper apis
+ * @param newcontroller the controller to be added the value to
+ * @param control_file name of the control file of the controller
+ * @param wr the name of wrapper api
+ * @param value_type which value out of four types
+ * @param struct cval the control value structure
+ */
+int add_control_value(struct cgroup_controller *newcontroller,
+	 char *control_file, char *wr, int value_type, struct cntl_val_t cval)
+{
+	int retval;
+
+	switch (value_type) {
+
+	case BOOL:
+		retval = cgroup_add_value_bool(newcontroller,
+					 control_file, cval.val_bool);
+		snprintf(wr, SIZE, "add_value_bool()");
+		break;
+	case INT64:
+		retval = cgroup_add_value_int64(newcontroller,
+					 control_file, cval.val_int64);
+		snprintf(wr, SIZE, "add_value_int64()");
+		break;
+	case UINT64:
+		retval = cgroup_add_value_uint64(newcontroller,
+					 control_file, cval.val_uint64);
+		snprintf(wr, SIZE, "add_value_uint64()");
+		break;
+	case STRING:
+		retval = cgroup_add_value_string(newcontroller,
+					 control_file, cval.val_string);
+		snprintf(wr, SIZE, "add_value_string()");
+		break;
+	default:
+		printf("ERROR: wrong value in add_control_value()\n");
+		return 1;
+		break;
+	}
+	return retval;
+}
+
+/**
+ * This function creates and returns a cgroup data structure
+ * @param group the name of the group
+ * @param controller_name the name of the controller to be added to the group
+ * @param control_file name of the control file of the controller
+ * @param value_type which value out of four types
+ * @param struct cval the control value structure
+ * @param struct ids the permissions struct
+ * @param the test number
+ */
+struct cgroup *new_cgroup(char *group, char *controller_name,
+			 char *control_file, int value_type,
+			 struct cntl_val_t cval, struct uid_gid_t ids, int i)
+{
+	int retval;
+	/* Names of wrapper apis */
+	char wr[SIZE];
+	struct cgroup *newcgroup;
+	struct cgroup_controller *newcontroller;
+
+	newcgroup = cgroup_new_cgroup(group);
+
+	if (newcgroup) {
+		retval = cgroup_set_uid_gid(newcgroup, ids.tasks_uid,
+			 ids.tasks_gid,	ids.control_uid, ids.control_gid);
+
+		if (retval) {
+			snprintf(wr, SIZE, "set_uid_gid()");
+			message(i++, FAIL, wr, retval, info[NOMESSAGE]);
+		}
+
+		newcontroller = cgroup_add_controller(newcgroup,
+							 controller_name);
+		if (newcontroller) {
+			retval =  add_control_value(newcontroller,
+					 control_file, wr, value_type, cval);
+
+			if (!retval) {
+				message(i++, PASS, "new_cgroup()",
+						 retval, info[NOMESSAGE]);
+			} else {
+				message(i++, FAIL, wr, retval ,
+							 info[NOMESSAGE]);
+				cgroup_free(&newcgroup);
+				return NULL;
+			}
+		 } else {
+			/* Since these wrappers do not return an int so -1 */
+			message(i++, FAIL, "add_controller", -1,
+							 info[NOMESSAGE]);
+			cgroup_free(&newcgroup);
+			return NULL;
+		}
+	} else {
+		message(i++, FAIL, "new_cgroup", -1, info[NOMESSAGE]);
+		return NULL;
+	}
+	return newcgroup;
+}
+
+/**
+ * Checks if the cgroup filesystem has been mounted
+ * @param multimnt to decide if check is for single mount or multimount
+ */
+int check_fsmounted(int multimnt)
+{
+	int count = 0;
+	int ret = 1;
+	struct mntent *entry = NULL, *tmp_entry = NULL;
+	/* Need a better mechanism to decide memory allocation size here */
+	char entry_buffer[FILENAME_MAX * 4];
+	FILE *proc_file = NULL;
+
+	tmp_entry = (struct mntent *) malloc(sizeof(struct mntent));
+	if (!tmp_entry) {
+		perror("Error: failled to mallloc for mntent\n");
+		ret = errno;
+		goto error;
+	}
+
+	proc_file = fopen("/proc/mounts", "r");
+	if (!proc_file) {
+		printf("Error in opening /proc/mounts.\n");
+		ret = errno;
+		goto error;
+	}
+	while ((entry = getmntent_r(proc_file, tmp_entry, entry_buffer,
+						 FILENAME_MAX*4)) != NULL) {
+		if (!strncmp(entry->mnt_type, "cgroup", strlen("cgroup"))) {
+			count++;
+			if (multimnt) {
+				if (count >= 2) {
+					printf("sanity check pass. %s\n",
+							 entry->mnt_type);
+					ret = 0;
+					goto error;
+				}
+			} else {
+				printf("sanity check pass. %s\n",
+							 entry->mnt_type);
+				ret = 0;
+				goto error;
+			}
+		}
+	}
+error:
+	if (tmp_entry)
+		free(tmp_entry);
+	if (proc_file)
+		fclose(proc_file);
+	return ret;
+}
+
+/**
+ * Checks if the current task belongs to the given tasks file
+ * @param tasksfile the task file to be tested for the task
+ */
+int check_task(char *tasksfile, pid_t pid)
+{
+	FILE *file;
+	pid_t curr_tid, tid;
+	int pass = 0;
+
+	file = fopen(tasksfile, "r");
+	if (!file) {
+		printf("ERROR: in opening %s\n", tasksfile);
+		printf("Exiting without running other testcases in this set\n");
+		exit(1);
+	}
+
+	if (pid)
+		curr_tid = pid;
+	else
+		curr_tid = cgrouptest_gettid();
+
+	while (!feof(file)) {
+		fscanf(file, "%u", &tid);
+		if (tid == curr_tid) {
+			pass = 1;
+			break;
+		}
+	}
+	fclose(file);
+
+	return pass;
+}
+
+/**
+ * Prints the test result in a readable format with some verbose messages
+ * @param num the test number
+ * @param pass test passed or failed
+ * @param api the name of the api tested
+ * @param retval the return value of the api
+ * @param extra the extra message to the user about the scenario tested
+ */
+void message(int num, int pass, const char *api, int retval, char *extra)
+{
+	char res[10];
+	char buf[2*SIZE];
+	if (pass)
+		strncpy(res, "PASS :", 10);
+	else
+		strncpy(res, "FAIL :", 10);
+
+	/* Populate message buffer for the api */
+	snprintf(buf, sizeof(buf), "cgroup_%s\t\t Ret Value = ", api);
+	fprintf(stdout, "TEST%2d:%s %s%d\t%s", num, res, buf, retval, extra);
+}
+
+/**
+ * Builds the path to target file/group
+ * @param target to write the built path to
+ * @param mountpoint for which mountpoint the path to be built
+ * @param group the name of the group (directory)
+ * @param file what file under the group
+ */
+void
+build_path(char *target, char *mountpoint, const char *group, const char *file)
+{
+	if (!target)
+		return;
+
+	strncpy(target, mountpoint, FILENAME_MAX);
+
+	if (group) {
+		strncat(target, "/", FILENAME_MAX - strlen(target));
+		strncat(target, group, FILENAME_MAX - strlen(target));
+	}
+
+	if (file) {
+		strncat(target, "/", FILENAME_MAX - strlen(target));
+		strncat(target, file, FILENAME_MAX - strlen(target));
+	}
+}
+
+/**
+ * Tests the cgroup_compare_cgroup() api under different scenarios
+ * @param ctl1 controller 1 to be used for testing
+ * @param ctl2 controller 1 to be used for testing
+ * @param the test number
+ */
+void test_cgroup_compare_cgroup(int ctl1, int ctl2, int i)
+{
+	int retval;
+
+	struct cntl_val_t cval;
+	cval.val_int64 = 0;
+	cval.val_uint64 = 0;
+	cval.val_bool = 0;
+	strcpy(cval.val_string, "5000");
+
+	struct cgroup *cgroup1 = NULL, *cgroup2 = NULL;
+	struct cgroup_controller *controller = NULL;
+	char controller_name[FILENAME_MAX], control_file[FILENAME_MAX];
+	char wr[SIZE], extra[] = "in cgroup_compare_cgroup";
+
+	retval = cgroup_compare_cgroup(NULL, NULL);
+	if (retval)
+		message(i++, PASS, "compare_cgroup()", retval, info[NULLGRP]);
+	else
+		message(i++, FAIL, "compare_cgroup()", retval, info[NULLGRP]);
+
+	cgroup1 = cgroup_new_cgroup("testgroup");
+	cgroup2 = cgroup_new_cgroup("testgroup");
+	cgroup_set_uid_gid(cgroup1, 0, 0, 0, 0);
+	cgroup_set_uid_gid(cgroup2, 0, 0, 0, 0);
+
+	retval = set_controller(ctl1, controller_name, control_file);
+
+	controller = cgroup_add_controller(cgroup1, controller_name);
+	if (controller) {
+		retval =  add_control_value(controller,
+					 control_file, wr, STRING, cval);
+		if (retval)
+			message(i++, FAIL, wr, retval, extra);
+	}
+
+	controller = cgroup_add_controller(cgroup2, controller_name);
+	if (controller) {
+		retval =  add_control_value(controller,
+					 control_file, wr, STRING, cval);
+		if (retval)
+			message(i++, FAIL, wr, retval, extra);
+	}
+
+	retval = cgroup_compare_cgroup(cgroup1, cgroup2);
+	if (retval)
+		message(i++, FAIL, "compare_cgroup()", retval, info[NOMESSAGE]);
+	else
+		message(i++, PASS, "compare_cgroup()", retval, info[NOMESSAGE]);
+
+	/* Test the api by putting diff number of controllers in cgroups */
+	retval = set_controller(ctl2, controller_name, control_file);
+	controller = cgroup_add_controller(cgroup2, controller_name);
+	if (controller) {
+		retval =  add_control_value(controller,
+					 control_file, wr, STRING, cval);
+		if (retval)
+			message(i++, FAIL, wr, retval, extra);
+	}
+
+	retval = cgroup_compare_cgroup(cgroup1, cgroup2);
+	if (retval == ECGROUPNOTEQUAL)
+		message(i++, PASS, "compare_cgroup()", retval, info[NOMESSAGE]);
+	else
+		message(i++, FAIL, "compare_cgroup()", retval, info[NOMESSAGE]);
+
+	cgroup_free(&cgroup1);
+	cgroup_free(&cgroup2);
+}
+
+/**
+ * Tests the cgroup_get_cgroup() api under different scenarios
+ * @param ctl1 controller 1 to be used for testing
+ * @param ctl2 controller 1 to be used for testing
+ * @param struct ids the permissions struct
+ * @param the test number
+ */
+void test_cgroup_get_cgroup(int ctl1, int ctl2, struct uid_gid_t ids, int i)
+{
+	struct cgroup *cgroup_filled = NULL, *cgroup_a = NULL, *cgroup_b = NULL;
+	struct cgroup_controller *controller = NULL;
+	char controller_name[FILENAME_MAX], control_file[FILENAME_MAX];
+	struct cntl_val_t cval = {0, 0, 0, "5000"};
+	int ret;
+
+	/*
+	 * No need to test the next 3 scenarios separately for Multimnt
+	 * so testing them only under single mount
+	 */
+	if (fs_mounted == FS_MOUNTED) {
+		/* 1. Test with nullcgroup first */
+		ret = cgroup_get_cgroup(NULL);
+		if (ret == ECGROUPNOTALLOWED)
+			message(i++, PASS, "get_cgroup()", ret, info[NULLGRP]);
+		else
+			message(i++, FAIL, "get_cgroup()", ret, info[NULLGRP]);
+
+		/* 2. Test with invalid name filled cgroup(non existing) */
+		cgroup_filled = cgroup_new_cgroup("nogroup");
+		if (!cgroup_filled)
+			message(i++, FAIL, "new_cgroup()", 0, info[NOMESSAGE]);
+
+		ret = cgroup_get_cgroup(cgroup_filled);
+		if (ret)
+			message(i++, PASS, "get_cgroup()", ret,
+							 info[NOTCRTDGRP]);
+		else
+			message(i++, FAIL, "get_cgroup()", ret,
+							 info[NOTCRTDGRP]);
+		/* Free the allocated cgroup before reallocation */
+		cgroup_free(&cgroup_filled);
+
+		/* 3.
+		 * Test with name filled cgroup. Ensure the group group1 exists
+		 * in the filesystem before calling this test function
+		 */
+		cgroup_filled = cgroup_new_cgroup("group1");
+		if (!cgroup_filled)
+			message(i++, FAIL, "new_cgroup()", 0, info[NOMESSAGE]);
+
+		ret = cgroup_get_cgroup(cgroup_filled);
+		if (!ret)
+			message(i++, PASS, "get_cgroup()", ret,
+							 info[NOMESSAGE]);
+		else
+			message(i++, FAIL, "get_cgroup()", ret,
+							 info[NOMESSAGE]);
+	}
+
+	/* SINGLE & MULTI MOUNT: Create, get and compare a cgroup */
+
+	/* get cgroup_a ds and create group_a in filesystem */
+	cgroup_a = create_new_cgroup_ds(ctl1, "group_a", STRING, cval, ids, 0);
+	if (fs_mounted == FS_MULTI_MOUNTED) {
+		/* Create under another controller also */
+		ret = set_controller(ctl2, controller_name, control_file);
+		controller = cgroup_add_controller(cgroup_a, controller_name);
+		if (controller)
+			message(i++, PASS, "cgroup_add_controller()",
+					0, info[NOMESSAGE]);
+		else
+			message(i++, FAIL, "cgroup_add_controller()",
+					-1, info[NOMESSAGE]);
+	}
+	test_cgroup_create_cgroup(0, cgroup_a, "group_a", 0, 1, 1, 00);
+
+	/* create group_b ds to be filled by cgroup_get_cgroup */
+	cgroup_b = cgroup_new_cgroup("group_a");
+	if (!cgroup_b)
+		message(i++, FAIL, "new_cgroup()", 0, info[NOMESSAGE]);
+	/* Fill the ds and compare the two */
+	ret = cgroup_get_cgroup(cgroup_b);
+	if (!ret) {
+		ret = cgroup_compare_cgroup(cgroup_a, cgroup_b);
+		if (ret == 0)
+			message(i++, PASS, "get_cgroup()", ret, info[SAMEGRP]);
+		else
+			message(i++, FAIL, "get_cgroup()", ret,
+							 info[NOMESSAGE]);
+	} else {
+		message(i++, FAIL, "get_cgroup()", ret, info[NOMESSAGE]);
+	}
+
+	/* Delete this created group from fs to leave fs clean */
+	if (fs_mounted == FS_MULTI_MOUNTED)
+		test_cgroup_delete_cgroup(0, cgroup_a, "group_a", 1, 1, 0, 0);
+	else
+		test_cgroup_delete_cgroup(0, cgroup_a, "group_a", 0, 1, 0, 0);
+
+	cgroup_free(&cgroup_a);
+	cgroup_free(&cgroup_b);
+	cgroup_free(&cgroup_filled);
+}
+
+/**
+ * Tests the cgroup_add_controller() and cgroup_free_controller() wrapper
+ * apis under different scenarios
+ * @param the test number
+ */
+void test_cgroup_add_free_controller(int i)
+{
+	struct cgroup *cgroup1 = NULL, *cgroup2 = NULL;
+	struct cgroup_controller *cgctl1, *cgctl2;
+
+	/* Test with a Null cgroup */
+	cgctl1 = cgroup_add_controller(cgroup1, "cpu");
+	if (!cgctl1)
+		message(i++, PASS, "add_controller()", 0, info[NOMESSAGE]);
+	else
+		message(i++, FAIL, "add_controller()", -1, info[NOMESSAGE]);
+
+	cgroup1 = cgroup_new_cgroup("testgroup");
+	cgctl1 = cgroup_add_controller(cgroup1, "cpuset");
+	if (cgctl1)
+		message(i++, PASS, "add_controller()", 0, info[NOMESSAGE]);
+	else
+		message(i++, FAIL, "add_controller()", -1, info[NOMESSAGE]);
+
+	cgctl2 = cgroup_add_controller(cgroup1, "cpu");
+	if (cgctl2)
+		message(i++, PASS, "add_controller()", 0, info[NOMESSAGE]);
+	else
+		message(i++, FAIL, "add_controller()", -1, info[NOMESSAGE]);
+
+	cgroup_free(&cgroup1);
+	cgroup_free_controllers(cgroup2);
+}
+
+/**
+ * Returns the tid of the current thread
+ */
+pid_t cgrouptest_gettid()
+{
+	return syscall(__NR_gettid);
+}

--- a/tests/test_named_hierarchy.c
+++ b/tests/test_named_hierarchy.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <libcgroup.h>
+
+/*
+ * Assumes cgroup is mounted at /cgroup using
+ *
+ * mount -t cgroup -o none,name=test none /cgroup
+ */
+int main()
+{
+	int ret;
+	struct cgroup *cgroup;
+	struct cgroup_controller *cgc;
+
+	ret = cgroup_init();
+	if (ret) {
+		printf("FAIL: cgroup_init failed with %s\n", cgroup_strerror(ret));
+		exit(3);
+	}
+
+	cgroup = cgroup_new_cgroup("test");
+	if (!cgroup) {
+		printf("FAIL: cgroup_new_cgroup failed\n");
+		exit(3);
+	}
+
+	cgc = cgroup_add_controller(cgroup, "name=test");
+	if (!cgc) {
+		printf("FAIL: cgroup_add_controller failed\n");
+		exit(3);
+	}
+
+	ret = cgroup_create_cgroup(cgroup, 1);
+	if (ret) {
+		printf("FAIL: cgroup_create_cgroup failed with %s\n", cgroup_strerror(ret));
+		exit(3);
+	}
+
+	if (access("/cgroup/test", F_OK))
+		printf("PASS\n");
+	else
+		printf("Failed to create cgroup\n");
+
+	return 0;
+}

--- a/tests/tools/Makefile.am
+++ b/tests/tools/Makefile.am
@@ -1,0 +1,2 @@
+SUBDIRS = cgconfigparser cgclassify multimount
+

--- a/tests/tools/README
+++ b/tests/tools/README
@@ -1,0 +1,35 @@
+libcgroup tools test suite
+==========================
+
+These files should test libcgroup tools, not the libcgroup library itself! All
+the tools use the library so it gets pretty well tested, but that's just a side
+effect, not an intention.
+
+Usage
+-----
+
+There are few requirements to run this test:
+ - !!! YOU MUST RUN THE TESTS AS ROOT !!! - the tests need to mount/unmount
+   stuff. The tests should not destroy anything important, but use a virtual
+   machine if possible, just to be sure.
+ - You must have no cgroup mounted (i.e. run cgclear before starting the test
+   suite).
+ - The tests require various tools to be present in $PATH or at the specified
+   location, among others:
+   diff, awk, su, /bin/bash, /bin/sleep
+ - The tests require that user and group named 'nobody' exists, some processes
+   with be started with its UID/GID.
+ - The tests mounts/unmounts cpu, cpuacct, freezer and net_cls controllers.
+   Make sure your kernel supports them.
+
+If you have met all above prerequisites just run 'make check' in this directory
+as root.
+
+Design
+------
+There is very simple testenv.sh script, which contains common functions for all
+tests. It includes also simple example how to write a test.
+
+The tests themselves are just simple shell scripts, which either end with exit
+status 0 (=success) or nonzero (=error). The tests should clean after themselves
+(incl. unmounting all groups and removing all temp. files).

--- a/tests/tools/cgclassify/Makefile.am
+++ b/tests/tools/cgclassify/Makefile.am
@@ -1,0 +1,5 @@
+EXTRA_DIST = cgclassify cgclassify-rules simple.conf
+
+# The legacy tests have been disabled because they do not successfully run
+# on Travis CI.
+#TESTS = cgclassify cgclassify-rules

--- a/tests/tools/cgclassify/cgclassify
+++ b/tests/tools/cgclassify/cgclassify
@@ -1,0 +1,134 @@
+#!/bin/bash
+#
+# Test cgclassify with various arguments, without /etc/cgrules.conf.
+# cglassify is tested with exact destination group, multiple PIDs, groups
+# specified by '*', multiple target groups, lot of PIDs on command line
+# and various error cases.
+
+. `dirname $0`/../testenv.sh
+
+function checkpid()
+{
+	# check that given process is in given groups
+	local PID=$1
+	# delete hierarchy number, ignore systemd
+	cat /proc/$PID/cgroup | sed 's/^[0-9]*://' | grep -v systemd > $TMP/pid-$PID.group
+	printf >$TMP/pid-$PID.expected "$2"
+	diff -u -w $TMP/pid-$PID.group $TMP/pid-$PID.expected
+	return $?
+}
+
+function resetgroup()
+{
+	# move given processes back to root group
+	$TOOLSDIR/cgclassify -g "*:/" $*
+}
+
+# prepare some hierarchy
+$TOOLSDIR/cgconfigparser -l `prepare_config simple.conf` || \
+	die "cannot parse simple.conf"
+
+# start few processes to torture
+/bin/sleep 10000 &
+PID1=$!
+/bin/sleep 10000 &
+PID2=$!
+/bin/sleep 10000 &
+PID3=$!
+
+# STEP1: simple cgclassify to exact groups
+$TOOLSDIR/cgclassify -g net_cls,cpu:common $PID1 || \
+	die "STEP1: cgclassify PID1 failed"
+$TOOLSDIR/cgclassify -g net_cls:net1 $PID2 || \
+	die "STEP1: cgclassify PID2 failed"
+$TOOLSDIR/cgclassify -g cpu:cpu1 $PID3 || \
+	die "STEP1: cgclassify PID3 failed"
+
+checkpid $PID1 "net_cls,freezer:/common\ncpuacct,cpu:/common\n" || \
+	die "STEP1: unexpected group of pid1"
+checkpid $PID2 "net_cls,freezer:/net1\ncpuacct,cpu:/\n" || \
+	die "STEP!: unexpected group of pid2"
+checkpid $PID3 "net_cls,freezer:/\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP!: unexpected group of pid3"
+
+# STEP2: try * and more PIDs
+$TOOLSDIR/cgclassify -g "*:/" $PID1 $PID2 $PID3 || \
+	die "cgclassify 2 failed"
+checkpid $PID1 "net_cls,freezer:/\ncpuacct,cpu:/\n" || \
+	die "STEP2: unexpected group of pid1"
+checkpid $PID2 "net_cls,freezer:/\ncpuacct,cpu:/\n" || \
+	die "STEP2: unexpected group of pid2"
+checkpid $PID3 "net_cls,freezer:/\ncpuacct,cpu:/\n" || \
+	die "STEP2: unexpected group of pid3"
+
+# STEP3: try different groups
+resetgroup $PID1 $PID2 $PID3
+$TOOLSDIR/cgclassify -g cpu:cpu1 -g net_cls:net1 $PID1
+checkpid $PID1 "net_cls,freezer:/net1\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP3: unexpected group of pid1"
+
+# STEP4: different groups multiple times (tha last should win)
+resetgroup $PID1 $PID2 $PID3
+$TOOLSDIR/cgclassify -g "*:/" -g cpu:common -g net_cls:common -g cpu:cpu1 -g net_cls:net1 $PID1 || \
+	die "STEP4: cgclassify pid1 failed"
+checkpid $PID1 "net_cls,freezer:/net1\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP4: unexpected group of pid1"
+$TOOLSDIR/cgclassify -g "*:/" -g cpu:common -g net_cls:common -g cpu:cpu1 $PID2 || \
+	die "STEP4: cgclassify pid2 failed"
+checkpid $PID2 "net_cls,freezer:/common\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP4: unexpected group of pid2"
+
+# STEP5: some error cases
+# group does not exist
+echo "Testing error cases, error messages will appear!"
+$TOOLSDIR/cgclassify -g cpu:invalid_group $PID1 && \
+	die "STEP5: cgclassify with invalig_group succeeded"
+# parameter is not a PID
+$TOOLSDIR/cgclassify -g cpu:/ xxx && \
+	die "STEP5: cgclassify with xxx pid succeeded"
+# let's hope process 1234567 does not exist
+$TOOLSDIR/cgclassify -g cpu:/ 1234567 && \
+	die "STEP5: cgclassify with 1234567 succeeded"
+# not-mounted controller
+$TOOLSDIR/cgclassify -g xxx:/ $PID1 && \
+	die "STEP5: cgclassify with xxx controller succeeded"
+# no -g parameter
+$TOOLSDIR/cgclassify -g  $PID1 && \
+	die "STEP5: cgclassify without -g succeeded"
+# invalid -g format
+$TOOLSDIR/cgclassify -g  cpu/cpu1 $PID1 && \
+	die "STEP5: cgclassify -g cpu/cpu1 succeeded"
+
+# some existing processes among unexisting
+resetgroup $PID1 $PID2 $PID3
+$TOOLSDIR/cgclassify -g cpu,net_cls:common $PID1 1234567 $PID2 1234568 $PID3 && \
+	die "STEP5: cgclassify with mixed processed succeeded"
+checkpid $PID1 "net_cls,freezer:/common\ncpuacct,cpu:/common\n" || \
+	die "STEP5: unexpected group of pid1"
+checkpid $PID2 "net_cls,freezer:/common\ncpuacct,cpu:/common\n" || \
+	die "STEP5: unexpected group of pid2"
+checkpid $PID3 "net_cls,freezer:/common\ncpuacct,cpu:/common\n" || \
+	die "STEP5: unexpected group of pid3"
+
+echo "End of error cases"
+
+# STEP6: *lot of* processes on command line
+echo "Testing lot of arguments, this will take some time"
+COUNT=1000
+echo >$TMP/pids
+(
+	for i in `seq $COUNT`; do
+		sleep 100000 &
+		echo $! >>$TMP/pids
+	done
+) > /dev/null
+$TOOLSDIR/cgclassify -g net_cls,cpu:common `cat $TMP/pids` || \
+	die "STEP6: cgclassify failed"
+
+kill `cat $TMP/pids`
+sleep 1 # to settle down the sleep load - sigterm does not kill sleep immediatelly
+
+kill $PID1 $PID2 $PID3
+$TOOLSDIR/cgclear
+cleanup
+exit 0

--- a/tests/tools/cgclassify/cgclassify-rules
+++ b/tests/tools/cgclassify/cgclassify-rules
@@ -1,0 +1,171 @@
+#!/bin/bash
+#
+# Test cgclassify with various /etc/cgrules.conf settings, like
+# simple rules, multiple matching rules, using @groups, executable
+# names and default rules.
+# The test relies on testenv.sh to backup/restore /etc/cgrules.conf.
+#
+
+. `dirname $0`/../testenv.sh
+
+# The test need sto start few processes with non-root UID/GID. Which should be
+# used?
+TESTUSER=nobody
+TESTGROUP=nobody
+
+function checkpid()
+{
+	# check that given process is in given groups
+	local PID=$1
+	# delete hierarchy number, ignore systemd
+	cat /proc/$PID/cgroup | sed 's/^[0-9]*://' | grep -v systemd > $TMP/pid-$PID.group
+	printf >$TMP/pid-$PID.expected "$2"
+	diff -u -w $TMP/pid-$PID.group $TMP/pid-$PID.expected
+	return $?
+}
+
+function resetgroup()
+{
+	# move given processes back to root group
+	$TOOLSDIR/cgclassify -g "*:/" $*
+}
+
+# prepare some hierarchy
+$TOOLSDIR/cgconfigparser -l `prepare_config simple.conf` || \
+	die "cannot parse simple.conf"
+
+# prepare specific process names
+ln -s /bin/sleep $TMP/sleep1
+$TMP/sleep1 10000 &
+PID1=$!
+ln -s /bin/sleep $TMP/sleep2
+$TMP/sleep2 10000 &
+PID2=$!
+
+# start some processes as $TESTUSER
+chmod o+rwX $TMP
+su $TESTUSER -s /bin/bash -c "$TMP/sleep1 10000" &
+su $TESTUSER -s /bin/bash -c "$TMP/sleep2 10000" &
+sleep 0.1
+NPID1=`ps h -u $TESTUSER | grep sleep1 | awk  '{ print $1; }' | tail -n 1`
+NPID2=`ps h -u $TESTUSER | grep sleep2 | awk  '{ print $1; }' | tail -n 1`
+
+# STEP1: simple global rule
+cat <<EOF >/etc/cgrules.conf
+unused	*	/
+*	*	common
+EOF
+$TOOLSDIR/cgclassify $PID1
+checkpid $PID1 "net_cls,freezer:/common\ncpuacct,cpu:/common\n" || \
+	die "STEP1: unexpected group of pid1"
+resetgroup $PID1
+
+# STEP2: two destination groups
+cat <<EOF >/etc/cgrules.conf
+unused	*	/
+*	cpu	cpu1
+%	net_cls	net1
+EOF
+$TOOLSDIR/cgclassify $PID1
+checkpid $PID1 "net_cls,freezer:/net1\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP2: unexpected group of pid1"
+resetgroup $PID1
+
+# STEP3: two matching rules, only the first is executed
+cat <<EOF >/etc/cgrules.conf
+unused	*	/
+*	cpu	cpu1
+*	net_cls	net1
+EOF
+$TOOLSDIR/cgclassify $PID1
+checkpid $PID1 "net_cls,freezer:/\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP3: unexpected group of pid1"
+resetgroup $PID1
+
+# STEP4: process name in a rule
+cat <<EOF >/etc/cgrules.conf
+unused	*	/
+*:sleep1	cpu	cpu1
+*:sleep2	net_cls	net1
+EOF
+$TOOLSDIR/cgclassify $PID1
+checkpid $PID1 "net_cls,freezer:/\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP4: unexpected group of pid1"
+$TOOLSDIR/cgclassify $PID2
+checkpid $PID2 "net_cls,freezer:/net1\ncpuacct,cpu:/\n" || \
+	die "STEP4: unexpected group of pid2"
+resetgroup $PID1 $PID2
+
+# STEP5: full path
+cat <<EOF >/etc/cgrules.conf
+unused	*	/
+*:$TMP/sleep1	cpu	cpu1
+*:$TMP/sleep2	net_cls	net1
+EOF
+$TOOLSDIR/cgclassify $PID1
+checkpid $PID1 "net_cls,freezer:/\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP5: unexpected group of pid1"
+$TOOLSDIR/cgclassify $PID2
+checkpid $PID2 "net_cls,freezer:/net1\ncpuacct,cpu:/\n" || \
+	die "STEP5: unexpected group of pid2"
+resetgroup $PID1 $PID2
+
+#STEP6: username
+cat <<EOF >/etc/cgrules.conf
+unused	*	/
+$TESTUSER	cpu	cpu1
+*	net_cls	net1
+EOF
+$TOOLSDIR/cgclassify $PID1 $NPID1
+checkpid $NPID1 "net_cls,freezer:/\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP6: unexpected group of npid1"
+checkpid $PID1 "net_cls,freezer:/net1\ncpuacct,cpu:/\n" || \
+	die "STEP6: unexpected group of pid1"
+resetgroup $PID1 $NPID1
+
+#STEP7: username + processname
+cat <<EOF >/etc/cgrules.conf
+unused	*	/
+$TESTUSER:$TMP/sleep1	cpu	cpu1
+*:$TMP/sleep1	net_cls	net1
+EOF
+$TOOLSDIR/cgclassify $PID1 $NPID1
+checkpid $NPID1 "net_cls,freezer:/\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP7: unexpected group of npid1"
+checkpid $PID1 "net_cls,freezer:/net1\ncpuacct,cpu:/\n" || \
+	die "STEP7: unexpected group of pid1"
+resetgroup $PID1 $NPID1
+
+#STEP8: groupname + processname
+cat <<EOF >/etc/cgrules.conf
+unused	*	/
+@$TESTGROUP:$TMP/sleep1	cpu	cpu1
+*:$TMP/sleep1	net_cls	net1
+EOF
+$TOOLSDIR/cgclassify $PID1 $NPID1
+checkpid $NPID1 "net_cls,freezer:/\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP8: unexpected group of npid1"
+checkpid $PID1 "net_cls,freezer:/net1\ncpuacct,cpu:/\n" || \
+	die "STEP8: unexpected group of pid1"
+resetgroup $PID1 $NPID1
+
+#STEP9: processname + default
+cat <<EOF >/etc/cgrules.conf
+unused	*	/
+*:$TMP/sleep1	cpu	cpu1
+*	net_cls	net1
+EOF
+$TOOLSDIR/cgclassify $PID1 $PID2
+checkpid $PID1 "net_cls,freezer:/\ncpuacct,cpu:/cpu1\n" || \
+	die "STEP9: unexpected group of pid1"
+checkpid $PID2 "net_cls,freezer:/net1\ncpuacct,cpu:/\n" || \
+	die "STEP9: unexpected group of pid2"
+resetgroup $PID1 $NPID1
+
+kill -9 $PID1 $PID2 $NPID1 $NPID2
+
+sleep 0.1
+$TOOLSDIR/cgclear
+
+cleanup
+exit 0

--- a/tests/tools/cgclassify/simple.conf
+++ b/tests/tools/cgclassify/simple.conf
@@ -1,0 +1,24 @@
+# Two hierarchies, two controllers each:
+
+mount {
+    cpu = TMP/cgroup/cpu;
+    cpuacct = TMP/cgroup/cpu;
+    net_cls = TMP/cgroup/net;
+    freezer = TMP/cgroup/net;
+}
+
+# One group common for all hierarchies:
+
+group common {
+    cpu {}
+    net_cls {}
+}
+
+# Two separate groups:
+group net1 {
+    net_cls{}
+}
+
+group cpu1 {
+    cpu {}
+}

--- a/tests/tools/cgconfigparser/Makefile.am
+++ b/tests/tools/cgconfigparser/Makefile.am
@@ -1,0 +1,30 @@
+EXTRA_DIST = cgconfigparser_simple \
+             cgconfigparser_conf_files_tests \
+             cgconfigparser_conf_files/cgconfig.conf.5.ex1 \
+             cgconfigparser_conf_files/cgconfig.conf.5.ex2 \
+             cgconfigparser_conf_files/cgconfig.conf.5.ex3 \
+             cgconfigparser_conf_files/cgconfig.conf.5.ex4 \
+             cgconfigparser_conf_files/permissions.conf \
+	     cgconfigparser_multiconfig \
+	     cgclear_config_multi \
+	     cgclear_config_one \
+	     permissions \
+	     cgconfigparser_conf_files/permissions_default1.conf \
+	     cgconfigparser_conf_files/permissions_default2.conf \
+	     cgconfigparser_conf_files/permissions_default3.conf \
+	     cgconfigparser_conf_files/permissions_default4.conf \
+	     multiconfig/1.conf \
+	     multiconfig/2.conf \
+	     multiconfig/3.conf \
+	     multiconfig/4.conf \
+	     multiconfig/5.conf \
+	     cgclear/cgclear_config_multi_1.conf \
+	     cgclear/cgclear_config_multi_2.conf \
+	     cgclear/cgclear_config_multi_3.conf \
+	     cgclear/cgclear_config_one.conf
+
+# The legacy tests have been disabled because they do not successfully run
+# on Travis CI.
+#TESTS = cgconfigparser_simple cgconfigparser_conf_files_tests permissions \
+#	cgconfigparser_multiconfig cgclear_config_multi cgclear_config_one
+

--- a/tests/tools/cgconfigparser/cgclear/cgclear_config_multi_1.conf
+++ b/tests/tools/cgconfigparser/cgclear/cgclear_config_multi_1.conf
@@ -1,0 +1,12 @@
+mount {
+    cpu = /TMP/cgroups/cpu;
+    cpuacct = /TMP/cgroups/cpu;
+}
+
+group 1 {
+    cpu { }
+}
+
+group 1/1 {
+    cpu { }
+}

--- a/tests/tools/cgconfigparser/cgclear/cgclear_config_multi_2.conf
+++ b/tests/tools/cgconfigparser/cgclear/cgclear_config_multi_2.conf
@@ -1,0 +1,11 @@
+group 2 {
+    cpu { }
+}
+
+group 1/2 {
+    cpu { }
+}
+
+group 1/2/2 {
+    cpu { }
+}

--- a/tests/tools/cgconfigparser/cgclear/cgclear_config_multi_3.conf
+++ b/tests/tools/cgconfigparser/cgclear/cgclear_config_multi_3.conf
@@ -1,0 +1,19 @@
+group 3 {
+    cpu { }
+}
+
+group 1/2/3 {
+    cpu { }
+}
+
+group 1/2/2/3 {
+    cpu { }
+}
+
+group 1/3 {
+    cpu { }
+}
+
+group 2/3 {
+    cpu { }
+}

--- a/tests/tools/cgconfigparser/cgclear/cgclear_config_one.conf
+++ b/tests/tools/cgconfigparser/cgclear/cgclear_config_one.conf
@@ -1,0 +1,16 @@
+mount {
+    cpu = /TMP/cgroups/cpu;
+    cpuacct = /TMP/cgroups/cpu;
+}
+
+group first {
+    cpu { }
+}
+
+group first/subgroup {
+    cpu { }
+}
+
+group second {
+    cpu { }
+}

--- a/tests/tools/cgconfigparser/cgclear_config_multi
+++ b/tests/tools/cgconfigparser/cgclear_config_multi
@@ -1,0 +1,59 @@
+#!/bin/bash
+# test cgclear with multiple config files
+
+. `dirname $0`/../testenv.sh
+
+# start a process to torture
+/bin/sleep 10000 &
+PID=$!
+
+# STEP1: parse three config files and cgclear them at once (in reverse order!)
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_multi_1.conf` \
+	|| die "STEP1: cgconfigparser multi_1 failed"
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_multi_2.conf` \
+	|| die "STEP1: cgconfigparser multi_2 failed"
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_multi_3.conf` \
+	|| die "STEP1: cgconfigparser multi_3 failed"
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep 1/2/3 <$TMP/groups.log >/dev/null \
+	|| die "STEP1: cannot find group '1/2/3'"
+
+# clear it all
+$TOOLSDIR/cgclear -e -l `prepare_config cgclear/cgclear_config_multi_1.conf` \
+	-l `prepare_config cgclear/cgclear_config_multi_2.conf` \
+	-l `prepare_config cgclear/cgclear_config_multi_3.conf` \
+	|| die "STEP1: cgclear failed"
+
+# check all is gone
+$TOOLSDIR/lscgroup 2>/dev/null \
+	&& die "STEP1: something is mounted after cgclear"
+
+
+# STEP2: same as step1, but in wrong order - cgclear should fail
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_multi_1.conf` \
+	|| die "STEP2: cgconfigparser multi_1 failed"
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_multi_2.conf` \
+	|| die "STEP2: cgconfigparser multi_2 failed"
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_multi_3.conf` \
+	|| die "STEP2: cgconfigparser multi_3 failed"
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep 1/2/3 <$TMP/groups.log >/dev/null \
+	|| die "STEP2: cannot find group '1/2/3'"
+
+# clear it all
+$TOOLSDIR/cgclear -e -l `prepare_config cgclear/cgclear_config_multi_3.conf` \
+	-l `prepare_config cgclear/cgclear_config_multi_2.conf` \
+	-l `prepare_config cgclear/cgclear_config_multi_1.conf` \
+	|| die "STEP2: cgclear failed"
+
+# check that cpu,cpuacct:/1/2 still exists
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep 1/2 <$TMP/groups.log >/dev/null \
+	|| die "STEP2: cannot find group '1/2 after cgclear"
+
+$TOOLSDIR/cgclear
+
+
+cleanup
+kill -9 $PID
+exit 0

--- a/tests/tools/cgconfigparser/cgclear_config_one
+++ b/tests/tools/cgconfigparser/cgclear_config_one
@@ -1,0 +1,146 @@
+#!/bin/bash
+# test cgclear with one config file
+
+. `dirname $0`/../testenv.sh
+
+# start a process to torture
+/bin/sleep 10000 &
+PID=$!
+
+# STEP1: parse one simple config with mount and cgclear it (incl. unmount)
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP1: cgconfigparser failed"
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep first <$TMP/groups.log >/dev/null \
+	|| die "STEP1: cannot find group 'first'"
+
+# unmount it
+$TOOLSDIR/cgclear -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP1: cgclear failed"
+
+# check all is gone
+$TOOLSDIR/lscgroup 2>/dev/null \
+	&& die "STEP1: something is mounted after cgclear"
+
+
+# STEP2: create a cgroup out of config's tree - it must survive cgclear
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP2: cgconfigparser failed"
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep first <$TMP/groups.log >/dev/null \
+	|| die "STEP2: cannot find group 'first'"
+
+$TOOLSDIR/cgcreate -g cpu:/evil \
+	|| die "STEP2: cgcreate failed"
+
+# clear it - 'evil' should survive
+$TOOLSDIR/cgclear -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP2: cgclear1 failed"
+
+# check evil is there
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep evil <$TMP/groups.log >/dev/null \
+	|| die "STEP2: evil not found"
+
+# clear everything
+$TOOLSDIR/cgclear || die "STEP2: cgclear2 failed"
+$TOOLSDIR/lscgroup 2>/dev/null \
+	&& die "STEP2: something is mounted after cgclear"
+
+
+# STEP3: leave a process and a subgroup somewhere and check cgclear *without* -e clears it
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP3: cgconfigparser failed"
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep first <$TMP/groups.log >/dev/null \
+	|| die "STEP3: cannot find group 'first'"
+
+$TOOLSDIR/cgclassify -g cpu:first $PID \
+	|| die "STEP3: cgclassify failed"
+$TOOLSDIR/cgcreate -g cpu:first/evil \
+	|| die "STEP3: cgcreate failed"
+
+# unmount it
+$TOOLSDIR/cgclear -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP3: cgclear failed"
+
+# check all is gone
+$TOOLSDIR/lscgroup 2>/dev/null \
+	&& die "STEP3: something is mounted after cgclear"
+
+
+
+# STEP4: leave a process somewhere and check cgclear with -e doesn't clear it
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP4: cgconfigparser failed"
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep first <$TMP/groups.log >/dev/null \
+	|| die "STEP4: cannot find group 'first'"
+
+$TOOLSDIR/cgclassify -g cpu:first $PID \
+	|| die "STEP4: cgclassify failed"
+
+# try to clear it - cgclear should not fail and the group should survive
+$TOOLSDIR/cgclear -e -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP4: cgclear failed"
+$TOOLSDIR/lscgroup > $TMP/groups2.log
+grep first <$TMP/groups2.log >/dev/null \
+	|| die "STEP4: cannot find group 'first' after cgclear"
+
+# cpu:first should survive
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep first <$TMP/groups.log >/dev/null \
+	|| die "STEP4: cannot find group 'first'"
+# cpu:second should *not* survive
+grep second <$TMP/groups.log >/dev/null \
+	&& die "STEP4: unexpected group 'second' found"
+# cpu:first/subgroup should *not* survive
+grep first/subgroup  <$TMP/groups.log >/dev/null \
+	&& die "STEP4: unexpected group 'first/subgroup' found"
+
+$TOOLSDIR/cgclear
+
+# check all is gone
+$TOOLSDIR/lscgroup 2>/dev/null \
+	&& die "STEP4: something is mounted after cgclear"
+
+
+
+# STEP5: leave a subgroup somewhere and check cgclear with -e doesn't clear it
+$TOOLSDIR/cgconfigparser -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP5: cgconfigparser failed"
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep first <$TMP/groups.log >/dev/null \
+	|| die "STEP5: cannot find group 'first'"
+
+$TOOLSDIR/cgcreate -g cpu:first/evil \
+	|| die "STEP5: cgcreate failed"
+
+# try to clear it - cgclear should not fail, the group should survive
+$TOOLSDIR/cgclear -e -l `prepare_config cgclear/cgclear_config_one.conf` \
+	|| die "STEP5: cgclear failed"
+$TOOLSDIR/lscgroup > $TMP/groups2.log
+grep first <$TMP/groups2.log >/dev/null \
+	|| die "STEP5: cannot find group 'first' after clear"
+
+# cpu:first/evil should survive
+$TOOLSDIR/lscgroup > $TMP/groups.log
+grep first/evil <$TMP/groups.log >/dev/null \
+	|| die "STEP5: cannot find group 'first/evil'"
+# cpu:second should *not* survive
+grep second <$TMP/groups.log >/dev/null \
+	&& die "STEP5: unexpected group 'second' found"
+# cpu:first/subgroup should *not* survive
+grep first/subgroup  <$TMP/groups.log >/dev/null \
+	&& die "STEP5: unexpected group 'first/subgroup' found"
+
+$TOOLSDIR/cgclear
+
+# check all is gone
+$TOOLSDIR/lscgroup 2>/dev/null \
+	&& die "STEP4: something is mounted after cgclear"
+
+kill -9 $PID
+
+cleanup
+exit 0

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files/cgconfig.conf.5.ex1
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files/cgconfig.conf.5.ex1
@@ -1,0 +1,5 @@
+              mount {
+                     cpu = /TMP/cgroups/cpu;
+                     cpuacct = /TMP/cgroups/cpu;
+              }
+

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files/cgconfig.conf.5.ex2
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files/cgconfig.conf.5.ex2
@@ -1,0 +1,36 @@
+              mount {
+                     cpu = /TMP/cgroups/cpu;
+                     cpuacct = /TMP/cgroups/cpu;
+              }
+
+              group daemons/www {
+                     perm {
+                            task {
+                                   uid = root;
+                                   gid = nobody;
+                            }
+                            admin {
+                                   uid = root;
+                                   gid = root;
+                            }
+                     }
+                     cpu {
+                            cpu.shares = "1000";
+                     }
+              }
+
+              group daemons/ftp {
+                     perm {
+                            task {
+                                   uid = root;
+                                   gid = nobody;
+                            }
+                            admin {
+                                   uid = root;
+                                   gid = root;
+                            }
+                     }
+                     cpu {
+                            cpu.shares = "500";
+                     }
+              }

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files/cgconfig.conf.5.ex3
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files/cgconfig.conf.5.ex3
@@ -1,0 +1,11 @@
+              mount {
+                     cpu = /TMP/cgroups/cpu;
+                     cpuacct = /TMP/cgroups/cpuacct;
+              }
+
+              group daemons {
+                     cpuacct{
+                     }
+                     cpu {
+                     }
+              }

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files/cgconfig.conf.5.ex4
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files/cgconfig.conf.5.ex4
@@ -1,0 +1,21 @@
+              mount {
+                     cpu = /TMP/cgroups/cpu;
+                     cpuacct = /TMP/cgroups/cpuacct;
+              }
+
+              group daemons {
+                     cpuacct{
+                     }
+              }
+
+              group daemons/www {
+                     cpu {
+                            cpu.shares = "1000";
+                     }
+              }
+
+              group daemons/ftp {
+                     cpu {
+                            cpu.shares = "500";
+                     }
+              }

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions.conf
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions.conf
@@ -1,0 +1,42 @@
+              mount {
+                     cpu = /TMP/cgroups/cpu;
+                     cpuacct = /TMP/cgroups/cpu;
+              }
+
+              group daemons/www {
+                     perm {
+                            task {
+                                   uid = root;
+                                   gid = nobody;
+                                   fperm = 750;
+                            }
+                            admin {
+                                   uid = root;
+                                   gid = root;
+                                   dperm = 770;
+                                   fperm = 777;
+                            }
+                     }
+                     cpu {
+                            cpu.shares = "1000";
+                     }
+              }
+
+              group daemons/ftp {
+                     perm {
+                            task {
+                                   uid = root;
+                                   gid = nobody;
+                                   fperm = 274;
+                            }
+                            admin {
+                                   uid = root;
+                                   gid = root;
+                                   dperm = 742;
+                                   fperm = 427;
+                            }
+                     }
+                     cpu {
+                            cpu.shares = "500";
+                     }
+              }

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions_default1.conf
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions_default1.conf
@@ -1,0 +1,64 @@
+mount {
+	cpu = /TMP/cgroups/cpu;
+	cpuacct = /TMP/cgroups/cpu;
+}
+
+default {
+	perm {
+		task {
+			uid=nobody;
+			gid=nobody;
+			fperm=757;
+		}
+		admin {
+			uid = nobody;
+			gid = nobody;
+			dperm = 757;
+			fperm = 757;
+		}
+	}
+}
+
+# inherit default
+group daemons/www {
+	cpu {
+		cpu.shares = "1000";
+	}
+}
+
+#override default
+group daemons/ftp {
+	perm {
+		task {
+			uid = root;
+			gid = root;
+			fperm = 274;
+		}
+		admin {
+			uid = root;
+			gid = root;
+			dperm = 742;
+			fperm = 427;
+		}
+	}
+	cpu {
+		cpu.shares = "500";
+	}
+}
+
+# override some default
+group daemons/ssh {
+	perm {
+		task {
+			uid = root;
+			fperm = 274;
+		}
+		admin {
+			uid = root;
+			fperm = 427;
+		}
+	}
+	cpu {
+		cpu.shares = "500";
+	}
+}

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions_default2.conf
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions_default2.conf
@@ -1,0 +1,82 @@
+mount {
+	cpu = /TMP/cgroups/cpu;
+	cpuacct = /TMP/cgroups/cpu;
+}
+
+default {
+	perm {
+		task {
+			uid=root;
+			gid=root;
+			fperm=700;
+		}
+		admin {
+			uid = root;
+			gid = root;
+			dperm = 700;
+			fperm = 700;
+		}
+	}
+}
+
+
+# inherit default
+group daemons/www {
+	cpu {
+		cpu.shares = "1000";
+	}
+}
+
+#override default
+group daemons/ftp {
+	perm {
+		task {
+			uid = root;
+			gid = root;
+			fperm = 274;
+		}
+		admin {
+			uid = root;
+			gid = root;
+			dperm = 742;
+			fperm = 427;
+		}
+	}
+	cpu {
+		cpu.shares = "500";
+	}
+}
+
+# override some default
+group daemons/ssh {
+	perm {
+		task {
+			uid = root;
+			fperm = 274;
+		}
+		admin {
+			uid = root;
+			fperm = 427;
+		}
+	}
+	cpu {
+		cpu.shares = "500";
+	}
+}
+
+# second default, wins
+default {
+	perm {
+		task {
+			uid=nobody;
+			gid=nobody;
+			fperm=757;
+		}
+		admin {
+			uid = nobody;
+			gid = nobody;
+			dperm = 757;
+			fperm = 757;
+		}
+	}
+}

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions_default3.conf
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions_default3.conf
@@ -1,0 +1,64 @@
+mount {
+	cpu = /TMP/cgroups/cpu;
+	cpuacct = /TMP/cgroups/cpu;
+}
+
+default {
+	perm {
+		task {
+			uid=nobody;
+			gid=nobody;
+			fperm=1757;
+		}
+		admin {
+			uid = nobody;
+			gid = nobody;
+			dperm = 2757;
+			fperm = 7757;
+		}
+	}
+}
+
+# inherit default
+group daemons/www {
+	cpu {
+		cpu.shares = "1000";
+	}
+}
+
+#override default
+group daemons/ftp {
+	perm {
+		task {
+			uid = root;
+			gid = root;
+			fperm = 274;
+		}
+		admin {
+			uid = root;
+			gid = root;
+			dperm = 742;
+			fperm = 427;
+		}
+	}
+	cpu {
+		cpu.shares = "500";
+	}
+}
+
+# override some default
+group daemons/ssh {
+	perm {
+		task {
+			uid = root;
+			fperm = 274;
+		}
+		admin {
+			uid = root;
+			fperm = 427;
+		}
+	}
+	cpu {
+		cpu.shares = "500";
+	}
+}

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions_default4.conf
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files/permissions_default4.conf
@@ -1,0 +1,48 @@
+mount {
+	cpu = /TMP/cgroups/cpu;
+	cpuacct = /TMP/cgroups/cpu;
+}
+
+# inherit default
+group daemons/www {
+	cpu {
+		cpu.shares = "1000";
+	}
+}
+
+#override default
+group daemons/ftp {
+	perm {
+		task {
+			uid = root;
+			gid = root;
+			fperm = 274;
+		}
+		admin {
+			uid = root;
+			gid = root;
+			dperm = 742;
+			fperm = 427;
+		}
+	}
+	cpu {
+		cpu.shares = "500";
+	}
+}
+
+# override some default
+group daemons/ssh {
+	perm {
+		task {
+			uid = root;
+			fperm = 274;
+		}
+		admin {
+			uid = root;
+			fperm = 427;
+		}
+	}
+	cpu {
+		cpu.shares = "500";
+	}
+}

--- a/tests/tools/cgconfigparser/cgconfigparser_conf_files_tests
+++ b/tests/tools/cgconfigparser/cgconfigparser_conf_files_tests
@@ -1,0 +1,240 @@
+#!/bin/bash
+# this script tests the examples 1-4 from cgconfig.conf man pages
+# - for each one tests whether the configuration which is created using described configuration
+# file is identical with the example described below
+# TODO: Example 5 is missing now
+
+
+. `dirname $0`/../testenv.sh
+
+CONFDIR=$TESTDIR/tools/cgconfigparser/cgconfigparser_conf_files
+
+# all mount points are in /$TMP/cgroups
+mkdir /$TMP/cgroups/ 2>/dev/null
+#-----------------------------------------------------------------------------
+# EXAMPLE 1
+#-----------------------------------------------------------------------------
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/cgconfig.conf.5.ex1` || \
+	die "cgconfigparser -l $CONFDIR/cgconfig.conf.5.ex1 failed"
+
+$TOOLSDIR/cgsnapshot  -b $CONFIGDIR/cgsnapshot_blacklist.conf -s \
+	 >/$TMP/temp.conf || die "example1 cgsnapshot failed"
+
+lssubsys_1=`$TOOLSDIR/lssubsys -m`
+
+$TOOLSDIR/cgclear || \
+	die "example1 1st cgclear failed"
+
+# cgsnapshot sanity test
+$TOOLSDIR/cgconfigparser -l /$TMP/temp.conf || \
+	die "example1 cgconfigparser failed"
+
+lssubsys_2=`$TOOLSDIR/lssubsys -m`
+
+$TOOLSDIR/cgclear || \
+	die "example1 2st cgclear failed"
+
+if [ "$lssubsys_1" != "$lssubsys_2" ]; then
+    echo "ERROR(example1): lssubsys_1='$lssubsys_1', lssubsys_2='$lssubsys_2'"
+    die "example1 failed"
+fi
+
+# cgconfigparser test
+mkdir /$TMP/cgroups/cpu 2>/dev/null
+mount -t cgroup -o cpu,cpuacct cpu $TMP/cgroups/cpu || die "example1 Mount failed"
+lssubsys_3=`lssubsys -m`
+$TOOLSDIR/cgclear || die "example1 3rd cgclear failed"
+
+if [ "$lssubsys_1" != "$lssubsys_3" ]; then
+    echo "ERROR(example1): lssubsys_1='$lssubsys_1', lssubsys_3='$lssubsys_3'"
+    die "example1 failed"
+fi
+
+#-----------------------------------------------------------------------------
+# EXAMPLE 2
+#-----------------------------------------------------------------------------
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/cgconfig.conf.5.ex2` || \
+    die "cgconfigparser -l $CONFDIR/cgconfig.conf.5.ex2 failed"
+
+val1=`$TOOLSDIR/cgget -nv -r cpu.shares daemons/ftp`;
+val2=`$TOOLSDIR/cgget -nv -r cpu.shares daemons/www`;
+
+
+if [ $val1 -ne 500 ]; then
+    echo "ERROR(example2): bogus variable setting daemons/ftp/cpu.shares $val1 "\
+        "(should be 500)"
+    die "example2 failed"
+fi
+
+if [ $val2 -ne 1000 ]; then
+    echo "ERROR(example2): bogus variable setting daemons/www/cpu.shares $val2 "\
+        "(should be 1000)"
+    die "example2 failed"
+fi
+
+$TOOLSDIR/cgsnapshot  -b $CONFIGDIR/cgsnapshot_blacklist.conf -s >\
+	/$TMP/temp.conf || die "example2 cgsnapshot failed"
+
+lssubsys_1=`$TOOLSDIR/lssubsys -m`
+$TOOLSDIR/cgclear || die "example2 1st cgclear failed"
+
+
+# cgsnapshot sanity test
+$TOOLSDIR/cgconfigparser -l /$TMP/temp.conf || \
+	die "example2 cgconfigparser of cgsnapshot file failed"
+
+lssubsys_2=`$TOOLSDIR/lssubsys -m`
+val1=`$TOOLSDIR/cgget -nv -r cpu.shares daemons/ftp`;
+val2=`$TOOLSDIR/cgget -nv -r cpu.shares daemons/www`;
+$TOOLSDIR/cgclear || die "example2 2st cgclear failed"
+
+if [ "$lssubsys_1" != "$lssubsys_2" ]; then
+    echo "ERROR(example2): lssubsys_1='$lssubsys_1', lssubsys_2='$lssubsys_2'"
+    die "example2 failed"
+fi
+
+
+if [ $val1 -ne 500 ]; then
+    echo "ERROR(example2): bogus variable setting daemons/ftp/cpu.shares $val1 "\
+    "(should be 500)"
+   die "example2 failed"
+fi
+
+if [ $val2 -ne 1000 ]; then
+    echo "ERROR(example2): bogus variable setting daemons/www/cpu.shares $val2 "\
+    "(should be 1000)"
+    die "example2 failed"
+fi
+
+# cgconfigparser test
+mkdir /$TMP/cgroups/cpu 2>/dev/null
+mount -t cgroup -o cpu,cpuacct cpu /$TMP/cgroups/cpu ||
+    die "example2 mount failed"
+mkdir /$TMP/cgroups/cpu/daemons 2>/dev/null
+
+mkdir /$TMP/cgroups/cpu/daemons/www 2>/dev/null
+echo 1000 > /$TMP/cgroups/cpu/daemons/www/cpu.shares ||
+    die "example2 var.setting failed"
+
+mkdir /$TMP/cgroups/cpu/daemons/ftp 2>/dev/null
+echo 500 > /$TMP/cgroups/cpu/daemons/ftp/cpu.shares ||
+    die "example2 var.setting failed"
+
+lssubsys_3=`$TOOLSDIR/lssubsys -m`
+$TOOLSDIR/cgclear || die "example2 3rd cgclear failed"
+
+
+if [ "$lssubsys_1" != "$lssubsys_3" ]; then
+    echo "ERROR(example1): lssubsys_1='$lssubsys_1', lssubsys_3='lssubsys_3'"
+    die "example2 failed"
+fi
+
+#-----------------------------------------------------------------------------
+# EXAMPLE 3
+#-----------------------------------------------------------------------------
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/cgconfig.conf.5.ex3` || \
+    die "cgconfigparser -l $CONFDIR/cgconfig.conf.5.ex3 failed"
+
+$TOOLSDIR/cgsnapshot -b $CONFIGDIR/cgsnapshot_blacklist.conf  \
+    -s >/$TMP/temp.conf || die "example3 cgsnapshot failed"
+lssubsys_1=`$TOOLSDIR/lssubsys -m`
+lscg1=`$TOOLSDIR/lscgroup`
+$TOOLSDIR/cgclear || die "example3 1st cgclear failed"
+
+# cgsnapshot sanity test
+$TOOLSDIR/cgconfigparser -l /$TMP/temp.conf || die "example3 cgconfigparser failed"
+lssubsys_2=`$TOOLSDIR/lssubsys -m`
+lscg2=`$TOOLSDIR/lscgroup`
+$TOOLSDIR/cgclear || die "example3 2st cgclear failed"
+
+if [ "$lssubsys_1" != "$lssubsys_2" ]; then
+    echo "ERROR(example3): lssubsys_1='$lssubsys_1', lssubsys_='$lssubsys_2'"
+    die "example3 failed"
+fi
+
+
+if [ "$lscg1" != "$lscg2" ]; then
+    echo "ERROR(example3): lscg1='$lscg1', lscg2='$lscg2'"
+    die "example3 failed"
+fi
+
+# cgconfigparser test
+mkdir /$TMP/cgroups/cpu 2>/dev/null
+mkdir /$TMP/cgroups/cpuacct 2>/dev/null
+mount -t cgroup -o cpu cpu /$TMP/cgroups/cpu || die "example3 Mount1 failed"
+mount -t cgroup -o cpuacct cpuacct /$TMP/cgroups/cpuacct || die "example3 Mount2 failed"
+
+mkdir /$TMP/cgroups/cpu/daemons 2>/dev/null
+mkdir /$TMP/cgroups/cpuacct/daemons 2>/dev/null
+
+lssubsys_3=`$TOOLSDIR/lssubsys -m`
+lscg3=`$TOOLSDIR/lscgroup`
+$TOOLSDIR/cgclear || die "example3 3rd cgclear failed"
+
+if [ "$lssubsys_1" != "$lssubsys_3" ]; then
+    echo "ERROR(example3): lssubsys_1='$lssubsys_1', lssubsys_3='$lssubsys_3'"
+    die "example3 failed"
+fi
+
+if [ "$lscg1" != "$lscg3" ]; then
+    echo "ERROR(example3): lscg1='$lscg1', lscg3='$lscg3'"
+    die "example3 failed"
+fi
+
+#-----------------------------------------------------------------------------
+# EXAMPLE 4
+#-----------------------------------------------------------------------------
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/cgconfig.conf.5.ex4` || \
+    die "cgconfigparser -l $CONFDIR/cgconfig.conf.5.ex4 failed"
+
+$TOOLSDIR/cgsnapshot -b $CONFIGDIR/cgsnapshot_blacklist.conf -s \
+    >/$TMP/temp.conf || die "example4 cgsnapshot failed"
+lssubsys_1=`$TOOLSDIR/lssubsys -m`
+lscg1=`$TOOLSDIR/lscgroup | sort`
+$TOOLSDIR/cgclear || die "example4 1st cgclear failed"
+
+# cgsnapshot sanity test
+$TOOLSDIR/cgconfigparser -l /$TMP/temp.conf || die "example4 cgconfigparser failed"
+lssubsys_2=`$TOOLSDIR/lssubsys -m`
+lscg2=`$TOOLSDIR/lscgroup| sort`
+$TOOLSDIR/cgclear || die "example4 2st cgclear failed"
+
+if [ "$lssubsys_1" != "$lssubsys_2" ]; then
+    echo "ERROR(example4): lssubsys_1='$lssubsys_1', lssubsys_2='$lssubsys_2'"
+    die "example4 failed"
+fi
+
+if [ "$lscg1" != "$lscg2" ]; then
+    echo "ERROR(example4): lscg1='$lscg1', lscg2='$lscg2'"
+    die "example4 failed"
+fi
+
+# cgconfigparser test
+mkdir /$TMP/cgroups/cpu 2>/dev/null
+mkdir /$TMP/cgroups/cpuacct 2>/dev/null
+mount -t cgroup -o cpu cpu /$TMP/cgroups/cpu || die "example4 Mount1 failed"
+mount -t cgroup -o cpuacct cpuacct /$TMP/cgroups/cpuacct || die "example4 Mount2 failed"
+
+mkdir /$TMP/cgroups/cpuacct/daemons 2>/dev/null
+mkdir /$TMP/cgroups/cpu/daemons 2>/dev/null
+mkdir /$TMP/cgroups/cpu/daemons/www 2>/dev/null
+mkdir /$TMP/cgroups/cpu/daemons/ftp 2>/dev/null
+
+lssubsys_3=`$TOOLSDIR/lssubsys -m`
+lscg3=`$TOOLSDIR/lscgroup | sort`
+cgclear || die "example3 3rd cgclear failed"
+
+
+if [ "$lssubsys_1" != "$lssubsys_3" ]; then
+    echo "ERROR(example4): lssubsys_1='$lssubsys_1', lssubsys_3='$lssubsys_3'"
+    die "example4 failed"
+fi
+
+if [ "$lscg1" != "$lscg3" ]; then
+    echo "ERROR(example4): lscg1='$lscg1', lscg3='$lscg3'"
+    die "example4 failed"
+fi
+
+
+cleanup
+exit 0

--- a/tests/tools/cgconfigparser/cgconfigparser_multiconfig
+++ b/tests/tools/cgconfigparser/cgconfigparser_multiconfig
@@ -1,0 +1,41 @@
+#!/bin/bash
+# test cgconfigparser with multiple config files
+
+. `dirname $0`/../testenv.sh
+
+# prepare config files in a temporary directory
+mkdir -p $TMP/conf.d
+for i in $TESTDIR/tools/cgconfigparser/multiconfig/*.conf; do
+	mv `prepare_config $i` $TMP/conf.d/
+done
+
+$TOOLSDIR/cgconfigparser -L $TMP/conf.d/ \
+	|| die "cgconfigparser failed"
+
+# check that all expected groups exist
+$TOOLSDIR/lscgroup > $TMP/groups.out
+grep "cpu,cpuacct:/1$" <$TMP/groups.out >/dev/null \
+	|| die "cannot find group 1"
+grep "freezer:/22$" <$TMP/groups.out >/dev/null \
+	|| die "cannot find group 2"
+grep "net_cls:/333$" <$TMP/groups.out >/dev/null \
+	|| die "cannot find group 3"
+grep "cpu,cpuacct:/1/4$" <$TMP/groups.out >/dev/null \
+	|| die "cannot find group 1/4"
+grep "freezer:/22/4$" <$TMP/groups.out >/dev/null \
+	|| die "cannot find group 22/4"
+grep "net_cls:/333/4$" <$TMP/groups.out >/dev/null \
+	|| die "cannot find group 333/4"
+grep "cpu,cpuacct:/5$" <$TMP/groups.out >/dev/null \
+	|| die "cannot find group 5"
+grep "freezer:/55$" <$TMP/groups.out >/dev/null \
+	|| die "cannot find group 55"
+grep "net_cls:/555$" <$TMP/groups.out >/dev/null \
+	|| die "cannot find group 555"
+
+# clear it at once
+$TOOLSDIR/cgclear -e -L $TMP/conf.d/ \
+	|| die "cgclear failed"
+
+cleanup
+exit 0

--- a/tests/tools/cgconfigparser/cgconfigparser_simple
+++ b/tests/tools/cgconfigparser/cgconfigparser_simple
@@ -1,0 +1,23 @@
+#!/bin/bash
+# simple sanity test for cgconfigparser, cgsnapshot and cgclear tool
+
+. `dirname $0`/../testenv.sh
+
+
+mkdir -p /$TMP/cgroups/cpu 2>/dev/null
+mount -t cgroup -o cpu,cpuacct cpu /$TMP/cgroups/cpu || die "Mount failed"
+
+$TOOLSDIR/cgsnapshot -b $CONFIGDIR/cgsnapshot_blacklist.conf >/$TMP/temp.conf || die "cgsnapshot failed"
+lss_o1=`$TOOLSDIR/lssubsys -m`
+$TOOLSDIR/cgclear || die "1st cgclear failed"
+
+$TOOLSDIR/cgconfigparser -l /$TMP/temp.conf || die "cgconfigparser failed"
+lss_o2=`$TOOLSDIR/lssubsys -m`
+$TOOLSDIR/cgclear || die "2nd cgclear failed"
+
+if [ "$lss_o1" != "$lss_o2" ]; then
+     echo "ERROR: first lss ouptput:'$lss_o1', second lss output:'$lss_o2'"
+fi
+
+cleanup
+exit 0

--- a/tests/tools/cgconfigparser/multiconfig/1.conf
+++ b/tests/tools/cgconfigparser/multiconfig/1.conf
@@ -1,0 +1,9 @@
+mount {
+    cpu = /TMP/cgroups/cpu;
+    cpuacct = /TMP/cgroups/cpu;
+}
+
+group 1 {
+    cpu { }
+}
+

--- a/tests/tools/cgconfigparser/multiconfig/2.conf
+++ b/tests/tools/cgconfigparser/multiconfig/2.conf
@@ -1,0 +1,12 @@
+mount {
+    freezer = /TMP/cgroups/freezer;
+}
+
+# check that cpu is already mounted
+group 2 {
+    cpu { }
+}
+
+group 22 {
+    freezer { }
+}

--- a/tests/tools/cgconfigparser/multiconfig/3.conf
+++ b/tests/tools/cgconfigparser/multiconfig/3.conf
@@ -1,0 +1,17 @@
+mount {
+    net_cls = /TMP/cgroups/net;
+}
+
+# check that cpu is already mounted
+group 3 {
+    cpu { }
+}
+
+# check that freezer is already mounted
+group 33 {
+    freezer { }
+}
+
+group 333 {
+    net_cls { }
+}

--- a/tests/tools/cgconfigparser/multiconfig/4.conf
+++ b/tests/tools/cgconfigparser/multiconfig/4.conf
@@ -1,0 +1,12 @@
+# now with a namespace
+namespace {
+    cpu=1;
+    cpuacct=1;
+    freezer=22;
+    net_cls=333;
+}
+group 4 {
+    cpu { }
+    freezer { }
+    net_cls { }
+}

--- a/tests/tools/cgconfigparser/multiconfig/5.conf
+++ b/tests/tools/cgconfigparser/multiconfig/5.conf
@@ -1,0 +1,12 @@
+# now without mount section
+group 5 {
+    cpu { }
+}
+
+group 55 {
+    freezer { }
+}
+
+group 555 {
+    net_cls { }
+}

--- a/tests/tools/cgconfigparser/permissions
+++ b/tests/tools/cgconfigparser/permissions
@@ -1,0 +1,177 @@
+#!/bin/bash
+# this script tests fperm and dperm configuration options
+
+
+. `dirname $0`/../testenv.sh
+
+CONFDIR=$TESTDIR/tools/cgconfigparser/cgconfigparser_conf_files
+
+# permissions test
+function check_perm()
+{
+    STEP=$1
+    FILENAME=$2
+    EXPECTED_PERM=$3
+    EXPECTED_UID=$4
+    EXPECTED_GID=$5
+    REAL_PERM=`stat -c "%a" $FILENAME`
+    REAL_UID=`stat -c "%U" $FILENAME`
+    REAL_GID=`stat -c "%G" $FILENAME`
+    if [ "$EXPECTED_PERM" != "$REAL_PERM" ]; then
+        die "$STEP: Wrong permissions of $FILENAME,"\
+            " expected $EXPECTED_PERM, actual $REAL_PERM"
+    fi
+    if [ "$EXPECTED_UID" != "$REAL_UID" ]; then
+        die "$STEP: Wrong uid of $FILENAME,"\
+            " expected $EXPECTED_UID, actual $REAL_UID"
+    fi
+    if [ "$EXPECTED_GID" != "$REAL_GID" ]; then
+        die "$STEP: Wrong gid of $FILENAME,"\
+            " expected $EXPECTED_GID, actual $REAL_GID"
+    fi
+}
+
+# all mount points are in /$TMP/cgroups
+mkdir /$TMP/cgroups/ 2>/dev/null
+
+# STEP1: simple config file without default section
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/permissions.conf` || \
+    die "STEP1: cgconfigparser -l $CONFDIR/permissions.conf failed"
+check_perm "STEP1" "/$TMP/cgroups/cpu/daemons/www" 770 root root
+check_perm "STEP1" "/$TMP/cgroups/cpu/daemons/www/cpu.shares" 666 root root
+check_perm "STEP1" "/$TMP/cgroups/cpu/daemons/www/tasks" 640 root nobody
+
+check_perm "STEP1" "/$TMP/cgroups/cpu/daemons/ftp" 742 root root
+check_perm "STEP1" "/$TMP/cgroups/cpu/daemons/ftp/cpu.shares" 426 root root
+check_perm "STEP1" "/$TMP/cgroups/cpu/daemons/ftp/tasks" 264 root nobody
+
+$TOOLSDIR/cgclear || die "STEP1: cgclear failed"
+
+# STEP2: config file with one default section
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/permissions_default1.conf` || \
+    die "STEP2: cgconfigparser -l $CONFDIR/permissions_default1.conf failed"
+
+check_perm "STEP2" "/$TMP/cgroups/cpu/daemons/www" 757 nobody nobody
+check_perm "STEP2" "/$TMP/cgroups/cpu/daemons/www/cpu.shares" 646 nobody nobody
+check_perm "STEP2" "/$TMP/cgroups/cpu/daemons/www/tasks" 646 nobody nobody
+
+check_perm "STEP2" "/$TMP/cgroups/cpu/daemons/ftp" 742 root root
+check_perm "STEP2" "/$TMP/cgroups/cpu/daemons/ftp/cpu.shares" 426 root root
+check_perm "STEP2" "/$TMP/cgroups/cpu/daemons/ftp/tasks" 264 root root
+
+check_perm "STEP2" "/$TMP/cgroups/cpu/daemons/ssh" 757 root nobody
+check_perm "STEP2" "/$TMP/cgroups/cpu/daemons/ssh/cpu.shares" 426 root nobody
+check_perm "STEP2" "/$TMP/cgroups/cpu/daemons/ssh/tasks" 264 root nobody
+
+$TOOLSDIR/cgclear || die "cgclear failed"
+
+# STEP3: config file with two default sections - the last wins
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/permissions_default2.conf` || \
+    die "STEP3: cgconfigparser -l $CONFDIR/permissions_default2.conf failed"
+
+check_perm "STEP3" "/$TMP/cgroups/cpu/daemons/www" 757 nobody nobody
+check_perm "STEP3" "/$TMP/cgroups/cpu/daemons/www/cpu.shares" 646 nobody nobody
+check_perm "STEP3" "/$TMP/cgroups/cpu/daemons/www/tasks" 646 nobody nobody
+
+check_perm "STEP3" "/$TMP/cgroups/cpu/daemons/ftp" 742 root root
+check_perm "STEP3" "/$TMP/cgroups/cpu/daemons/ftp/cpu.shares" 426 root root
+check_perm "STEP3" "/$TMP/cgroups/cpu/daemons/ftp/tasks" 264 root root
+
+check_perm "STEP3" "/$TMP/cgroups/cpu/daemons/ssh" 757 root nobody
+check_perm "STEP3" "/$TMP/cgroups/cpu/daemons/ssh/cpu.shares" 426 root nobody
+check_perm "STEP3" "/$TMP/cgroups/cpu/daemons/ssh/tasks" 264 root nobody
+
+$TOOLSDIR/cgclear || die "cgclear failed"
+
+# STEP4: config file with one default section, now with SUID and SGID bits
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/permissions_default3.conf` || \
+    die "STEP4: cgconfigparser -l $CONFDIR/permissions_default3.conf failed"
+
+check_perm "STEP4" "/$TMP/cgroups/cpu/daemons/www" 2757 nobody nobody
+check_perm "STEP4" "/$TMP/cgroups/cpu/daemons/www/cpu.shares" 7646 nobody nobody
+check_perm "STEP4" "/$TMP/cgroups/cpu/daemons/www/tasks" 1646 nobody nobody
+
+check_perm "STEP4" "/$TMP/cgroups/cpu/daemons/ftp" 742 root root
+check_perm "STEP4" "/$TMP/cgroups/cpu/daemons/ftp/cpu.shares" 426 root root
+check_perm "STEP4" "/$TMP/cgroups/cpu/daemons/ftp/tasks" 264 root root
+
+check_perm "STEP4" "/$TMP/cgroups/cpu/daemons/ssh" 2757 root nobody
+check_perm "STEP4" "/$TMP/cgroups/cpu/daemons/ssh/cpu.shares" 426 root nobody
+check_perm "STEP4" "/$TMP/cgroups/cpu/daemons/ssh/tasks" 264 root nobody
+
+$TOOLSDIR/cgclear || die "cgclear failed"
+
+# STEP5: config file without default section, but with -a -t params
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/permissions_default4.conf` -t nobody:nobody -a nobody:nobody -d 757 -f 757 || \
+    die "STEP5: cgconfigparser -l $CONFDIR/permissions_default4.conf failed"
+
+check_perm "STEP5" "/$TMP/cgroups/cpu/daemons/www" 757 nobody nobody
+check_perm "STEP5" "/$TMP/cgroups/cpu/daemons/www/cpu.shares" 646 nobody nobody
+check_perm "STEP5" "/$TMP/cgroups/cpu/daemons/www/tasks" 644 nobody nobody
+
+check_perm "STEP5" "/$TMP/cgroups/cpu/daemons/ftp" 742 root root
+check_perm "STEP5" "/$TMP/cgroups/cpu/daemons/ftp/cpu.shares" 426 root root
+check_perm "STEP5" "/$TMP/cgroups/cpu/daemons/ftp/tasks" 264 root root
+
+check_perm "STEP5" "/$TMP/cgroups/cpu/daemons/ssh" 757 root nobody
+check_perm "STEP5" "/$TMP/cgroups/cpu/daemons/ssh/cpu.shares" 426 root nobody
+check_perm "STEP5" "/$TMP/cgroups/cpu/daemons/ssh/tasks" 264 root nobody
+
+$TOOLSDIR/cgclear || die "cgclear failed"
+
+# STEP6: config file without default section, but with -a -t params and sticky bit
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/permissions_default4.conf` -t nobody:nobody -a nobody:nobody -d 2757 -f 7757 || \
+    die "STEP6: cgconfigparser -l $CONFDIR/permissions_default4.conf failed"
+
+check_perm "STEP6" "/$TMP/cgroups/cpu/daemons/www" 2757 nobody nobody
+check_perm "STEP6" "/$TMP/cgroups/cpu/daemons/www/cpu.shares" 7646 nobody nobody
+check_perm "STEP6" "/$TMP/cgroups/cpu/daemons/www/tasks" 644 nobody nobody
+
+check_perm "STEP6" "/$TMP/cgroups/cpu/daemons/ftp" 742 root root
+check_perm "STEP6" "/$TMP/cgroups/cpu/daemons/ftp/cpu.shares" 426 root root
+check_perm "STEP6" "/$TMP/cgroups/cpu/daemons/ftp/tasks" 264 root root
+
+check_perm "STEP6" "/$TMP/cgroups/cpu/daemons/ssh" 2757 root nobody
+check_perm "STEP6" "/$TMP/cgroups/cpu/daemons/ssh/cpu.shares" 426 root nobody
+check_perm "STEP6" "/$TMP/cgroups/cpu/daemons/ssh/tasks" 264 root nobody
+
+$TOOLSDIR/cgclear || die "cgclear failed"
+
+# STEP7: config file without default section, but with only -d params (=-f is taken from umask)
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/permissions_default4.conf` -t nobody:nobody -a nobody:nobody -d 757 || \
+    die "STEP7: cgconfigparser -l $CONFDIR/permissions_default4.conf failed"
+
+check_perm "STEP7" "/$TMP/cgroups/cpu/daemons/www" 757 nobody nobody
+check_perm "STEP7" "/$TMP/cgroups/cpu/daemons/www/cpu.shares" 644 nobody nobody
+check_perm "STEP7" "/$TMP/cgroups/cpu/daemons/www/tasks" 644 nobody nobody
+
+check_perm "STEP7" "/$TMP/cgroups/cpu/daemons/ftp" 742 root root
+check_perm "STEP7" "/$TMP/cgroups/cpu/daemons/ftp/cpu.shares" 426 root root
+check_perm "STEP7" "/$TMP/cgroups/cpu/daemons/ftp/tasks" 264 root root
+
+check_perm "STEP7" "/$TMP/cgroups/cpu/daemons/ssh" 757 root nobody
+check_perm "STEP7" "/$TMP/cgroups/cpu/daemons/ssh/cpu.shares" 426 root nobody
+check_perm "STEP7" "/$TMP/cgroups/cpu/daemons/ssh/tasks" 264 root nobody
+
+$TOOLSDIR/cgclear || die "cgclear failed"
+
+# STEP8: config file without default section, but with -f, -d and -t
+$TOOLSDIR/cgconfigparser -l `prepare_config $CONFDIR/permissions_default4.conf` -t nobody:nobody -a nobody:nobody -d 757 -f 757 -s 7247 || \
+    die "STEP8: cgconfigparser -l $CONFDIR/permissions_default4.conf failed"
+
+check_perm "STEP8" "/$TMP/cgroups/cpu/daemons/www" 757 nobody nobody
+check_perm "STEP8" "/$TMP/cgroups/cpu/daemons/www/cpu.shares" 646 nobody nobody
+check_perm "STEP8" "/$TMP/cgroups/cpu/daemons/www/tasks" 7246 nobody nobody
+
+check_perm "STEP8" "/$TMP/cgroups/cpu/daemons/ftp" 742 root root
+check_perm "STEP8" "/$TMP/cgroups/cpu/daemons/ftp/cpu.shares" 426 root root
+check_perm "STEP8" "/$TMP/cgroups/cpu/daemons/ftp/tasks" 264 root root
+
+check_perm "STEP8" "/$TMP/cgroups/cpu/daemons/ssh" 757 root nobody
+check_perm "STEP8" "/$TMP/cgroups/cpu/daemons/ssh/cpu.shares" 426 root nobody
+check_perm "STEP8" "/$TMP/cgroups/cpu/daemons/ssh/tasks" 264 root nobody
+
+$TOOLSDIR/cgclear || die "cgclear failed"
+
+cleanup
+exit 0

--- a/tests/tools/multimount/Makefile.am
+++ b/tests/tools/multimount/Makefile.am
@@ -1,0 +1,5 @@
+EXTRA_DIST = many_mp many_named
+
+# The legacy tests have been disabled because they do not successfully run
+# on Travis CI.
+#TESTS = many_mp  many_named

--- a/tests/tools/multimount/many_mp
+++ b/tests/tools/multimount/many_mp
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Test hierarchies mounted multiple times (one hierarchy mounted 99 times)
+# - cgsnapshot
+# - cgconfigparser
+# - lssubsys
+
+. `dirname $0`/../testenv.sh
+
+# cgconfigparser cannot handle more than 100 mount points :-(
+COUNT=99
+
+function check_config()
+{
+	CONFIG=$1
+	# check basic sanity of generatet cgconfig.conf file
+	#  - it has expected number of mount points
+	if [ `grep '=' < $CONFIG | wc -l` -ne $(($COUNT*4)) ]; then
+		die "wrong number of mount points in $CONFIG"
+	fi
+
+	#  - it has mount section
+	grep "mount" >/dev/null <$CONFIG \
+		|| die "cgsnapshot failed, no mount section found in $CONFIG"
+
+	#  - it has 99 different mount points
+	for i in `seq $COUNT`; do
+		grep "cpuacct$i" >/dev/null <$CONFIG \
+			|| die "cgsnapshot failed, no cpuacct$i found in $CONFIG"
+	done
+}
+
+for i in `seq $COUNT`; do
+	mkdir -p $TMP/cgroups/cpuacct$i 2>/dev/null
+	mount -t cgroup -o cpuacct,cpuset,memory,freezer cpuacct$i \
+			$TMP/cgroups/cpuacct$i \
+		|| die "Mount $i failed"
+done
+
+# check lssubsys
+# plain lssubsys - only one line with 4 controllers is expected
+$TOOLSDIR/lssubsys >$TMP/subsys1.out \
+	|| die "plain lssubsys failed"
+[ `wc -l <$TMP/subsys1.out` -eq 1 ] \
+	|| die "unexpected output of plan lssubsys"
+
+# lssubsys -m - first mount point is returned
+$TOOLSDIR/lssubsys -m >$TMP/subsys2.out \
+	|| die "lssubsys -m failed"
+[ `wc -l <$TMP/subsys2.out` -eq 1 ] \
+	|| die "unexpected output of lssubsys -m"
+grep <$TMP/subsys2.out cpuacct1 >/dev/null \
+	|| die "lssubsys -m does not show the first mount point"
+
+# lssubsys -M - all mount points are returned
+$TOOLSDIR/lssubsys -M >$TMP/subsys3.out \
+	|| die "lssubsys -M failed"
+[ `wc -l <$TMP/subsys3.out` -eq $COUNT ] \
+	|| die "unexpected output of lssubsys -M"
+for i in `seq $COUNT`; do
+	grep <$TMP/subsys3.out cpuacct$i >/dev/null \
+		|| die "lssubsys -m does not show cpuacct$i"
+done
+
+# check cgsnapshot
+$TOOLSDIR/cgsnapshot -b $CONFIGDIR/cgsnapshot_blacklist.conf >$TMP/snapshot.conf \
+	|| die "cgsnapshot failed"
+
+check_config $TMP/snapshot.conf
+
+$TOOLSDIR/cgclear || die "cgclear 1 failed"
+
+# check cgconfigparser - try to parse the generated config
+$TOOLSDIR/cgconfigparser -l $TMP/snapshot.conf \
+	|| die "cgconfigparser failed to parse the snapshot"
+
+# and make its snapshot again
+$TOOLSDIR/cgsnapshot -b $CONFIGDIR/cgsnapshot_blacklist.conf >$TMP/snapshot2.conf \
+	|| die "cgsnapshot2 failed"
+
+check_config $TMP/snapshot2.conf
+
+$TOOLSDIR/cgclear
+
+cleanup
+exit 0

--- a/tests/tools/multimount/many_named
+++ b/tests/tools/multimount/many_named
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Tests named hierarchies, mouted several times
+# - cgsnapshot
+# - cgconfigparser
+# - lssubsys
+
+. `dirname $0`/../testenv.sh
+
+# 10 named hierarchies, each mounted 8 times
+HIERARCHIES=10
+COUNT=8
+
+function check_config()
+{
+	# check basic sanity of the generated file
+	CONFIG=$1
+
+	# it has expected nr. of mount points
+	if [ `grep '=' <$CONFIG | wc -l` -ne $(($COUNT*$HIERARCHIES+3)) ];then
+		die "wrong number of mount points displayed in $CONFIG"
+	fi
+	# it has mount section
+	grep "mount" >/dev/null <$CONFIG \
+		|| die "cgsnapshot failed, no mount section found in $CONFIG"
+	# it has every hierarchy at least once
+	for i in `seq $HIERARCHIES`; do
+		grep "name=$i" >/dev/null <$CONFIG \
+			|| die "cgsnapshot failed, no name=$i found in $CONFIG"
+	done
+	# it has cpuacct,cpuset,name=cputest mount
+	grep "name=cputest" >/dev/null <$CONFIG \
+		|| die "cannot find name=cputest in $CONFIG"
+	grep "cpuacct" >/dev/null <$CONFIG \
+		|| die "cannot find cpuacct in $CONFIG"
+}
+
+for i in `seq $HIERARCHIES`; do
+	for j in `seq $COUNT`; do
+		mkdir -p $TMP/cgroups/named$i-$j 2>/dev/null
+		mount -t cgroup -o none,name=$i named$i \
+			$TMP/cgroups/named$i-$j \
+			|| die "Mount $i_$j failed"
+	done
+done
+
+# add one named mount point with other controllers
+mkdir -p $TMP/cgroups/cpu 2>/dev/null
+mount -t cgroup -o cpuset,cpuacct,name=cputest test $TMP/cgroups/cpu \
+		|| die "Mount cpu failed"
+
+# !!! lssubsys does NOT support named hierarchies now !!!
+# check lssubsys
+# plain lssubsys - every hierarchy only once
+#$TOOLSDIR/lssubsys >$TMP/subsys1.out \
+#	|| die "plain lssubsys failed"
+#[ `wc -l <$TMP/subsys1.out` -eq $(( $HIERARCHIES+1 )) ] \
+#	|| die "unexpected output of plain lssubsys"
+
+# lssubsys -m - first mount point is returned
+#$TOOLSDIR/lssubsys -m >$TMP/subsys2.out \
+#	|| die "lssubsys -m failed"
+#[ `wc -l <$TMP/subsys2.out` -eq $(( $HIERARCHIES+1 )) ] \
+#	|| die "unexpected output of lssubsys -m"
+#grep <$TMP/subsys2.out cgroups/cpu >/dev/null \
+#	|| die "lssubsys -m does not show the first mount point for cputest"
+#for i in `seq $HIERARCHIES`; do
+#	grep <$TMP/subsys2.out cgroups/named$i-1 >/dev/null \
+#		|| die "lssubsys -m does not show cgroups/named$i-1"
+#done
+
+# lssubsys -M - all mount points are returned
+#$TOOLSDIR/lssubsys -M >$TMP/subsys3.out \
+#	|| die "lssubsys -M failed"
+#[ `wc -l <$TMP/subsys3.out` -eq $(( $COUNT*$HIERARCHIES+1)) ] \
+#	|| die "unexpected output of lssubsys -M"
+#for i in `seq $HIERARCHIES`; do
+#	for j in `seq $COUNT`; do
+#		grep <$TMP/subsys3.out cgroups/named$i-$j >/dev/null \
+#		|| die "lssubsys -m does not show cgroups/named$i-$j"
+#	done
+#done
+
+$TOOLSDIR/cgsnapshot -b $CONFIGDIR/cgsnapshot_blacklist.conf >$TMP/snapshot.conf \
+	|| die "cgsnapshot failed"
+
+check_config $TMP/snapshot.conf
+
+$TOOLSDIR/cgclear || die "cgclear 1 failed"
+
+# try to parse the config...
+$TOOLSDIR/cgconfigparser -l $TMP/snapshot.conf \
+	|| die "cgconfigparser failed to parse the snapshot"
+# and make its snapshot again
+$TOOLSDIR/cgsnapshot -b $CONFIGDIR/cgsnapshot_blacklist.conf >$TMP/snapshot2.conf \
+	|| die "cgsnapshot2 failed"
+
+check_config $TMP/snapshot2.conf
+
+$TOOLSDIR/cgclear
+
+cleanup
+exit 0

--- a/tests/tools/testenv.sh.in
+++ b/tests/tools/testenv.sh.in
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Simple test framework for libcgroup.
+# Upon loading it does following:
+#  - sets $TMP, where all temporary files should be stored.
+#  - backs-up /etc/cgrules.conf in the $TMP
+#    (so it does not interfere with tests)
+#
+# Function cleanup() or die() must be called to destroy this temporary
+# directory and restore previous cgrules.conf!
+#
+# Usage:
+# . ./testenv.sh
+# <do some testing>
+# cleanup
+# exit 0
+
+# Print an error message and exit
+# Usage:
+#   cgclear || die "cgclear failed"
+function die()
+{
+	echo $*
+	@abs_top_srcdir@/libtool --mode=execute @abs_top_srcdir@/src/tools/cgclear
+	if [ -e $TMP/cgrules-backup.conf ]; then
+		mv $TMP/cgrules-backup.conf /etc/cgrules.conf &>/dev/null
+	else
+		rm /etc/cgrules.conf &>/dev/null
+	fi
+	rm -rf $TMP
+	unset TMP
+	exit 1
+}
+
+# Clear everything that was created at loading this script, i.e.
+# remove the temporary directory
+# In addition, check that nothing remained mounted.
+# Usage:
+#   cleanup
+function cleanup()
+{
+	RET=0
+	grep -v systemd </proc/mounts >$TMP/mounts
+	if grep "^cgroup" $TMP/mounts &>/dev/null; then
+		echo "Error: cleanup has found mounted cgroup:"
+		grep cgroup /proc/mounts
+		RET=1
+		cgclear
+	fi
+	if [ -e $TMP/cgrules-backup.conf ]; then
+		mv $TMP/cgrules-backup.conf /etc/cgrules.conf &>/dev/null
+	else
+		rm /etc/cgrules.conf &>/dev/null
+	fi
+	rm -rf $TMP
+	unset TMP
+	[ -z $RET ] || exit $RET
+}
+
+# Copies a file to $TMP and replaces all occurrences of TMP in the file with
+# value of $TMP. The function prints the name of the new file to its std.
+# output.
+# Usage:
+#    cgconfigparser -l `prepare_config config/sample.conf`
+function prepare_config()
+{
+	INPUT=$1
+	OUTPUT=$TMP/`basename $INPUT`
+	# echo -n "m4_changequote()" | m4 -P -D "TMP=$TMP" - $FILE >$OUTPUT
+	sed -e "s!\bTMP\b!$TMP!g" <$INPUT >$OUTPUT || (
+		echo "Error: prepare config failed!" >&2; exit 1
+	)
+	echo $OUTPUT
+}
+
+export TMP=`mktemp --tmpdir -d libcgroup-tmp-XXXXXXX`
+# store the rules on safe place, we don't want them to mess up the tests
+mv /etc/cgrules.conf $TMP/cgrules-backup.conf &>/dev/null
+# tools directory
+export TOOLSDIR="@abs_top_srcdir@/libtool --mode=execute @abs_top_srcdir@/src/tools/"
+# config files directory
+export CONFIGDIR="@abs_top_srcdir@/samples"
+# test directory
+export TESTDIR="@abs_top_srcdir@/tests"

--- a/tests/walk_task.c
+++ b/tests/walk_task.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <libcgroup.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+int main(int argc, char *argv[])
+{
+	int ret, i;
+	char *group = NULL;
+	void *handle;
+
+	if (argc < 2) {
+		printf("No list of groups provided\n");
+		return -1;
+	}
+
+	ret = cgroup_init();
+
+	if (ret) {
+		printf("cgroup_init failed with %s\n", cgroup_strerror(ret));
+		return -1;
+	}
+
+	for (i = 1; i < argc; i++) {
+		pid_t pid;
+		group = strdup(argv[i]);
+		printf("Printing the details of groups %s\n", group);
+		ret = cgroup_get_task_begin(group, "cpu", &handle, &pid);
+		while (!ret) {
+			printf("Pid is %u\n", pid);
+			ret = cgroup_get_task_next(&handle, &pid);
+			if (ret && ret != ECGEOF) {
+				printf("cgroup_get_task_next failed with %s\n",
+							cgroup_strerror(ret));
+				if (ret == ECGOTHER)
+					printf("failure with %s\n",
+							strerror(errno));
+				return -1;
+			}
+		}
+		free(group);
+		group = NULL;
+		ret = cgroup_get_task_end(&handle);
+	}
+
+	return 0;
+
+}

--- a/tests/walk_test.c
+++ b/tests/walk_test.c
@@ -1,0 +1,121 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+#include <libcgroup.h>
+
+void visit_node(struct cgroup_file_info *info, char *root)
+{
+	if (info->type == CGROUP_FILE_TYPE_DIR) {
+		printf("path %s, parent %s, relative %s, full %s\n",
+			info->path, info->parent, info->full_path +
+				+ strlen(root) - 1,
+				info->full_path);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	char *controller;
+	void *handle;
+	struct cgroup_file_info info;
+	char root[FILENAME_MAX];
+	int lvl, i;
+
+	if (argc < 2) {
+		fprintf(stderr, "Usage %s: <controller name>\n",
+			argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	controller = argv[1];
+
+	ret = cgroup_init();
+	if (ret != 0) {
+		fprintf(stderr, "Init failed\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ret = cgroup_walk_tree_begin(controller, "/", 0, &handle, &info, &lvl);
+
+	if (ret != 0) {
+		fprintf(stderr, "Walk failed\n");
+		exit(EXIT_FAILURE);
+	}
+	strcpy(root, info.full_path);
+	printf("Begin pre-order walk\n");
+	printf("root is %s\n", root);
+	visit_node(&info, root);
+	while ((ret = cgroup_walk_tree_next(0, &handle, &info, lvl)) !=
+			ECGEOF) {
+		visit_node(&info, root);
+	}
+	cgroup_walk_tree_end(&handle);
+
+	printf("pre-order walk finished\n");
+	ret = cgroup_walk_tree_begin(controller, "/", 0, &handle, &info, &lvl);
+
+	if (ret != 0) {
+		fprintf(stderr, "Walk failed\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ret = cgroup_walk_tree_set_flags(&handle, CGROUP_WALK_TYPE_POST_DIR);
+
+	if (ret) {
+		fprintf(stderr, "Walk failed with %s\n", cgroup_strerror(ret));
+		exit(EXIT_FAILURE);
+	}
+
+	strcpy(root, info.full_path);
+	printf("Begin post-order walk\n");
+	printf("root is %s\n", root);
+	visit_node(&info, root);
+	while ((ret = cgroup_walk_tree_next(0, &handle, &info, lvl)) !=
+			ECGEOF) {
+		visit_node(&info, root);
+	}
+	cgroup_walk_tree_end(&handle);
+	printf("post order walk finished\n");
+
+	ret = cgroup_walk_tree_begin(controller, "/a", 2, &handle, &info, &lvl);
+
+	if (ret != 0) {
+		fprintf(stderr, "Walk failed\n");
+		exit(EXIT_FAILURE);
+	}
+	strcpy(root, info.full_path);
+	printf("root is %s\n", root);
+	visit_node(&info, root);
+	while ((ret = cgroup_walk_tree_next(2, &handle, &info, lvl)) !=
+			ECGEOF) {
+		visit_node(&info, root);
+	}
+	cgroup_walk_tree_end(&handle);
+
+	/*
+	 * Walk only the first five nodes
+	 */
+	i = 0;
+	printf("Walking the first 5 nodes\n");
+	ret = cgroup_walk_tree_begin(controller, "/", 0, &handle, &info, &lvl);
+
+	if (ret != 0) {
+		fprintf(stderr, "Walk failed\n");
+		exit(EXIT_FAILURE);
+	}
+	strcpy(root, info.full_path);
+	printf("root is %s\n", root);
+	visit_node(&info, root);
+	i++;
+	while ((ret = cgroup_walk_tree_next(0, &handle, &info, lvl)) !=
+			ECGEOF) {
+		visit_node(&info, root);
+		if (++i >= 5)
+			break;
+	}
+	cgroup_walk_tree_end(&handle);
+	return EXIT_SUCCESS;
+}

--- a/tests/wrapper_test.c
+++ b/tests/wrapper_test.c
@@ -1,0 +1,44 @@
+#include <libcgroup.h>
+#include <stdio.h>
+#include <string.h>
+#include "../src/libcgroup-internal.h"
+
+int main()
+{
+	struct cgroup *cgroup;
+	struct cgroup_controller *cgc;
+	int fail = 0;
+
+	cgroup = cgroup_new_cgroup("test");
+	cgc = cgroup_add_controller(cgroup, "cpu");
+
+	cgroup_add_value_int64(cgc, "cpu.shares", 2048);
+	cgroup_add_value_uint64(cgc, "cpu.something", 1000);
+	cgroup_add_value_bool(cgc, "cpu.bool", 1);
+
+	if (!strcmp(cgroup->controller[0]->values[0]->name, "cpu.shares")) {
+		if (strcmp(cgroup->controller[0]->values[0]->value, "2048")) {
+			printf("FAIL for add_value_int\n");
+			fail = 1;
+		}
+	}
+
+	if (!strcmp(cgroup->controller[0]->values[1]->name, "cpu.something")) {
+		if (strcmp(cgroup->controller[0]->values[1]->value, "1000")) {
+			printf("FAIL for add_value_uint\n");
+			fail = 1;
+		}
+	}
+
+	if (!strcmp(cgroup->controller[0]->values[2]->name, "cpu.bool")) {
+		if (strcmp(cgroup->controller[0]->values[2]->value, "1")) {
+			printf("FAIL for add_value_bool\n");
+			fail = 1;
+		}
+	}
+
+	if (!fail)
+		printf("PASS!\n");
+
+	return fail;
+}


### PR DESCRIPTION
Merge the libcgroup-tests repo back into the main libcgroup repo. The submodules logic has been deleted and the tests are now directly hosted within the libcgroup repo.  This pull request is for the release-2.0 branch