### PR TITLE
Merge libcgroup-tests repo back into libcgroup repo [release-3.0]

### DIFF
--- a/.github/actions/setup-libcgroup/action.yml
+++ b/.github/actions/setup-libcgroup/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
   - run: sudo apt-get update
     shell: bash
-  - run: sudo apt-get install libpam-dev lcov python3-pip python3-dev
+  - run: sudo apt-get install libpam-dev lcov python3-pip python3-dev cmake bison flex byacc g++ autoconf automake libtool -y
     shell: bash
   - run: sudo pip install cython
     shell: bash

--- a/.github/actions/setup-libcgroup/action.yml
+++ b/.github/actions/setup-libcgroup/action.yml
@@ -1,7 +1,7 @@
 #
 # Action to setup the libcgroup directory
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -29,8 +29,6 @@ runs:
   - run: sudo apt-get install libpam-dev lcov python3-pip python3-dev
     shell: bash
   - run: sudo pip install cython
-    shell: bash
-  - run: rm -fr tests/
     shell: bash
   - run: ./bootstrap.sh
     shell: bash

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = googletest
 	url = https://github.com/google/googletest.git
 	fetchRecurseSubmodules = true
-[submodule "tests"]
-	path = tests
-	url = https://github.com/libcgroup/libcgroup-tests.git

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,11 +12,6 @@ fi
 # update the git submodules - libcgroup-tests and googletest
 git submodule update --init --recursive
 
-# configure libcgroup-tests
-pushd tests
-git checkout main
-popd
-
 # configure googletest
 pushd googletest/googletest
 git checkout release-1.8.0

--- a/tests/.github/actions/setup-libcgroup/action.yml
+++ b/tests/.github/actions/setup-libcgroup/action.yml
@@ -1,0 +1,70 @@
+#
+# Action to setup the libcgroup directory
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+name: Setup the libcgroup directory
+description: "Install dependencies, git clone, bootstrap, configure, and make libcgroup"
+runs:
+  using: "composite"
+  steps:
+  - run: sudo apt-get update
+    shell: bash
+  - run: sudo apt-get install libpam-dev lcov python3-pip python3-dev
+    shell: bash
+  - run: sudo pip install cython
+    shell: bash
+  - run: rm -fr tests/
+    shell: bash
+  - run: |
+      mkdir -p tests
+      mv Makefile.am tests/
+      mv ftests/ tests/
+      mv gunit/ tests/
+      mv .gitmodules tests/
+      mv .git tests/
+    shell: bash
+  - run: git clone https://github.com/libcgroup/libcgroup libcg
+    shell: bash
+  - run: |
+      rm -rf libcg/.github
+      rm -fr libcg/tests
+      mv libcg/* ./
+      mv libcg/.gitmodules ./
+      mv libcg/.git ./
+    shell: bash
+  - run: |
+      git submodule update --init --recursive -- googletest
+      pushd googletest/googletest
+      git checkout release-1.8.0
+      cmake -DBUILD_SHARED_LIBS=ON .
+      make
+      popd
+    shell: bash
+  - run: |
+      test -d m4 || mkdir m4
+      autoreconf -fi
+      rm -fr autom4te.cache
+    shell: bash
+  - run: CFLAGS="$CFLAGS -g -O0 -Werror" ./configure --sysconfdir=/etc --localstatedir=/var --enable-code-coverage --enable-opaque-hierarchy="name=systemd" --enable-python
+    shell: bash
+  - run: make
+    shell: bash
+  - run: lcov -i -d . -c -o lcov.base
+    shell: bash

--- a/tests/.github/workflows/continuous-integration.yml
+++ b/tests/.github/workflows/continuous-integration.yml
@@ -1,0 +1,166 @@
+#
+# Continuous Integration Workflow for libcgroup-tests
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+name: Continuous Integration
+on: ["push", "pull_request"]
+
+jobs:
+  flake8-lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: flake8 Lint
+        uses: reviewdog/action-flake8@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Thanks to github user @martyrs
+  # https://github.community/t/how-to-properly-clean-up-self-hosted-runners/128909/3
+  cleaner:
+    name: Delete Self-Hosted Runner Workspaces
+    runs-on: self-hosted
+    steps:
+      - name: Delete workspace path
+        run: |
+          echo "Cleaning up previous run"
+          rm -rf "${{ github.workspace }}"
+
+  unittests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Initialize the directory
+      uses: ./.github/actions/setup-libcgroup
+    - name: Run unit tests
+      run: |
+        pushd tests/gunit
+        make check
+        popd
+    - name: Display test logs
+      if: ${{ always() }}
+      run: cat tests/gunit/test-suite.log
+
+  functionaltestsv1:
+    name: Cgroup v1 Functional Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install container dependencies
+      run: sudo apt-get install lxc lxd
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Initialize the directory
+      uses: ./.github/actions/setup-libcgroup
+    - name: Run functional tests
+      run: |
+        # The cgroup v1 runner hosted by Github Actions doesn't allow
+        # for exclusive cpusets.  Thus, skip the cpuset automated test
+        pushd src/python/build/lib.*
+        export PYTHONPATH=$PYTHONPATH:$(pwd)
+        popd
+        pushd tests/ftests
+        ./ftests.py -l 10 -L ftests.log
+        ./ftests.py -l 10 -L ftests-nocontainer.log --skip 38 --no-container
+        popd
+
+  functionaltestsv1v2:
+    name: Cgroup v1/v2 Functional Tests
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Mount cpuset cgroup v2 controller
+      run: |
+        # unmount the cpuset v1 controller.  This should make it available
+        # in the v2 hierarchy after all references have been freed
+        sudo umount /sys/fs/cgroup/cpuset
+        # wait for the references to the cpuset controller to go away
+        sleep 30
+        cat /sys/fs/cgroup/unified/cgroup.controllers
+        sudo su -c "echo +cpuset > /sys/fs/cgroup/unified/cgroup.subtree_control"
+        cat /sys/fs/cgroup/unified/cgroup.subtree_control
+    - name: Install container dependencies
+      run: sudo apt-get install lxc lxd
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Initialize the directory
+      uses: ./.github/actions/setup-libcgroup
+    - name: Run functional tests
+      run: |
+        pushd src/python/build/lib.*
+        export PYTHONPATH=$PYTHONPATH:$(pwd)
+        popd
+        pushd tests/ftests
+        make check
+        popd
+    - name: Display test logs
+      if: ${{ always() }}
+      run: |
+        cat tests/ftests/ftests.sh.log
+        cat tests/ftests/ftests-nocontainer.sh.log
+    - name: Archive test logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Cgroup v1v2 test logs
+        path: tests/ftests/*.log
+
+  functionaltestsv2:
+    name: Cgroup v2 Functional Tests
+    needs: [cleaner]
+    runs-on: self-hosted
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Initialize the directory
+      uses: ./.github/actions/setup-libcgroup
+    - name: Run functional tests
+      run: |
+        pushd src/python/build/lib.*
+        export PYTHONPATH=$PYTHONPATH:$(pwd)
+        popd
+        pushd tests/ftests
+        make check
+        popd
+    - name: Display test logs
+      if: ${{ always() }}
+      run: |
+        cat tests/ftests/ftests.sh.log
+        cat tests/ftests/ftests-nocontainer.sh.log
+    - name: Archive test logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Cgroup v2 test logs
+        path: tests/ftests/*.log

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,15 @@
+get_all_controller
+get_controller
+get_mount_point
+get_procs
+get_variable_names
+libcg_ba
+libcgrouptest01
+pathtest
+proctest
+read_stats
+setuid
+test_named_hierarchy
+walk_task
+walk_test
+wrapper_test

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = ftests gunit

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,5 @@
+[![Build Status](https://github.com/libcgroup/libcgroup-tests/workflows/Continuous%20Integration/badge.svg?branch=main)](https://github.com/libcgroup/libcgroup-tests/actions)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/libcgroup/libcgroup-tests.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/libcgroup/libcgroup-tests/alerts/?mode=list)
+
+The libcgroup-tests repository contains the automated tests for the
+[libcgroup](https://github.com/libcgroup/libcgroup) project.

--- a/tests/ftests/.gitignore
+++ b/tests/ftests/.gitignore
@@ -1,0 +1,5 @@
+tmp.conf
+*.log
+*.pyc
+*.swp
+*.trs

--- a/tests/ftests/001-cgget-basic_cgget_v1.py
+++ b/tests/ftests/001-cgget-basic_cgget_v1.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Basic cgget functionality test
+#
+# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '001cgget'
+SETTING = 'cpu.shares'
+VALUE = '512'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+    Cgroup.set(config, CGNAME, SETTING, VALUE)
+
+
+def test(config):
+    Cgroup.get_and_validate(config, CGNAME, SETTING, VALUE)
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/002-cgdelete-recursive_delete.py
+++ b/tests/ftests/002-cgdelete-recursive_delete.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Cgroup recursive cgdelete functionality test
+#
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+PARENT = '002cgdelete'
+CHILD = 'childcg'
+GRANDCHILD = 'grandchildcg'
+
+
+def prereqs(config):
+    # This test should run on both cgroup v1 and v2
+    return consts.TEST_PASSED, None
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT)
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT, CHILD))
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT, CHILD, GRANDCHILD))
+
+    version = CgroupVersion.get_version(CONTROLLER)
+    if version == CgroupVersion.CGROUP_V1:
+        # cgdelete in a cgroup v1 controller should be able to move a process
+        # from a child cgroup to its parent.
+        #
+        # Moving a process from a child cgroup to its parent isn't (easily)
+        # supported in cgroup v2 because of cgroup v2's restriction that
+        # processes only be located in leaf cgroups
+        grandchild_cgrp_path = os.path.join(PARENT, CHILD, GRANDCHILD)
+        config.process.create_process_in_cgroup(config, CONTROLLER,
+                                                grandchild_cgrp_path)
+
+
+def test(config):
+    Cgroup.delete(config, CONTROLLER, PARENT, recursive=True)
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    pass
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/003-cgget-basic_cgget_v2.py
+++ b/tests/ftests/003-cgget-basic_cgget_v2.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Basic cgget functionality test
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+CGNAME = '003cgget'
+
+SETTING = 'cpuset.mems'
+VALUE = '0'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v2 cpuset controller'
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+    Cgroup.set(config, CGNAME, SETTING, VALUE)
+
+
+def test(config):
+    Cgroup.get_and_validate(config, CGNAME, SETTING, VALUE)
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/004-cgsnapshot-basic_snapshot_v1.py
+++ b/tests/ftests/004-cgsnapshot-basic_snapshot_v1.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Basic cgsnapshot functionality test
+#
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'memory'
+CGNAME = '004cgsnapshot'
+CGSNAPSHOT = """group 004cgsnapshot {
+                    memory {
+                            memory.use_hierarchy="1";
+                            memory.soft_limit_in_bytes="9223372036854771712";
+                            memory.force_empty="";
+                            memory.move_charge_at_immigrate="0";
+                            memory.kmem.tcp.max_usage_in_bytes="0";
+                            memory.max_usage_in_bytes="0";
+                            memory.oom_control="oom_kill_disable 0
+                                under_oom 0
+                                oom_kill 0";
+                            memory.limit_in_bytes="9223372036854771712";
+                            memory.swappiness="60";
+                            memory.kmem.failcnt="0";
+                            memory.kmem.max_usage_in_bytes="0";
+                            memory.failcnt="0";
+                            memory.kmem.tcp.failcnt="0";
+                            memory.kmem.limit_in_bytes="9223372036854771712";
+                            memory.use_hierarchy="1";
+                            memory.kmem.tcp.limit_in_bytes="9223372036854771712";
+"""
+
+CGSNAPSHOT_SWAP = """                            memory.memsw.failcnt="0";
+                            memory.memsw.limit_in_bytes="9223372036854771712";
+                            memory.memsw.max_usage_in_bytes="0";
+                    }
+            }"""
+
+CGSNAPSHOT_NOSWAP = """                    }
+            }"""
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 memory controller'
+        return result, cause
+
+    if not config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test must be run within a container'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        # check if the memsw.failcnt file exists.  if so, add it to the
+        # expected snapshot
+        Cgroup.get(config, setting='memory.memsw.failcnt', cgname=CGNAME)
+        expected_str = CGSNAPSHOT + CGSNAPSHOT_SWAP
+    except RunError:
+        # memsw files don't exist.  exclude them from the snapshot
+        expected_str = CGSNAPSHOT + CGSNAPSHOT_NOSWAP
+
+    expected = Cgroup.snapshot_to_dict(expected_str)
+    actual = Cgroup.snapshot(config, controller=CONTROLLER)
+
+    if expected[CGNAME] != actual[CGNAME]:
+        result = consts.TEST_FAILED
+        cause = 'Expected cgsnapshot result did not equal actual cgsnapshot'
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/005-cgsnapshot-basic_snapshot_v2.py
+++ b/tests/ftests/005-cgsnapshot-basic_snapshot_v2.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Basic cgsnapshot functionality test
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+CGNAME = '005cgsnapshot'
+CGSNAPSHOT = """group 005cgsnapshot {
+                    cpuset {
+                            cpuset.cpus.partition="member";
+                            cpuset.mems="";
+                            cpuset.cpus="";
+                    }
+            }"""
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v2 cpuset controller'
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    expected = Cgroup.snapshot_to_dict(CGSNAPSHOT)
+    actual = Cgroup.snapshot(config, controller=CONTROLLER)
+
+    if expected[CGNAME].controllers[CONTROLLER] != \
+       actual[CGNAME].controllers[CONTROLLER]:
+        result = consts.TEST_FAILED
+        cause = 'Expected cgsnapshot result did not equal actual cgsnapshot'
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/006-cgrules-basic_cgrules_v1.py
+++ b/tests/ftests/006-cgrules-basic_cgrules_v1.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Basic cgrules functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from process import Process
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+PARENT_CGNAME = '006cgrules'
+CHILD_CGNAME = 'childcg'
+
+# move all perl processes to the 006cgrules/childcg cgroup in the
+# cpu controller
+CGRULE = (
+            '*:/usr/bin/perl cpu {}'
+            ''.format(os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+         )
+
+cg = Cgroup(os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
+    Cgroup.create(config, CONTROLLER,
+                  os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+
+    Cgroup.set_cgrules_conf(config, CGRULE, append=False)
+    cg.start_cgrules(config)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = config.process.create_process(config)
+    proc_cgroup = Process.get_cgroup(config, pid, CONTROLLER)
+
+    # proc/{pid}/cgroup alsways prepends a '/' to the cgroup path
+    if proc_cgroup != os.path.join('/', PARENT_CGNAME, CHILD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'PID {} was expected to be in cgroup {} but is in '
+                    'cgroup {}'
+                    ''.format(pid,
+                              os.path.join('/', PARENT_CGNAME, CHILD_CGNAME),
+                              proc_cgroup)
+                )
+
+    return result, cause
+
+
+def teardown(config):
+    # destroy the child processes
+    config.process.join_children(config)
+    cg.join_children(config)
+    Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/007-cgrules-basic_cgrules_v2.py
+++ b/tests/ftests/007-cgrules-basic_cgrules_v2.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Basic cgrules functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from process import Process
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+CGNAME = '007cgrules'
+
+# move all perl processes to the 007cgrules cgroup in the
+# cpuset controller
+CGRULE = '*:/usr/bin/perl cpuset {}'.format(CGNAME)
+
+cg = Cgroup(CGNAME)
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v2 cpuset controller'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+    Cgroup.set_cgrules_conf(config, CGRULE, append=False)
+    cg.start_cgrules(config)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = config.process.create_process(config)
+    proc_cgroup = Process.get_cgroup(config, pid, CONTROLLER)
+
+    # proc/{pid}/cgroup alsways prepends a '/' to the cgroup path
+    if proc_cgroup != os.path.join('/', CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'PID {} was expected to be in cgroup {} but is in '
+                    'cgroup {}'
+                    ''.format(pid, os.path.join('/', CGNAME), proc_cgroup)
+                )
+
+    return result, cause
+
+
+def teardown(config):
+    # destroy the child processes
+    config.process.join_children(config)
+    cg.join_children(config)
+    Cgroup.delete(config, CONTROLLER, CGNAME, recursive=False)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/008-cgget-multiple_r_flags.py
+++ b/tests/ftests/008-cgget-multiple_r_flags.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - multiple '-r' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'memory'
+CGNAME = '008cgget'
+
+SETTING1_V1 = 'memory.limit_in_bytes'
+SETTING1_V2 = 'memory.max'
+VALUE1 = '1048576'
+
+SETTING2_V1 = 'memory.soft_limit_in_bytes'
+SETTING2_V2 = 'memory.high'
+VALUE2 = '1024000'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        Cgroup.set(config, CGNAME, SETTING1_V1, VALUE1)
+        Cgroup.set(config, CGNAME, SETTING2_V1, VALUE2)
+    elif version == CgroupVersion.CGROUP_V2:
+        Cgroup.set(config, CGNAME, SETTING1_V2, VALUE1)
+        Cgroup.set(config, CGNAME, SETTING2_V2, VALUE2)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        settings = [SETTING1_V1, SETTING2_V1]
+    elif version == CgroupVersion.CGROUP_V2:
+        settings = [SETTING1_V2, SETTING2_V2]
+
+    out = Cgroup.get(config, controller=None, cgname=CGNAME, setting=settings)
+
+    if out.splitlines()[0] != '{}:'.format(CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'cgget expected the cgroup name {} in the first line.\n'
+                    'Instead it received {}'
+                    ''.format(CGNAME, out.splitlines()[0])
+                )
+
+    if out.splitlines()[1] != '{}: {}'.format(settings[0], VALUE1):
+        result = consts.TEST_FAILED
+        cause = (
+                    'cgget expected the following:\n\t{}: {}\n'
+                    'but received:\n\t{}'
+                    ''.format(settings[0], VALUE1, out.splitlines()[1])
+                )
+
+    if out.splitlines()[2] != '{}: {}'.format(settings[1], VALUE2):
+        result = consts.TEST_FAILED
+        cause = (
+                    'cgget expected the following:\n\t{}: {}\n'
+                    'but received:\n\t{}'
+                    ''.format(settings[1], VALUE2, out.splitlines()[2])
+                )
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/009-cgget-g_flag_controller_only.py
+++ b/tests/ftests/009-cgget-g_flag_controller_only.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - '-g' <controller>
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '009cgget'
+
+EXPECTED_OUT_V1 = [
+    '''009cgget:
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
+
+EXPECTED_OUT_V2 = [
+    '''009cgget:
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI
+    '''009cgget:
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=CGNAME)
+
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        for expected_out in EXPECTED_OUT_V1:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
+    elif version == CgroupVersion.CGROUP_V2:
+        for expected_out in EXPECTED_OUT_V2:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected {} lines but received {} lines'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
+        return result, cause
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != expected_out.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(expected_out.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
+            return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - '-g' <controller>:<path>
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '010cgget'
+
+EXPECTED_OUT_V1 = [
+    '''cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
+
+EXPECTED_OUT_V2 = [
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+]
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller='{}:{}'.format(CONTROLLER, CGNAME),
+                     print_headers=False)
+
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        for expected_out in EXPECTED_OUT_V1:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
+    elif version == CgroupVersion.CGROUP_V2:
+        for expected_out in EXPECTED_OUT_V2:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected line count: {}, but received line count: {}'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
+        return result, cause
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected {} lines but received {} lines'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
+        return result, cause
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != expected_out.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(expected_out.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
+            return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/011-cgget-r_flag_two_cgroups.py
+++ b/tests/ftests/011-cgget-r_flag_two_cgroups.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - '-r' <name> <cgroup1> <cgroup2>
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'memory'
+CGNAME1 = '011cgget1'
+CGNAME2 = '011cgget2'
+
+SETTING_V1 = 'memory.limit_in_bytes'
+SETTING_V2 = 'memory.max'
+VALUE = '2048000'
+
+EXPECTED_OUT_V1 = '''011cgget1:
+memory.limit_in_bytes: 2048000
+
+011cgget2:
+memory.limit_in_bytes: 2048000
+'''
+
+EXPECTED_OUT_V2 = '''011cgget1:
+memory.max: 2048000
+
+011cgget2:
+memory.max: 2048000
+'''
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        Cgroup.set(config, CGNAME1, SETTING_V1, VALUE)
+        Cgroup.set(config, CGNAME2, SETTING_V1, VALUE)
+    elif version == CgroupVersion.CGROUP_V2:
+        Cgroup.set(config, CGNAME1, SETTING_V2, VALUE)
+        Cgroup.set(config, CGNAME2, SETTING_V2, VALUE)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        setting = SETTING_V1
+        expected_out = EXPECTED_OUT_V1
+    elif version == CgroupVersion.CGROUP_V2:
+        setting = SETTING_V2
+        expected_out = EXPECTED_OUT_V2
+
+    out = Cgroup.get(config, controller=None, cgname=[CGNAME1, CGNAME2],
+                     setting=setting)
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != expected_out.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(expected_out.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
+            return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/012-cgget-multiple_r_flags2.py
+++ b/tests/ftests/012-cgget-multiple_r_flags2.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - multiple '-r' flags and multiple cgroups
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'memory'
+CGNAME1 = '012cgget1'
+CGNAME2 = '012cgget2'
+
+SETTING1_V1 = 'memory.limit_in_bytes'
+SETTING1_V2 = 'memory.max'
+VALUE1 = '4194304'
+
+SETTING2_V1 = 'memory.soft_limit_in_bytes'
+SETTING2_V2 = 'memory.high'
+VALUE2 = '4096000'
+
+EXPECTED_OUT = '''{}:
+{}
+{}
+
+{}:
+{}
+{}
+'''.format(CGNAME1, VALUE1, VALUE2, CGNAME2, VALUE1, VALUE2)
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        Cgroup.set(config, CGNAME1, SETTING1_V1, VALUE1)
+        Cgroup.set(config, CGNAME1, SETTING2_V1, VALUE2)
+        Cgroup.set(config, CGNAME2, SETTING1_V1, VALUE1)
+        Cgroup.set(config, CGNAME2, SETTING2_V1, VALUE2)
+    elif version == CgroupVersion.CGROUP_V2:
+        Cgroup.set(config, CGNAME1, SETTING1_V2, VALUE1)
+        Cgroup.set(config, CGNAME1, SETTING2_V2, VALUE2)
+        Cgroup.set(config, CGNAME2, SETTING1_V2, VALUE1)
+        Cgroup.set(config, CGNAME2, SETTING2_V2, VALUE2)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        settings = [SETTING1_V1, SETTING2_V1]
+    elif version == CgroupVersion.CGROUP_V2:
+        settings = [SETTING1_V2, SETTING2_V2]
+
+    out = Cgroup.get(config, controller=None, cgname=[CGNAME1, CGNAME2],
+                     setting=settings, values_only=True)
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(EXPECTED_OUT.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
+            return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/013-cgget-multiple_g_flags.py
+++ b/tests/ftests/013-cgget-multiple_g_flags.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - multiple '-g' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER1 = 'pids'
+CONTROLLER2 = 'cpu'
+CGNAME = '013cgget'
+
+EXPECTED_OUT_V1 = [
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
+
+EXPECTED_OUT_V2 = [
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER1, CGNAME)
+    Cgroup.create(config, CONTROLLER2, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=[CONTROLLER1, CONTROLLER2],
+                     cgname=CGNAME)
+
+    version = CgroupVersion.get_version(CONTROLLER1)
+
+    if version == CgroupVersion.CGROUP_V1:
+        for expected_out in EXPECTED_OUT_V1:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
+    elif version == CgroupVersion.CGROUP_V2:
+        for expected_out in EXPECTED_OUT_V2:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected {} lines but received {} lines'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
+        return result, cause
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != expected_out.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(expected_out.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
+            return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    ver1 = CgroupVersion.get_version(CONTROLLER1)
+    ver2 = CgroupVersion.get_version(CONTROLLER2)
+
+    if ver1 == CgroupVersion.CGROUP_V2 and \
+       ver2 == CgroupVersion.CGROUP_V2:
+        # If both controllers are cgroup v2, then we only need to delete
+        # one cgroup.  The path will be the same for both
+        Cgroup.delete(config, [CONTROLLER1, CONTROLLER2], CGNAME)
+    else:
+        Cgroup.delete(config, CONTROLLER1, CGNAME)
+        Cgroup.delete(config, CONTROLLER2, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/014-cgget-a_flag.py
+++ b/tests/ftests/014-cgget-a_flag.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - exercise the '-a' flag
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER1 = 'memory'
+CONTROLLER2 = 'cpuset'
+CGNAME = '014cgget'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    ver1 = CgroupVersion.get_version(CONTROLLER1)
+    ver2 = CgroupVersion.get_version(CONTROLLER2)
+
+    if ver1 == CgroupVersion.CGROUP_V2 and \
+       ver2 == CgroupVersion.CGROUP_V2:
+        # If both controllers are cgroup v2, then we only need to make
+        # one cgroup.  The path will be the same for both
+        Cgroup.create(config, [CONTROLLER1, CONTROLLER2], CGNAME)
+    else:
+        Cgroup.create(config, CONTROLLER1, CGNAME)
+        Cgroup.create(config, CONTROLLER2, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, cgname=CGNAME, all_controllers=True)
+
+    # arbitrary check to ensure we read several lines
+    if len(out.splitlines()) < 20:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected multiple lines, but only received {}'
+                    ''.format(len(out.splitlines()))
+                )
+        return result, cause
+
+    # arbitrary check for a setting that's in both cgroup v1 and cgroup v2
+    # memory.stat
+    if '\tpgmajfault' not in out:
+        result = consts.TEST_FAILED
+        cause = 'Unexpected output\n{}'.format(out)
+        return result, cause
+
+    # make sure that a cpuset value was in the output:
+    if 'cpuset.cpus' not in out:
+        result = consts.TEST_FAILED
+        cause = 'Failed to find cpuset settings in output\n{}'.format(out)
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    ver1 = CgroupVersion.get_version(CONTROLLER1)
+    ver2 = CgroupVersion.get_version(CONTROLLER2)
+
+    if ver1 == CgroupVersion.CGROUP_V2 and \
+       ver2 == CgroupVersion.CGROUP_V2:
+        # If both controllers are cgroup v2, then we only need to make
+        # one cgroup.  The path will be the same for both
+        Cgroup.delete(config, [CONTROLLER1, CONTROLLER2], CGNAME)
+    else:
+        Cgroup.delete(config, CONTROLLER1, CGNAME)
+        Cgroup.delete(config, CONTROLLER2, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/015-cgget-multiline_r_flag.py
+++ b/tests/ftests/015-cgget-multiline_r_flag.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - get a multiline value via the '-r' flag
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'memory'
+CGNAME = '015cgget'
+
+SETTING = 'memory.stat'
+VALUE = '512'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=CGNAME,
+                     setting=SETTING, print_headers=True,
+                     values_only=False)
+
+    # arbitrary check to ensure we read several lines
+    if len(out.splitlines()) < 10:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected multiple lines, but only received {}'
+                    ''.format(len(out.splitlines()))
+                )
+        return result, cause
+
+    # arbitrary check for a setting that's in both cgroup v1 and cgroup v2
+    # memory.stat
+    if '\tunevictable' not in out:
+        result = consts.TEST_FAILED
+        cause = 'Unexpected output\n{}'.format(out)
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/016-cgget-invalid_options.py
+++ b/tests/ftests/016-cgget-invalid_options.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - multiple '-g' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '016cgget'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    # Github Actions has issues with cgget and the code coverage profiler.
+    # This causes issues with the error handling of this test
+    if not config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test must be run within a container'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        # cgget -g cpu
+        Cgroup.get(config, controller=CONTROLLER)
+    except RunError as re:
+        if 'Wrong input parameters,' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#1 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#1 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #1 erroneously passed'
+        return result, cause
+
+    try:
+        # cgget -g cpu:016cgget 016cgget
+        Cgroup.get(config, controller='{}:{}'.format(CONTROLLER, CGNAME),
+                   cgname=CGNAME)
+    except RunError as re:
+        if 'Wrong input parameters,' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#2 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#2 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #2 erroneously passed'
+        return result, cause
+
+    try:
+        # cgget -r invalidsetting 016cgget
+        Cgroup.get(config, setting='invalidsetting', cgname=CGNAME,
+                   print_headers=False, values_only=True)
+    except RunError as re:
+        if 'cgget: error parsing parameter name' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = (
+                        "#3 Expected 'cgget: error parsing parameter name' to "
+                        "be in stderr"
+                    )
+            return result, cause
+
+        # legacy cgget returns 0 but populates stderr for this case.
+        # This feels wrong, so the updated cgget returns ECGINVAL
+        if re.ret != 91 and re.ret != 0:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#3 Expected return code of 0 or 91 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #3 erroneously passed'
+        return result, cause
+
+    try:
+        # cgget -r invalid.setting 016cgget
+        Cgroup.get(config, setting='invalid.setting', cgname=CGNAME,
+                   print_headers=False, values_only=True)
+    except RunError as re:
+        if 'cgget: cannot find controller' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = (
+                        "#4 Expected 'cgget: cannot find controller' to be in "
+                        "stderr"
+                    )
+            return result, cause
+
+        # legacy cgget returns 0 but populates stderr for this case.
+        # This feels wrong, so the updated cgget returns ECGOTHER
+        if re.ret != 96 and re.ret != 0:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#4 Expected return code of 0 or 96 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #4 erroneously passed'
+        return result, cause
+
+    try:
+        # cgget -r cpu.invalid 016cgget
+        Cgroup.get(config, setting='{}.invalid'.format(CONTROLLER),
+                   cgname=CGNAME, print_headers=False, values_only=True)
+    except RunError as re:
+        if 'variable file read failed' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#5 Expected 'variable file read failed' to be in stderr"
+            return result, cause
+
+        # legacy cgget returns 0 but populates stderr for this case.
+        # This feels wrong, so the updated cgget returns ECGOTHER
+        if re.ret != 96 and re.ret != 0:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#5 Expected return code of 0 or 96 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #5 erroneously passed'
+        return result, cause
+
+    try:
+        # cgget with no parameters
+        Cgroup.get(config, controller=None, cgname=None, setting=None,
+                   print_headers=True, values_only=False,
+                   all_controllers=False, cghelp=False)
+    except RunError as re:
+        if 'Wrong input parameters,' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#6 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 1:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#6 Expected return code of 1 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #6 erroneously passed'
+        return result, cause
+
+    # cgget -h
+    ret = Cgroup.get(config, cghelp=True)
+    if 'Print parameter(s)' not in ret:
+        result = consts.TEST_FAILED
+        cause = '#7 Failed to print help text'
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/017-cgconfig-load_file.py
+++ b/tests/ftests/017-cgconfig-load_file.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgconfigparser functionality test using a configuration file
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '017cgconfig'
+CFS_PERIOD = '500000'
+CFS_QUOTA = '100000'
+SHARES = '999'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+        cpu.cfs_period_us = {};
+        cpu.cfs_quota_us = {};
+        cpu.shares = {};
+    }}
+}}'''.format(CGNAME, CONTROLLER, CFS_PERIOD, CFS_QUOTA, SHARES)
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '017cgconfig.conf')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+
+def test(config):
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_period_us', CFS_PERIOD)
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_quota_us', CFS_QUOTA)
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.shares', SHARES)
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+    os.remove(CONFIG_FILE_NAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/018-cgconfig-load_dir.py
+++ b/tests/ftests/018-cgconfig-load_dir.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgconfigparser functionality test using a configuration directory
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CPU_CTRL = 'cpu'
+MEMORY_CTRL = 'memory'
+CGNAME = '018cgconfig'
+CFS_PERIOD = '400000'
+CFS_QUOTA = '50000'
+SHARES = '123'
+
+LIMIT_IN_BYTES = '409600'
+SOFT_LIMIT_IN_BYTES = '376832'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+        cpu.cfs_period_us = {};
+        cpu.cfs_quota_us = {};
+        cpu.shares = {};
+    }}
+    {} {{
+        memory.limit_in_bytes = {};
+        memory.soft_limit_in_bytes = {};
+    }}
+}}'''.format(CGNAME, CPU_CTRL, CFS_PERIOD, CFS_QUOTA, SHARES,
+             MEMORY_CTRL, LIMIT_IN_BYTES, SOFT_LIMIT_IN_BYTES)
+
+CONFIG_FILE_DIR = os.path.join(os.getcwd(), '018cgconfig')
+CONFIG_FILE_NAME = os.path.join(CONFIG_FILE_DIR, 'cgconfig.conf')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+        return result, cause
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 memory controller'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    os.mkdir(CONFIG_FILE_DIR)
+
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+
+def test(config):
+    Cgroup.configparser(config, load_dir=CONFIG_FILE_DIR)
+
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_period_us', CFS_PERIOD)
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_quota_us', CFS_QUOTA)
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.shares', SHARES)
+    Cgroup.get_and_validate(config, CGNAME, 'memory.limit_in_bytes',
+                            LIMIT_IN_BYTES)
+    Cgroup.get_and_validate(config, CGNAME, 'memory.soft_limit_in_bytes',
+                            SOFT_LIMIT_IN_BYTES)
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    Cgroup.delete(config, CPU_CTRL, CGNAME)
+    Cgroup.delete(config, MEMORY_CTRL, CGNAME)
+    os.remove(CONFIG_FILE_NAME)
+    os.rmdir(CONFIG_FILE_DIR)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/019-cgconfig-uidgid_dperm_fperm.py
+++ b/tests/ftests/019-cgconfig-uidgid_dperm_fperm.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgconfigparser functionality test - '-a', '-d', '-f' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from container import ContainerError
+from run import Run, RunError
+from cgroup import Cgroup
+import consts
+import ftests
+import utils
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+CGNAME = '019cgconfig'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+    }}
+}}'''.format(CGNAME, CONTROLLER)
+
+USER = 'cguser019'
+GROUP = 'cggroup019'
+DPERM = '515'
+FPERM = '246'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '019cgconfig.conf')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+    if config.args.container:
+        config.container.run(['useradd', '-p', 'Test019#1', USER])
+        config.container.run(['groupadd', GROUP])
+    else:
+        Run.run(['sudo', 'useradd', '-p', 'Test019#1', USER])
+        Run.run(['sudo', 'groupadd', '-f', GROUP])
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME, dflt_usr=USER,
+                        dflt_grp=GROUP, dperm=DPERM, fperm=FPERM)
+
+    mnt_path = Cgroup.get_controller_mount_point(CONTROLLER)
+    cpus_path = os.path.join(mnt_path, CGNAME, 'cpuset.cpus')
+
+    user = utils.get_file_owner_username(config, cpus_path)
+    group = utils.get_file_owner_group_name(config, cpus_path)
+
+    if user != USER:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Owner name failed.  Expected {}, received {}\n'
+                    ''.format(USER, user)
+                )
+        return result, cause
+
+    if group != GROUP:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Owner group failed.  Expected {}, received {}\n'
+                    ''.format(GROUP, group)
+                )
+        return result, cause
+
+    fperm = utils.get_file_permissions(config, cpus_path)
+    if fperm != FPERM:
+        result = consts.TEST_FAILED
+        cause = (
+                    'File permissions failed.  Expected {}, received {}\n'
+                    ''.format(FPERM, fperm)
+                )
+        return result, cause
+
+    dperm = utils.get_file_permissions(config, os.path.join(mnt_path, CGNAME))
+    if dperm != DPERM:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Directory permissions failed.  Expected {}, received {}\n'
+                    ''.format(DPERM, dperm)
+                )
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    os.remove(CONFIG_FILE_NAME)
+
+    try:
+        if config.args.container:
+            config.container.run(['userdel', USER])
+            config.container.run(['groupdel', GROUP])
+        else:
+            Run.run(['sudo', 'userdel', '-r', USER])
+            Run.run(['sudo', 'groupdel', GROUP])
+    except (ContainerError, RunError, ValueError):
+        pass
+
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/020-cgconfig-tasks_perms_owner.py
+++ b/tests/ftests/020-cgconfig-tasks_perms_owner.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgconfigparser functionality test - '-s', '-t', flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from container import ContainerError
+from run import Run, RunError
+import consts
+import ftests
+import utils
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+CGNAME = '020cgconfig'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+    }}
+}}'''.format(CGNAME, CONTROLLER)
+
+USER = 'cguser020'
+GROUP = 'cggroup020'
+TPERM = '642'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '020cgconfig.conf')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpuset controller'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+    if config.args.container:
+        config.container.run(['useradd', '-p', 'Test020#1', USER])
+        config.container.run(['groupadd', GROUP])
+    else:
+        Run.run(['sudo', 'useradd', '-p', 'Test020#1', USER])
+        Run.run(['sudo', 'groupadd', '-f', GROUP])
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME, tperm=TPERM,
+                        tasks_usr=USER, tasks_grp=GROUP)
+
+    mnt_path = Cgroup.get_controller_mount_point(CONTROLLER)
+    tasks_path = os.path.join(mnt_path, CGNAME, 'tasks')
+
+    user = utils.get_file_owner_username(config, tasks_path)
+    group = utils.get_file_owner_group_name(config, tasks_path)
+
+    if user != USER:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Owner name failed.  Expected {}, received {}\n'
+                    ''.format(USER, user)
+                )
+        return result, cause
+
+    if group != GROUP:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Owner group failed.  Expected {}, received {}\n'
+                    ''.format(GROUP, group)
+                )
+        return result, cause
+
+    tperm = utils.get_file_permissions(config, tasks_path)
+    if tperm != TPERM:
+        result = consts.TEST_FAILED
+        cause = (
+                    'File permissions failed.  Expected {}, received {}\n'
+                    ''.format(TPERM, tperm)
+                )
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    os.remove(CONFIG_FILE_NAME)
+
+    try:
+        if config.args.container:
+            config.container.run(['userdel', USER])
+            config.container.run(['groupdel', GROUP])
+        else:
+            Run.run(['sudo', 'userdel', '-r', USER])
+            Run.run(['sudo', 'groupdel', GROUP])
+    except (ContainerError, RunError, ValueError):
+        pass
+
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/021-cgconfig-invalid_options.py
+++ b/tests/ftests/021-cgconfig-invalid_options.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgconfigparser functionality test - invalid and help options
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+CGNAME = '021cgconfig'
+
+CONFIG_FILE = '''group
+{} {{
+    {} {{
+        cpuset.cpus = abc123;
+    }}
+}}'''.format(CGNAME, CONTROLLER)
+
+USER = 'cguser021'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '021cgconfig.conf')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(CONFIG_FILE)
+    f.close()
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    ret = Cgroup.configparser(config, cghelp=True)
+    if 'Parse and load the specified cgroups' not in ret:
+        result = consts.TEST_FAILED
+        cause = 'Failed to print cgconfigparser help text'
+        return result, cause
+
+    try:
+        Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+    except RunError as re:
+        if 'Invalid argument' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "Expected 'Invalid argument' to be in stderr"
+            return result, cause
+
+        if re.ret != 96:
+            result = consts.TEST_FAILED
+            cause = 'Expected return code of 96 but received {}'.format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case erroneously passed'
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    os.remove(CONFIG_FILE_NAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/022-cgset-multiple_r_flag.py
+++ b/tests/ftests/022-cgset-multiple_r_flag.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgset functionality test - set multiple values via the '-r' flag
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'memory'
+CGNAME = '022cgset'
+
+SETTINGS = ['memory.limit_in_bytes',
+            'memory.soft_limit_in_bytes',
+            'memory.swappiness']
+VALUES = ['1024000', '512000', '55']
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 memory controller'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    Cgroup.set(config, cgname=CGNAME, setting=SETTINGS, value=VALUES)
+
+    for i, setting in enumerate(SETTINGS):
+        Cgroup.get_and_validate(config, CGNAME, setting, VALUES[i])
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/023-cgset-copy_from.py
+++ b/tests/ftests/023-cgset-copy_from.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgset functionality test - test the '--copy-from' option
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'memory'
+SRC_CGNAME = '023cgsetsrc'
+DST_CGNAME = '023cgsetdst'
+
+SETTINGS = ['memory.limit_in_bytes',
+            'memory.soft_limit_in_bytes',
+            'memory.swappiness']
+VALUES = ['122880', '40960', '42']
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 memory controller'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, SRC_CGNAME)
+    Cgroup.create(config, CONTROLLER, DST_CGNAME)
+    Cgroup.set(config, cgname=SRC_CGNAME, setting=SETTINGS, value=VALUES)
+
+
+def test(config):
+    Cgroup.set(config, cgname=DST_CGNAME, copy_from=SRC_CGNAME)
+
+    for i, setting in enumerate(SETTINGS):
+        Cgroup.get_and_validate(config, DST_CGNAME, setting, VALUES[i])
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, SRC_CGNAME)
+    Cgroup.delete(config, CONTROLLER, DST_CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/025-cgset-multiple_cgroups.py
+++ b/tests/ftests/025-cgset-multiple_cgroups.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgset functionality test - set multiple cgroups' values
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'memory'
+CGNAME1 = '025cgset1'
+CGNAME2 = '025cgset2'
+
+SETTING = 'memory.swappiness'
+VALUE = '42'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 memory controller'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+
+
+def test(config):
+    Cgroup.set(config, cgname=[CGNAME1, CGNAME2], setting=SETTING, value=VALUE)
+
+    Cgroup.get_and_validate(config, CGNAME1, SETTING, VALUE)
+    Cgroup.get_and_validate(config, CGNAME2, SETTING, VALUE)
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/026-cgset-multiple_r_multiple_cgroup.py
+++ b/tests/ftests/026-cgset-multiple_r_multiple_cgroup.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgset functionality test - set multiple values in multiple cgroups
+#                                     via the '-r' flag
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'memory'
+CGNAMES = ['026cgset1', '026cgset2']
+
+SETTINGS = ['memory.limit_in_bytes',
+            'memory.soft_limit_in_bytes',
+            'memory.swappiness']
+VALUES = ['2048000', '1024000', '89']
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 memory controller'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    for cg in CGNAMES:
+        Cgroup.create(config, CONTROLLER, cg)
+
+
+def test(config):
+    Cgroup.set(config, cgname=CGNAMES, setting=SETTINGS, value=VALUES)
+
+    for i, setting in enumerate(SETTINGS):
+        for cg in CGNAMES:
+            Cgroup.get_and_validate(config, cg, setting, VALUES[i])
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    for cg in CGNAMES:
+        Cgroup.delete(config, CONTROLLER, cg)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/027-cgset-invalid_options.py
+++ b/tests/ftests/027-cgset-invalid_options.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgset functionality test - invalid options
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME1 = '027cgset1'
+CGNAME2 = '027cgset2'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        # cgset -r cpu.shares=100 --copy-from 027cgset2 027cgset1
+        Cgroup.set(config, cgname=CGNAME1, setting='cpu.shares', value='100',
+                   copy_from=CGNAME2)
+    except RunError as re:
+        if 'Wrong input parameters,' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#1 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#1 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #1 erroneously passed'
+        return result, cause
+
+    try:
+        # cgset -r cpu.shares=100
+        Cgroup.set(config, cgname=None, setting='cpu.shares', value='100')
+    except RunError as re:
+        if 'cgset: no cgroup specified' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#2 Expected 'no cgroup specified' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#2 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #2 erroneously passed'
+        return result, cause
+
+    try:
+        # cgset 027cgset1
+        Cgroup.set(config, cgname=CGNAME1)
+    except RunError as re:
+        if 'cgset: no name-value pair was set' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#3 Expected 'no name-value pair' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#3 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #3 erroneously passed'
+        return result, cause
+
+    try:
+        # cgset - no flags provided
+        Cgroup.set(config)
+    except RunError as re:
+        if 'Usage is' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#4 Expected 'Usage is' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#4 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #4 erroneously passed'
+        return result, cause
+
+    try:
+        # cgset -r cpu.shares= 027cgset1
+        Cgroup.set(config, cgname=CGNAME1, setting='cpu.shares', value='')
+    except RunError as re:
+        if 'wrong parameter of option -r' not in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#5 Expected 'Wrong parameter of option' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = (
+                        '#5 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Test case #5 erroneously passed'
+        return result, cause
+
+    # cgset -h
+    ret = Cgroup.set(config, cghelp=True)
+    if 'Usage:' not in ret:
+        result = consts.TEST_FAILED
+        cause = '#6 Failed to print help text'
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/029-lssubsys-basic_lssubsys.py
+++ b/tests/ftests/029-lssubsys-basic_lssubsys.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Basic lssubsys functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    pass
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    mount_list = Cgroup.get_cgroup_mounts(config, expand_v2_mounts=False)
+
+    # cgroup v2 mounts won't show up unless '-a' is specified
+    lssubsys_list = Cgroup.lssubsys(config, ls_all=False)
+
+    for mount in mount_list:
+        if mount.version == CgroupVersion.CGROUP_V2:
+            continue
+
+        if mount.controller == 'name=systemd' or mount.controller == 'systemd':
+            continue
+
+        found = False
+        for lsmount in lssubsys_list.splitlines():
+            if ',' in lsmount:
+                for ctrl in lsmount.split(','):
+                    if ctrl == mount.controller:
+                        found = True
+                        break
+
+            if lsmount == mount.controller:
+                found = True
+                break
+
+        if not found:
+            result = consts.TEST_FAILED
+            cause = (
+                        'Failed to find {} in lssubsys list'
+                        ''.format(mount.controller)
+                    )
+            return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    pass
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/030-lssubsys-lssubsys_all.py
+++ b/tests/ftests/030-lssubsys-lssubsys_all.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# 'lssubsys -a' test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup
+import consts
+import ftests
+import sys
+import os
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    pass
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    mount_list = Cgroup.get_cgroup_mounts(config, expand_v2_mounts=True)
+
+    # cgroup v2 mounts won't show up unless '-a' is specified
+    lssubsys_list = Cgroup.lssubsys(config, ls_all=True)
+
+    for mount in mount_list:
+        if mount.controller == 'name=systemd' or mount.controller == 'systemd':
+            continue
+
+        found = False
+        for lsmount in lssubsys_list.splitlines():
+            if ',' in lsmount:
+                for ctrl in lsmount.split(','):
+                    if ctrl == mount.controller:
+                        found = True
+                        break
+
+            if lsmount == mount.controller:
+                found = True
+                break
+
+            if lsmount == 'blkio' and mount.controller == 'io':
+                found = True
+                break
+
+        if not found:
+            result = consts.TEST_FAILED
+            cause = (
+                        'Failed to find {} in lssubsys list'
+                        ''.format(mount.controller)
+                    )
+            return result, cause
+
+    ret = Cgroup.lssubsys(config, cghelp=True)
+    if 'Usage:' not in ret:
+        result = consts.TEST_FAILED
+        cause = 'Failed to print help text'
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    pass
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/031-lscgroup-g_flag.py
+++ b/tests/ftests/031-lscgroup-g_flag.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# lscgroup functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import utils
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+PARENT_CGNAME = '031lscgroup'
+CHILD_CGNAME = 'childlscgroup'
+GRANDCHILD_CGNAME = 'grandchildlscgroup'
+
+# lscgroup is inconsistent in its handling of trailing slashes
+#
+# When invoking lscgroup with no flags, no trailing slashes are present in
+# any of the cgroups.
+#
+# When invoking lscgroup with the -g flag, a trailing slash is present on
+# the first cgroup returned (i.e. the cgroup specified in the -g flag)
+#
+EXPECTED_OUT1 = '''{}:/{}/
+{}:/{}/{}
+{}:/{}/{}/{}'''.format(CONTROLLER, PARENT_CGNAME,
+                       CONTROLLER, PARENT_CGNAME, CHILD_CGNAME,
+                       CONTROLLER, PARENT_CGNAME, CHILD_CGNAME,
+                       GRANDCHILD_CGNAME)
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    v2_cnt = 0
+    mount_list = Cgroup.get_cgroup_mounts(config)
+
+    for mount in mount_list:
+        if mount.version == CgroupVersion.CGROUP_V2:
+            v2_cnt += 1
+
+    if v2_cnt > 1:
+        # There is a bug in lscgroup - see issue #50 - where it doesn't
+        # properly list the enabled controllers for a cgroup v2 cgroup.
+        # Skip this test because of this
+        result = consts.TEST_SKIPPED
+        cause = 'See Github Issue #50 - lscgroup lists controllers...'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
+    Cgroup.create(
+                    config, CONTROLLER, os.path.join(
+                        PARENT_CGNAME, CHILD_CGNAME)
+                 )
+    Cgroup.create(config, CONTROLLER,
+                  os.path.join(PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME))
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.lscgroup(config, controller=CONTROLLER, path=PARENT_CGNAME)
+    if out != EXPECTED_OUT1:
+        result = consts.TEST_FAILED
+        cause = (
+                    "Expected lscgroup output doesn't match received output\n'"
+                    "Expected:\n{}\n"
+                    "Received:\n{}\n"
+                    "".format(utils.indent(EXPECTED_OUT1, 4),
+                              utils.indent(out, 4))
+                )
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/032-lscgroup-multiple_g_flags.py
+++ b/tests/ftests/032-lscgroup-multiple_g_flags.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# lscgroup functionality test - multiple '-g' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import utils
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+PARENT_CGNAME = '032lscgroup'
+CHILD_CGNAME = 'childlscgroup'
+GRANDCHILD_CGNAME = 'grandchildlscgroup'
+SIBLING_CGNAME = '032sibling'
+SIBLING_CHILD_CGNAME = 'cousinlscgroup'
+
+# lscgroup is inconsistent in its handling of trailing slashes
+#
+# When invoking lscgroup with no flags, no trailing slashes are present in
+# any of the cgroups.
+#
+# When invoking lscgroup with the -g flag, a trailing slash is present on
+# the first cgroup returned (i.e. the cgroup specified in the -g flag)
+#
+EXPECTED_OUT1 = '''{}:/{}/
+{}:/{}/{}
+{}:/{}/{}/{}
+{}:/{}/
+{}:/{}/{}'''.format(CONTROLLER, PARENT_CGNAME,
+                    CONTROLLER, PARENT_CGNAME, CHILD_CGNAME,
+                    CONTROLLER, PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME,
+                    CONTROLLER, SIBLING_CGNAME,
+                    CONTROLLER, SIBLING_CGNAME, SIBLING_CHILD_CGNAME)
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    v2_cnt = 0
+    mount_list = Cgroup.get_cgroup_mounts(config)
+
+    for mount in mount_list:
+        if mount.version == CgroupVersion.CGROUP_V2:
+            v2_cnt += 1
+
+    if v2_cnt > 1:
+        # There is a bug in lscgroup - see issue #50 - where it doesn't
+        # properly list the enabled controllers for a cgroup v2 cgroup.
+        # Skip this test because of this
+        result = consts.TEST_SKIPPED
+        cause = 'See Github Issue #50 - lscgroup lists controllers...'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
+    Cgroup.create(config, CONTROLLER,
+                  os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+    Cgroup.create(config, CONTROLLER,
+                  os.path.join(PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME))
+
+    Cgroup.create(config, CONTROLLER, SIBLING_CGNAME)
+    Cgroup.create(config, CONTROLLER,
+                  os.path.join(SIBLING_CGNAME, SIBLING_CHILD_CGNAME))
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.lscgroup(config, controller=[CONTROLLER, CONTROLLER],
+                          path=[PARENT_CGNAME, SIBLING_CGNAME])
+    if out != EXPECTED_OUT1:
+        result = consts.TEST_FAILED
+        cause = (
+                    "Expected lscgroup output doesn't match received output\n"
+                    "Expected:\n{}\n"
+                    "Received:\n{}\n"
+                    "".format(utils.indent(EXPECTED_OUT1, 4),
+                              utils.indent(out, 4))
+                )
+        return result, cause
+
+    ret = Cgroup.lscgroup(config, cghelp=True)
+    if 'Usage:' not in ret:
+        result = consts.TEST_FAILED
+        cause = 'Failed to print help text'
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+    Cgroup.delete(config, CONTROLLER, SIBLING_CGNAME, recursive=True)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/033-cgget-no_flags.py
+++ b/tests/ftests/033-cgget-no_flags.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - no flags, only a cgroup
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+CGNAME = '033cgget'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=CGNAME)
+
+    if out.splitlines()[0] != '{}:'.format(CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'cgget expected the cgroup name {} in the first line.\n'
+                    'Instead it received {}'
+                    ''.format(CGNAME, out.splitlines()[0])
+                )
+
+    if len(out.splitlines()) < 5:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Too few lines output by cgget.  Received {} lines'
+                    ''.format(len(out.splitlines()))
+                )
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/034-cgexec-basic_cgexec.py
+++ b/tests/ftests/034-cgexec-basic_cgexec.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Cgroup cgexec test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup
+from run import Run
+import consts
+import ftests
+import sys
+import os
+
+
+CONTROLLER = 'cpuset'
+CGNAME = '034cgexec'
+
+
+def prereqs(config):
+    if not config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test must be run within a container'
+        return result, cause
+
+    return consts.TEST_PASSED, None
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    config.process.create_process_in_cgroup(config, CONTROLLER, CGNAME,
+                                            cgclassify=False)
+
+    pids = Cgroup.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
+    if pids is None:
+        result = consts.TEST_FAILED
+        cause = 'No processes were found in cgroup {}'.format(CGNAME)
+        return result, cause
+
+    # run cgexec -h
+    ret = Cgroup.cgexec(config, controller=CONTROLLER, cgname=CGNAME,
+                        cmdline=None, cghelp=True)
+    if 'Run the task in given control group(s)' not in ret:
+        result = consts.TEST_FAILED
+        cause = 'Failed to print cgexec help text: {}'.format(ret)
+        return result, cause
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    pids = Cgroup.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
+    if pids:
+        for p in pids.splitlines():
+            if config.args.container:
+                config.container.run(['kill', '-9', p])
+            else:
+                Run.run(['sudo', 'kill', '-9', p])
+
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/035-cgset-set_cgroup_type.py
+++ b/tests/ftests/035-cgset-set_cgroup_type.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgget/cgset cgroup.type functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+# Which controller isn't all that important, but it is important that we
+# have a cgroup v2 controller
+CONTROLLER = 'cpu'
+CGNAME = '035cgset'
+
+SETTING = 'cgroup.type'
+BEFORE = 'domain'
+AFTER = 'threaded'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v2'
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+    Cgroup.get_and_validate(config, CGNAME, SETTING, BEFORE)
+
+    return consts.TEST_PASSED, None
+
+
+def test(config):
+    Cgroup.set_and_validate(config, CGNAME, SETTING, AFTER)
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/036-cgset-multi_thread.py
+++ b/tests/ftests/036-cgset-multi_thread.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Multithreaded cgroup v2 test
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from run import Run
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+PARENT_CGNAME = '036threaded'
+CHILD_CGPATH = os.path.join(PARENT_CGNAME, 'childcg')
+
+SETTING = 'cgroup.type'
+AFTER = 'threaded'
+THREADS = 3
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v2'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
+    Cgroup.create(config, CONTROLLER, CHILD_CGPATH)
+
+    Cgroup.set_and_validate(config, CHILD_CGPATH, SETTING, AFTER)
+
+    return consts.TEST_PASSED, None
+
+
+def test(config):
+    config.process.create_threaded_process_in_cgroup(
+                                config, CONTROLLER, PARENT_CGNAME, THREADS)
+
+    threads = Cgroup.get(config, controller=None, cgname=PARENT_CGNAME,
+                         setting='cgroup.threads', print_headers=False,
+                         values_only=True)
+    threads = threads.replace('\n', '').split('\t')
+
+#   #pick the first thread
+    thread_tid = threads[1]
+
+    Cgroup.set_and_validate(config, CHILD_CGPATH, 'cgroup.threads', thread_tid)
+
+    return consts.TEST_PASSED, None
+
+
+def teardown(config):
+    # destroy the child processes
+    pids = Cgroup.get_pids_in_cgroup(config, PARENT_CGNAME, CONTROLLER)
+    if pids:
+        for p in pids.splitlines():
+            Run.run(['sudo', 'kill', '-9', p])
+
+    Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/037-cgxget-cpu_settings.py
+++ b/tests/ftests/037-cgxget-cpu_settings.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgxget functionality test - various cpu settings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '037cgxget'
+
+CGRP_VER_V1 = CgroupVersion.CGROUP_V1
+CGRP_VER_V2 = CgroupVersion.CGROUP_V2
+
+TABLE = [
+    # writesetting, writeval, writever, readsetting, readval, readver
+    ['cpu.shares', '512', CGRP_VER_V1, 'cpu.shares', '512', CGRP_VER_V1],
+    ['cpu.shares', '512', CGRP_VER_V1, 'cpu.weight', '50',  CGRP_VER_V2],
+
+    ['cpu.weight', '200', CGRP_VER_V2, 'cpu.shares', '2048', CGRP_VER_V1],
+    ['cpu.weight', '200', CGRP_VER_V2, 'cpu.weight', '200',  CGRP_VER_V2],
+
+    ['cpu.cfs_quota_us',  '10000',       CGRP_VER_V1,
+     'cpu.cfs_quota_us',  '10000',       CGRP_VER_V1],
+    ['cpu.cfs_period_us', '100000',      CGRP_VER_V1,
+     'cpu.cfs_period_us', '100000',      CGRP_VER_V1],
+    ['cpu.cfs_period_us', '50000',       CGRP_VER_V1,
+     'cpu.max',           '10000 50000', CGRP_VER_V2],
+
+    ['cpu.cfs_quota_us',  '-1',         CGRP_VER_V1,
+     'cpu.cfs_quota_us',  '-1',         CGRP_VER_V1],
+    ['cpu.cfs_period_us', '100000',     CGRP_VER_V1,
+     'cpu.max',           'max 100000', CGRP_VER_V2],
+
+    ['cpu.max',           '5000 25000', CGRP_VER_V2,
+     'cpu.max',           '5000 25000', CGRP_VER_V2],
+    ['cpu.max',           '6000 26000', CGRP_VER_V2,
+     'cpu.cfs_quota_us',  '6000',       CGRP_VER_V1],
+    ['cpu.max',           '7000 27000', CGRP_VER_V2,
+     'cpu.cfs_period_us', '27000',      CGRP_VER_V1],
+
+    ['cpu.max',          'max 40000', CGRP_VER_V2,
+     'cpu.max',          'max 40000', CGRP_VER_V2],
+    ['cpu.max',          'max 41000', CGRP_VER_V2,
+     'cpu.cfs_quota_us', '-1',        CGRP_VER_V1],
+]
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    for entry in TABLE:
+        Cgroup.xset(config, cgname=CGNAME, setting=entry[0], value=entry[1],
+                    version=entry[2])
+
+        out = Cgroup.xget(config, cgname=CGNAME, setting=entry[3],
+                          version=entry[5], values_only=True,
+                          print_headers=False)
+        if out != entry[4]:
+            result = consts.TEST_FAILED
+            cause = (
+                    'After setting {}={}, expected {}={}, but received '
+                    '{}={}'.format(entry[0], entry[1], entry[3], entry[4],
+                                   entry[3], out)
+                    )
+            return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/038-cgxget-cpuset_settings.py
+++ b/tests/ftests/038-cgxget-cpuset_settings.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgxget functionality test - various cpuset settings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from run import Run, RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpuset'
+CGNAME = '038cgxget'
+
+CGRP_VER_V1 = CgroupVersion.CGROUP_V1
+CGRP_VER_V2 = CgroupVersion.CGROUP_V2
+
+TABLE = [
+    # writesetting, writeval, writever, readsetting, readval, readver
+    ['cpuset.cpus',           '0-1', CGRP_VER_V1,
+     'cpuset.cpus',           '0-1', CGRP_VER_V1],
+    ['cpuset.cpus',           '0-1', CGRP_VER_V1,
+     'cpuset.cpus',           '0-1', CGRP_VER_V2],
+    ['cpuset.cpus',           '0-1', CGRP_VER_V1,
+     'cpuset.effective_cpus', '0-1', CGRP_VER_V1],
+    ['cpuset.cpus',           '0-1', CGRP_VER_V1,
+     'cpuset.cpus.effective', '0-1', CGRP_VER_V2],
+    ['cpuset.cpus',           '1',   CGRP_VER_V2,
+     'cpuset.cpus',           '1',   CGRP_VER_V1],
+    ['cpuset.cpus',           '1',   CGRP_VER_V2,
+     'cpuset.cpus',           '1',   CGRP_VER_V2],
+
+    ['cpuset.mems',           '0', CGRP_VER_V1,
+     'cpuset.mems',           '0', CGRP_VER_V1],
+    ['cpuset.mems',           '0', CGRP_VER_V1,
+     'cpuset.mems',           '0', CGRP_VER_V2],
+    ['cpuset.mems',           '0', CGRP_VER_V2,
+     'cpuset.mems',           '0', CGRP_VER_V1],
+    ['cpuset.mems',           '0', CGRP_VER_V2,
+     'cpuset.mems',           '0', CGRP_VER_V2],
+    ['cpuset.mems',           '0', CGRP_VER_V1,
+     'cpuset.effective_mems', '0', CGRP_VER_V1],
+    ['cpuset.mems',           '0', CGRP_VER_V1,
+     'cpuset.mems.effective', '0', CGRP_VER_V2],
+
+    ['cpuset.cpu_exclusive',  '1',      CGRP_VER_V1,
+     'cpuset.cpu_exclusive',  '1',      CGRP_VER_V1],
+    ['cpuset.cpu_exclusive',  '1',      CGRP_VER_V1,
+     'cpuset.cpus.partition', 'root',   CGRP_VER_V2],
+    ['cpuset.cpu_exclusive',  '0',      CGRP_VER_V1,
+     'cpuset.cpu_exclusive',  '0',      CGRP_VER_V1],
+    ['cpuset.cpu_exclusive',  '0',      CGRP_VER_V1,
+     'cpuset.cpus.partition', 'member', CGRP_VER_V2],
+
+    ['cpuset.cpus.partition', 'root',   CGRP_VER_V2,
+     'cpuset.cpu_exclusive',  '1',      CGRP_VER_V1],
+    ['cpuset.cpus.partition', 'root',   CGRP_VER_V2,
+     'cpuset.cpus.partition', 'root',   CGRP_VER_V2],
+    ['cpuset.cpus.partition', 'member', CGRP_VER_V2,
+     'cpuset.cpu_exclusive', '0',       CGRP_VER_V1],
+    ['cpuset.cpus.partition', 'member', CGRP_VER_V2,
+     'cpuset.cpus.partition', 'member', CGRP_VER_V2],
+]
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    nproc = Run.run('nproc')
+    if int(nproc) < 2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires 2 or more processors'
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    for entry in TABLE:
+        try:
+            Cgroup.xset(config, cgname=CGNAME, setting=entry[0],
+                        value=entry[1], version=entry[2])
+        except RunError as re:
+            if re.stderr.find('Invalid argument') >= 0:
+                # The kernel disallowed this setting, likely due to the many
+                # complexities of exclusive cpusets
+                continue
+            raise re
+
+        out = Cgroup.xget(config, cgname=CGNAME, setting=entry[3],
+                          version=entry[5], values_only=True,
+                          print_headers=False)
+        if out != entry[4]:
+            result = consts.TEST_FAILED
+            cause = (
+                        'After setting {}={}, expected {}={}, but received '
+                        '{}={}'
+                        ''.format(entry[0], entry[1], entry[3], entry[4],
+                                  entry[3], out)
+                    )
+            return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/039-pybindings-cgxget.py
+++ b/tests/ftests/039-pybindings-cgxget.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgxget functionality test using the python bindings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli
+from libcgroup import Cgroup, Version
+from cgroup import CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '039bindings'
+
+SETTING1 = 'cpu.shares'
+VALUE1 = '4096'
+
+SETTING2 = 'cpu.weight'
+VALUE2 = '400'
+
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    CgroupCli.create(config, CONTROLLER, CGNAME)
+    if CgroupVersion.get_version('cpu') == CgroupVersion.CGROUP_V1:
+        CgroupCli.set(config, CGNAME, SETTING1, VALUE1)
+    else:
+        CgroupCli.set(config, CGNAME, SETTING2, VALUE2)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cg1 = Cgroup(CGNAME, Version.CGROUP_V1)
+    cg1.add_controller(CONTROLLER)
+    cg1.add_setting(SETTING1)
+
+    cg1.cgxget()
+
+    if len(cg1.controllers) != 1:
+        result = consts.TEST_FAILED
+        cause = (
+                    "Controller length doesn't match, expected 1, but "
+                    "received {}"
+                    "".format(len(cg1.controllers))
+                )
+        return result, cause
+
+    if len(cg1.controllers[CONTROLLER].settings) != 1:
+        result = consts.TEST_FAILED
+        cause = (
+                    "Settings length doesn't match, expected 1, but "
+                    " received {}"
+                    "".format(len(cg1.controllers[CONTROLLER].settings))
+                )
+        return result, cause
+
+    if cg1.controllers[CONTROLLER].settings[SETTING1] != VALUE1:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected {} = {} but received {}'
+                    ''.format(SETTING1, VALUE1,
+                              cg1.controllers[CONTROLLER].settings[SETTING1])
+                )
+        return result, cause
+
+    cg2 = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg2.add_controller(CONTROLLER)
+    cg2.add_setting(SETTING2)
+
+    cg2.cgxget()
+
+    if len(cg2.controllers) != 1:
+        result = consts.TEST_FAILED
+        cause = (
+                    "Controller length doesn't match, expected 1, but"
+                    " received {}"
+                    "".format(len(cg2.controllers))
+                )
+        return result, cause
+
+    if len(cg2.controllers[CONTROLLER].settings) != 1:
+        result = consts.TEST_FAILED
+        cause = (
+                    "Settings length doesn't match, expected 1, but"
+                    "received {}"
+                    "".format(len(cg2.controllers[CONTROLLER].settings))
+                )
+        return result, cause
+
+    if cg2.controllers[CONTROLLER].settings[SETTING2] != VALUE2:
+        result = consts.TEST_FAILED
+        cause = (
+                    'Expected {} = {} but received {}'
+                    ''.format(SETTING2, VALUE2,
+                              cg2.controllers[CONTROLLER].settings[SETTING2])
+                )
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    CgroupCli.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/040-pybindings-cgxset.py
+++ b/tests/ftests/040-pybindings-cgxset.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgxset functionality test using the python bindings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import CgroupVersion as CgroupCliVersion
+from cgroup import Cgroup as CgroupCli
+from libcgroup import Cgroup, Version
+from run import Run
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '040bindings'
+
+SETTING1 = 'cpu.shares'
+VALUE1 = '512'
+
+SETTING2 = 'cpu.weight'
+VALUE2 = '50'
+
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    user_name = Run.run('whoami', shell_bool=True)
+    group_name = Run.run('groups', shell_bool=True).split(' ')[0]
+
+    CgroupCli.create(config, controller_list=CONTROLLER, cgname=CGNAME,
+                     user_name=user_name, group_name=group_name)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cg1 = Cgroup(CGNAME, Version.CGROUP_V1)
+    cg1.add_controller(CONTROLLER)
+    cg1.add_setting(SETTING1, VALUE1)
+
+    cg1.cgxset()
+
+    value_v1 = CgroupCli.xget(
+                                config, setting=SETTING1, print_headers=False,
+                                values_only=True,
+                                version=CgroupCliVersion.CGROUP_V1,
+                                cgname=CGNAME
+                             )
+
+    if value_v1 != VALUE1:
+        result = consts.TEST_FAILED
+        cause = 'Expected {}, but received {}'.format(VALUE1, value_v1)
+        return result, cause
+
+    # Set the cpu.shares/cpu.weight to an arbitrary value to ensure
+    # the following v2 cgxset works properly
+    CgroupCli.xset(config, cgname=CGNAME, setting=SETTING1, value='1234',
+                   version=CgroupCliVersion.CGROUP_V1)
+
+    cg2 = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg2.add_controller(CONTROLLER)
+    cg2.add_setting(SETTING2, VALUE2)
+
+    cg2.cgxset()
+
+    value_v2 = CgroupCli.xget(
+                                config, setting=SETTING2, print_headers=False,
+                                values_only=True,
+                                version=CgroupCliVersion.CGROUP_V2,
+                                cgname=CGNAME
+                             )
+
+    if value_v2 != VALUE2:
+        result = consts.TEST_FAILED
+        cause = 'Expected {}, but received {}'.format(VALUE2, value_v2)
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    CgroupCli.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/041-pybindings-library_version.py
+++ b/tests/ftests/041-pybindings-library_version.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# get the library version using the python bindings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from libcgroup import Cgroup
+import consts
+import ftests
+import sys
+import os
+
+
+def prereqs(config):
+    return consts.TEST_PASSED, None
+
+
+def setup(config):
+    return consts.TEST_PASSED, None
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    [major, minor, release] = Cgroup.library_version()
+
+    if not isinstance(major, int):
+        result = consts.TEST_FAILED
+        cause = 'Major version failed. Received {}'.format(major)
+        return result, cause
+
+    if not isinstance(minor, int):
+        result = consts.TEST_FAILED
+        cause = 'Minor version failed. Received {}'.format(minor)
+        return result, cause
+
+    if not isinstance(release, int):
+        result = consts.TEST_FAILED
+        cause = 'Release version failed. Received {}'.format(release)
+        return result, cause
+
+    return result, cause
+
+
+def teardown(config):
+    pass
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/042-cgxget-unmappable.py
+++ b/tests/ftests/042-cgxget-unmappable.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Cgxget test with no mappable settings
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '042cgxget'
+SETTING = 'cpu.stat'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version(CONTROLLER) == CgroupVersion.CGROUP_V1:
+        # request the opposite version of what this system is running
+        requested_ver = CgroupVersion.CGROUP_V2
+    else:
+        requested_ver = CgroupVersion.CGROUP_V1
+
+    out = Cgroup.xget(
+                        config, cgname=CGNAME, setting=SETTING,
+                        version=requested_ver, print_headers=False,
+                        ignore_unmappable=True
+                      )
+    if len(out):
+        result = consts.TEST_FAILED
+        cause = 'Expected cgxget to return nothing.  Received {}'.format(out)
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/043-cgcreate-empty_controller.py
+++ b/tests/ftests/043-cgcreate-empty_controller.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgcreate with no controller specified functionality test
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import sys
+import os
+
+# Which controller isn't all that important, but it is important that we
+# have a cgroup v2 controller
+CONTROLLER = 'cpu'
+CGNAME = '043cgcreate'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v2'
+
+    return result, cause
+
+
+def setup(config):
+    return consts.TEST_PASSED, None
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.create(config, None, CGNAME)
+
+    # verify the cgroup exists by reading cgroup.procs
+    Cgroup.get(
+                config, controller=None, cgname=CGNAME,
+                setting='cgroup.procs', print_headers=True,
+                values_only=False
+              )
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, None, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/044-pybindings-cgcreate_empty_controller.py
+++ b/tests/ftests/044-pybindings-cgcreate_empty_controller.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# empty cgcreate functionality test using the python bindings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli
+from libcgroup import Cgroup, Version
+from cgroup import CgroupVersion
+from run import Run
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+PARENT_NAME = '044cgcreate'
+CGNAME = os.path.join(PARENT_NAME, 'madeviapython')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v2'
+
+    return result, cause
+
+
+def setup(config):
+    user_name = Run.run('whoami', shell_bool=True)
+    group_name = Run.run('groups', shell_bool=True).split(' ')[0]
+
+    CgroupCli.create(config, controller_list=CONTROLLER, cgname=PARENT_NAME,
+                     user_name=user_name, group_name=group_name)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg.create()
+
+    # Read a valid file within the newly created cgroup.
+    # This should fail if the cgroup was not created successfully
+    cg.add_setting(setting_name='cgroup.procs')
+    cg.cgxget()
+
+    return result, cause
+
+
+def teardown(config):
+    CgroupCli.delete(config, None, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/045-pybindings-list_mount_points.py
+++ b/tests/ftests/045-pybindings-list_mount_points.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgroup_list_mount_points functionality test using the python bindings
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from libcgroup import Cgroup, Version
+import consts
+import ftests
+import sys
+import os
+
+CGNAME = '045bindings'
+
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    return consts.TEST_PASSED, None
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    mount_points_v1 = Cgroup.mount_points(Version.CGROUP_V1)
+    mount_points_v2 = Cgroup.mount_points(Version.CGROUP_V2)
+    if not mount_points_v1 and not mount_points_v2:
+        result = consts.TEST_FAILED
+        cause = ("No cgroup mount point found")
+
+    return result, cause
+
+
+def teardown(config):
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/046-cgexec-empty_controller.py
+++ b/tests/ftests/046-cgexec-empty_controller.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+#
+# cgexec to an empty cgroup functionality test using the python bindings
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from run import Run
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = '046cgexec'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v2'
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, None, cgname=CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    config.process.create_process_in_cgroup(config, '', CGNAME)
+    output = Cgroup.get(
+                         config, controller=None, cgname=CGNAME,
+                         setting='cgroup.procs', print_headers=False,
+                         values_only=False
+                        )
+
+    if not len(output):
+        result = consts.TEST_FAILED
+        cause = 'No process created in the cgroup'
+
+    return result, cause
+
+
+def teardown(config):
+    pids = Cgroup.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
+    if pids:
+        for p in pids.splitlines():
+            if config.args.container:
+                config.container.run(['kill', '-9', p])
+            else:
+                Run.run(['sudo', 'kill', '-9', p])
+
+    Cgroup.delete(config, None, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/047-cgcreate-delete_cgrp_shared_mnt.py
+++ b/tests/ftests/047-cgcreate-delete_cgrp_shared_mnt.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Test deleting cgroup on mount point shared by cgroup v1 controllers
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER1 = 'cpu'
+CONTROLLER2 = 'cpuacct'
+
+CGNAME = '047shared_mnts'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+
+    # cpuacct controller is only available on cgroup v1, if an exception
+    # gets raised, then no cgroup v1 controllers mounted.
+    try:
+        CgroupVersion.get_version('cpuacct')
+    except IndexError:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpuacct controller'
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER1, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        Cgroup.delete(config, CONTROLLER2, CGNAME)
+    except RunError as re:
+        if 'No such file or directory' in re.stderr:
+            cause = 'cpu and cpuacct controllers do not share mount points.'
+            result = consts.TEST_FAILED
+        else:
+            raise re
+
+    try:
+        Cgroup.delete(config, CONTROLLER1, CGNAME)
+    except RunError as re:
+        if 'No such file or directory' in re.stderr:
+            cause = 'Missing support to delete cgroup on shared mount points.'
+            result = consts.TEST_FAILED
+        else:
+            raise re
+
+    return result, cause
+
+
+def teardown(config):
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/999-stress-cgroup_init.py
+++ b/tests/ftests/999-stress-cgroup_init.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Stressing cgroup_int() code
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.  All rights reserved.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from libcgroup import Cgroup
+from run import Run
+import consts
+import ftests
+import sys
+import os
+
+MNT_COUNT = 101
+MNT_POINT = '/tmp/999stress/'
+DIR_PREFIX = 'name'
+
+
+def cgroup_path(count):
+    return MNT_POINT + DIR_PREFIX + str(count)
+
+
+def prereqs(config):
+    return consts.TEST_PASSED, None
+
+
+def setup(config):
+    cmd = ['sudo', 'mkdir']
+
+    cmd.append(MNT_POINT)
+
+    for count in range(MNT_COUNT):
+        cmd.append(cgroup_path(count))
+
+    # execute mkdir top-level top-level/sub-directory* at once.
+    Run.run(cmd)
+
+    for count in range(MNT_COUNT):
+        cmd = ['sudo', 'mount', '-t', 'cgroup', '-o']
+        cmd.append('none,name=' + DIR_PREFIX + str(count))
+        cmd.append('none')
+        cmd.append(cgroup_path(count))
+        Run.run(cmd)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        Cgroup.cgroup_init()
+    except RuntimeError as re:
+        if 'Failed to initialize libcgroup: 50008' not in str(re):
+            cause = str(re)
+            result = consts.TEST_FAILED
+
+    return result, cause
+
+
+def teardown(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    for count in range(MNT_COUNT):
+        cmd = ['sudo', 'umount']
+        cmd.append(cgroup_path(count))
+        Run.run(cmd)
+
+    cmd = ['sudo', 'rmdir']
+    for count in range(MNT_COUNT):
+        cmd.append(cgroup_path(count))
+
+    cmd.append(MNT_POINT)
+
+    # execute rmdir top-level top-level/sub-directory* at once.
+    Run.run(cmd)
+
+    return result, cause
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# libcgroup functional tests Makefile.am
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+TESTS = ftests.sh ftests-nocontainer.sh
+
+EXTRA_DIST_PYTHON_UTILS = \
+			  cgroup.py \
+			  config.py \
+			  consts.py \
+			  container.py \
+			  controller.py \
+			  ftests.py \
+			  __init__.py \
+			  log.py \
+			  process.py \
+			  run.py \
+			  utils.py
+
+EXTRA_DIST_PYTHON_TESTS = \
+			  001-cgget-basic_cgget_v1.py \
+			  002-cgdelete-recursive_delete.py \
+			  003-cgget-basic_cgget_v2.py \
+			  004-cgsnapshot-basic_snapshot_v1.py \
+			  005-cgsnapshot-basic_snapshot_v2.py \
+			  006-cgrules-basic_cgrules_v1.py \
+			  007-cgrules-basic_cgrules_v2.py \
+			  008-cgget-multiple_r_flags.py \
+			  009-cgget-g_flag_controller_only.py \
+			  010-cgget-g_flag_controller_and_cgroup.py \
+			  011-cgget-r_flag_two_cgroups.py \
+			  012-cgget-multiple_r_flags2.py \
+			  013-cgget-multiple_g_flags.py \
+			  014-cgget-a_flag.py \
+			  015-cgget-multiline_r_flag.py \
+			  016-cgget-invalid_options.py \
+			  017-cgconfig-load_file.py \
+			  018-cgconfig-load_dir.py \
+			  019-cgconfig-uidgid_dperm_fperm.py \
+			  020-cgconfig-tasks_perms_owner.py \
+			  021-cgconfig-invalid_options.py \
+			  022-cgset-multiple_r_flag.py \
+			  023-cgset-copy_from.py \
+			  025-cgset-multiple_cgroups.py \
+			  026-cgset-multiple_r_multiple_cgroup.py \
+			  027-cgset-invalid_options.py \
+			  029-lssubsys-basic_lssubsys.py \
+			  030-lssubsys-lssubsys_all.py \
+			  031-lscgroup-g_flag.py \
+			  032-lscgroup-multiple_g_flags.py \
+			  033-cgget-no_flags.py \
+			  034-cgexec-basic_cgexec.py \
+			  035-cgset-set_cgroup_type.py \
+			  036-cgset-multi_thread.py \
+			  037-cgxget-cpu_settings.py \
+			  038-cgxget-cpuset_settings.py \
+			  039-pybindings-cgxget.py \
+			  040-pybindings-cgxset.py \
+			  041-pybindings-library_version.py \
+			  042-cgxget-unmappable.py \
+			  043-cgcreate-empty_controller.py \
+			  044-pybindings-cgcreate_empty_controller.py
+
+EXTRA_DIST = README.md ftests.sh ftests-nocontainer.sh \
+	     ${EXTRA_DIST_PYTHON_UTILS} ${EXTRA_DIST_PYTHON_TESTS}
+
+clean-local: clean-local-check
+.PHONY: clean-local-check
+clean-local-check:
+	-rm -f *.pyc

--- a/tests/ftests/README.md
+++ b/tests/ftests/README.md
@@ -1,0 +1,65 @@
+## Functional Test Suite for libcgroup
+
+This folder contains the functional test suite for libcgroup.
+The functional test suite utilizes lxc containers to guarantee
+a non-destructive test environment.
+
+The tests can be invoked individually, as a group of related
+tests, or from automake via the standard 'make check'
+command.
+
+## Invocation
+
+Run a single test (first cd to tests/ftests):
+
+    ./001-cgget-basic_cgget.py
+    or
+    ./ftests.py -N 15      # Run test #015
+
+Run a suite of tests (first cd to tests/ftests):
+
+    ./ftests.py -s cgget   # Run all cgget tests
+
+Run all the tests by hand
+
+    ./ftests.py
+    # This may be advantageous over running make check
+    # because it will try to re-use the same lxc
+    # container for all of the tests.  This should
+    # provide a significant performance increase
+
+Run the tests from automake
+
+    make check
+    # Then examine the *.trs and *.log files for
+    # specifics regarding each test result
+
+## Results
+
+The test suite will generate test results upon completion of
+the test run.  An example result is below:
+
+```
+Test Results:
+        Run Date:                     Jun 03 13:41:35
+        Passed:                               1  test
+        Skipped:                              0 tests
+        Failed:                               0 tests
+-----------------------------------------------------------------
+Timing Results:
+        Test                               Time (sec)
+        ---------------------------------------------------------
+        setup                                    6.95
+        001-cgget-basic_cgget.py                 0.07
+        teardown                                 0.00
+        ---------------------------------------------------------
+        Total Run Time                           7.02
+```
+
+A log file can also be generated to help in debugging failed
+tests.  Run `ftests.py -h` to view the syntax.
+
+To generate a log file called foo.log at a debug level (8) run
+the following:
+
+        ./ftests.py -l 8 -L foo.log

--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -1,0 +1,959 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Cgroup class for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from container import ContainerError
+from controller import Controller
+from run import Run, RunError
+import multiprocessing as mp
+from enum import Enum
+import consts
+import utils
+import time
+import copy
+import os
+
+
+class CgroupMount(object):
+    def __init__(self, mount_line):
+        entries = mount_line.split()
+
+        if entries[2] == 'cgroup':
+            self.version = CgroupVersion.CGROUP_V1
+        elif entries[2] == 'cgroup2':
+            self.version = CgroupVersion.CGROUP_V2
+        else:
+            raise ValueError('Unknown cgroup version')
+
+        self.mount_point = entries[1]
+
+        self.controller = None
+        if self.version == CgroupVersion.CGROUP_V1:
+            self.controller = entries[3].split(',')[-1]
+
+            if self.controller == 'clone_children':
+                # the cpuset controller may append this option to the end
+                # rather than the controller name like all other controllers
+                self.controller = 'cpuset'
+
+    def __str__(self):
+        out_str = 'CgroupMount'
+        out_str += '\n\tMount Point = {}'.format(self.mount_point)
+        out_str += '\n\tCgroup Version = {}'.format(self.version)
+        if self.controller is not None:
+            out_str += '\n\tController = {}'.format(self.controller)
+
+        return out_str
+
+
+class CgroupVersion(Enum):
+    CGROUP_UNK = 0
+    CGROUP_V1 = 1
+    CGROUP_V2 = 2
+
+    # given a controller name, get the cgroup version of the controller
+    @staticmethod
+    def get_version(controller):
+        with open('/proc/mounts', 'r') as mntf:
+            for line in mntf.readlines():
+                mnt_path = line.split()[1]
+
+                if line.split()[0] == 'cgroup':
+                    for option in line.split()[3].split(','):
+                        if option == controller:
+                            return CgroupVersion.CGROUP_V1
+                elif line.split()[0] == 'cgroup2':
+                    ctrlf_path = os.path.join(mnt_path, 'cgroup.controllers')
+                    with open(ctrlf_path, 'r') as ctrlf:
+                        controllers = ctrlf.readline()
+                        for ctrl in controllers.split():
+                            if ctrl == controller:
+                                return CgroupVersion.CGROUP_V2
+
+        raise IndexError(
+                            'Unknown version for controller {}'
+                            ''.format(controller)
+                        )
+
+
+class Cgroup(object):
+    # This class is analogous to libcgroup's struct cgroup
+    def __init__(self, name):
+        self.name = name
+        # self.controllers maps to
+        # struct cgroup_controller *controller[CG_CONTROLLER_MAX];
+        self.controllers = dict()
+
+        self.children = list()
+
+    def __str__(self):
+        out_str = 'Cgroup {}\n'.format(self.name)
+        for ctrl_key in self.controllers:
+            out_str += utils.indent(str(self.controllers[ctrl_key]), 4)
+
+        return out_str
+
+    def __eq__(self, other):
+        if not isinstance(other, Cgroup):
+            return False
+
+        if not self.name == other.name:
+            return False
+
+        if self.controllers != other.controllers:
+            return False
+
+        return True
+
+    @staticmethod
+    def build_cmd_path(cmd):
+        return os.path.join(consts.LIBCG_MOUNT_POINT,
+                            'src/tools/{}'.format(cmd))
+
+    @staticmethod
+    def build_daemon_path(cmd):
+        return os.path.join(consts.LIBCG_MOUNT_POINT,
+                            'src/daemon/{}'.format(cmd))
+
+    @staticmethod
+    def create(config, controller_list, cgname, user_name=None,
+               group_name=None, dperm=None, fperm=None, tperm=None,
+               tasks_user_name=None, tasks_group_name=None, cghelp=False):
+        if isinstance(controller_list, str):
+            controller_list = [controller_list]
+
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgcreate'))
+
+        if user_name is not None and group_name is not None:
+            cmd.append('-a')
+            cmd.append('{}:{}'.format(user_name, group_name))
+
+        if dperm is not None:
+            cmd.append('-d')
+            cmd.append(dperm)
+
+        if fperm is not None:
+            cmd.append('-f')
+            cmd.append(fperm)
+
+        if tperm is not None:
+            cmd.append('-s')
+            cmd.append(tperm)
+
+        if tasks_user_name is not None and tasks_group_name is not None:
+            cmd.append('-t')
+            cmd.append('{}:{}'.format(tasks_user_name, tasks_group_name))
+
+        if cghelp:
+            cmd.append('-h')
+
+        if controller_list:
+            controllers_and_path = '{}:{}'.format(
+                ','.join(controller_list), cgname)
+        else:
+            controllers_and_path = ':{}'.format(cgname)
+
+        cmd.append('-g')
+        cmd.append(controllers_and_path)
+
+        if config.args.container:
+            config.container.run(cmd)
+        else:
+            Run.run(cmd)
+
+    @staticmethod
+    def delete(config, controller_list, cgname, recursive=False):
+        if isinstance(controller_list, str):
+            controller_list = [controller_list]
+
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgdelete'))
+
+        if recursive:
+            cmd.append('-r')
+
+        if controller_list:
+            controllers_and_path = '{}:{}'.format(
+                ','.join(controller_list), cgname)
+        else:
+            controllers_and_path = ':{}'.format(cgname)
+
+        cmd.append('-g')
+        cmd.append(controllers_and_path)
+
+        if config.args.container:
+            config.container.run(cmd)
+        else:
+            Run.run(cmd)
+
+    @staticmethod
+    def __set(config, cmd, cgname=None, setting=None, value=None,
+              copy_from=None, cghelp=False):
+        if setting is not None or value is not None:
+            if isinstance(setting, str) and isinstance(value, str):
+                cmd.append('-r')
+                cmd.append('{}={}'.format(setting, value))
+            elif isinstance(setting, list) and isinstance(value, list):
+                if len(setting) != len(value):
+                    raise ValueError(
+                                        'Settings list length must equal '
+                                        'values list length'
+                                    )
+
+                for idx, stg in enumerate(setting):
+                    cmd.append('-r')
+                    cmd.append('{}={}'.format(stg, value[idx]))
+            else:
+                raise ValueError(
+                                    'Invalid inputs to cgget:\nsetting: {}\n'
+                                    'value{}'
+                                    ''.format(setting, value)
+                                )
+
+        if copy_from is not None:
+            cmd.append('--copy-from')
+            cmd.append(copy_from)
+
+        if cgname is not None:
+            if isinstance(cgname, str):
+                # use the string as is
+                cmd.append(cgname)
+            elif isinstance(cgname, list):
+                for cg in cgname:
+                    cmd.append(cg)
+
+        if cghelp:
+            cmd.append('-h')
+
+        if config.args.container:
+            return config.container.run(cmd)
+        else:
+            return Run.run(cmd)
+
+    @staticmethod
+    def set(config, cgname=None, setting=None, value=None, copy_from=None,
+            cghelp=False):
+        """cgset equivalent method
+
+        The following variants of cgset are being tested by the
+        automated functional tests:
+
+        Command                                          Test Number
+        cgset -r setting=value cgname                        various
+        cgset -r setting1=val1 -r setting2=val2
+              -r setting3=val2 cgname                            022
+        cgset --copy_from foo bar                                023
+        cgset --copy_from foo bar1 bar2                          024
+        cgset -r setting=value foo bar                           025
+        cgset -r setting1=value1 setting2=value2 foo bar         026
+        various invalid flag combinations                        027
+        """
+        cmd = list()
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgset'))
+
+        return Cgroup.__set(config, cmd, cgname, setting, value, copy_from,
+                            cghelp)
+
+    @staticmethod
+    def xset(config, cgname=None, setting=None, value=None, copy_from=None,
+             version=CgroupVersion.CGROUP_UNK, cghelp=False,
+             ignore_unmappable=False):
+        """cgxset equivalent method
+        """
+        cmd = list()
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgxset'))
+
+        if version == CgroupVersion.CGROUP_V1:
+            cmd.append('-1')
+        elif version == CgroupVersion.CGROUP_V2:
+            cmd.append('-2')
+
+        if ignore_unmappable:
+            cmd.append('-i')
+
+        return Cgroup.__set(config, cmd, cgname, setting, value, copy_from,
+                            cghelp)
+
+    @staticmethod
+    def __get(config, cmd, controller=None, cgname=None, setting=None,
+              print_headers=True, values_only=False,
+              all_controllers=False, cghelp=False):
+        if not print_headers:
+            cmd.append('-n')
+        if values_only:
+            cmd.append('-v')
+
+        if setting is not None:
+            if isinstance(setting, str):
+                # the user provided a simple string.  use it as is
+                cmd.append('-r')
+                cmd.append(setting)
+            elif isinstance(setting, list):
+                for sttng in setting:
+                    cmd.append('-r')
+                    cmd.append(sttng)
+            else:
+                raise ValueError('Unsupported setting value')
+
+        if controller is not None:
+            if isinstance(controller, str) and ':' in controller:
+                # the user provided a controller:cgroup.  use it as is
+                cmd.append('-g')
+                cmd.append(controller)
+            elif isinstance(controller, str):
+                # the user provided a controller only.  use it as is
+                cmd.append('-g')
+                cmd.append(controller)
+            elif isinstance(controller, list):
+                for ctrl in controller:
+                    cmd.append('-g')
+                    cmd.append(ctrl)
+            else:
+                raise ValueError('Unsupported controller value')
+
+        if all_controllers:
+            cmd.append('-a')
+
+        if cgname is not None:
+            if isinstance(cgname, str):
+                # use the string as is
+                cmd.append(cgname)
+            elif isinstance(cgname, list):
+                for cg in cgname:
+                    cmd.append(cg)
+
+        if cghelp:
+            cmd.append('-h')
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            ret = Run.run(cmd)
+
+        return ret
+
+    @staticmethod
+    def get(config, controller=None, cgname=None, setting=None,
+            print_headers=True, values_only=False,
+            all_controllers=False, cghelp=False):
+        """cgget equivalent method
+
+        Returns:
+        str: The stdout result of cgget
+
+        The following variants of cgget() are being tested by the
+        automated functional tests:
+
+        Command                                          Test Number
+        cgget -r cpuset.cpus mycg                                001
+        cgget -r cpuset.cpus -r cpuset.mems mycg                 008
+        cgget -g cpu mycg                                        009
+        cgget -g cpu:mycg                                        010
+        cgget -r cpuset.cpus mycg1 mycg2                         011
+        cgget -r cpuset.cpus -r cpuset.mems mycg1 mycg2          012
+        cgget -g cpu -g freezer mycg                             013
+        cgget -a mycg                                            014
+        cgget -r memory.stat mycg (multiline value read)         015
+        various invalid flag combinations                        016
+        """
+        cmd = list()
+        cmd.append(Cgroup.build_cmd_path('cgget'))
+
+        return Cgroup.__get(config, cmd, controller, cgname, setting,
+                            print_headers, values_only, all_controllers,
+                            cghelp)
+
+    @staticmethod
+    def xget(config, controller=None, cgname=None, setting=None,
+             print_headers=True, values_only=False,
+             all_controllers=False, version=CgroupVersion.CGROUP_UNK,
+             cghelp=False, ignore_unmappable=False):
+        """cgxget equivalent method
+
+        Returns:
+        str: The stdout result of cgxget
+        """
+        cmd = list()
+        cmd.append(Cgroup.build_cmd_path('cgxget'))
+
+        if version == CgroupVersion.CGROUP_V1:
+            cmd.append('-1')
+        elif version == CgroupVersion.CGROUP_V2:
+            cmd.append('-2')
+
+        if ignore_unmappable:
+            cmd.append('-i')
+
+        return Cgroup.__get(config, cmd, controller, cgname, setting,
+                            print_headers, values_only, all_controllers,
+                            cghelp)
+
+    @staticmethod
+    def classify(config, controller, cgname, pid_list, sticky=False,
+                 cancel_sticky=False):
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgclassify'))
+        cmd.append('-g')
+        cmd.append('{}:{}'.format(controller, cgname))
+
+        if isinstance(pid_list, str):
+            cmd.append(pid_list)
+        elif isinstance(pid_list, int):
+            cmd.append(str(pid_list))
+        elif isinstance(pid_list, list):
+            for pid in pid_list:
+                cmd.append(pid)
+
+        if config.args.container:
+            config.container.run(cmd)
+        else:
+            Run.run(cmd)
+
+    @staticmethod
+    # given a stdout of cgsnapshot-like data, create a dictionary of cgroup
+    # objects
+    def snapshot_to_dict(cgsnapshot_stdout):
+        cgdict = dict()
+
+        class parsemode(Enum):
+            UNKNOWN = 0
+            GROUP = 1
+            CONTROLLER = 2
+            SETTING = 3
+            PERM = 4
+            ADMIN = 5
+            TASK = 6
+
+        mode = parsemode.UNKNOWN
+
+        for line in cgsnapshot_stdout.splitlines():
+            line = line.strip()
+
+            if mode == parsemode.UNKNOWN:
+                if line.startswith('#'):
+                    continue
+
+                elif line.startswith('group') and line.endswith('{'):
+                    cg_name = line.split()[1]
+                    if cg_name in cgdict:
+                        # We already have a cgroup with this name.  This block
+                        # of text contains the next controller for this cgroup
+                        cg = cgdict[cg_name]
+                    else:
+                        cg = Cgroup(cg_name)
+
+                    mode = parsemode.GROUP
+
+            elif mode == parsemode.GROUP:
+                if line.startswith('perm {'):
+                    mode = parsemode.PERM
+                elif line.endswith('{'):
+                    ctrl_name = line.split()[0]
+                    cg.controllers[ctrl_name] = Controller(ctrl_name)
+
+                    mode = parsemode.CONTROLLER
+                elif line.endswith('}'):
+                    # we've found the end of this group
+                    cgdict[cg_name] = cg
+
+                    mode = parsemode.UNKNOWN
+
+            elif mode == parsemode.CONTROLLER:
+                if line.endswith('";'):
+                    # this is a setting on a single line
+                    setting = line.split('=')[0]
+                    value = line.split('=')[1]
+
+                    cg.controllers[ctrl_name].settings[setting] = value
+
+                elif line.endswith('}'):
+                    # we've found the end of this controller
+                    mode = parsemode.GROUP
+
+                else:
+                    # this is a multi-line setting
+                    setting = line.split('=')[0]
+                    value = '{}\n'.format(line.split('=')[1])
+                    mode = parsemode.SETTING
+
+            elif mode == parsemode.SETTING:
+                if line.endswith('";'):
+                    # this is the last line of the multi-line setting
+                    value += line
+
+                    cg.controllers[ctrl_name].settings[setting] = value
+                    mode = parsemode.CONTROLLER
+
+                else:
+                    value += '{}\n'.format(line)
+
+            elif mode == parsemode.PERM:
+                if line.startswith('admin {'):
+                    mode = parsemode.ADMIN
+                elif line.startswith('task {'):
+                    mode = parsemode.TASK
+                elif line.endswith('}'):
+                    mode = parsemode.GROUP
+
+            elif mode == parsemode.ADMIN or mode == parsemode.TASK:
+                # todo - handle these modes
+                if line.endswith('}'):
+                    mode = parsemode.PERM
+
+        return cgdict
+
+    @staticmethod
+    def snapshot(config, controller=None):
+        cmd = list()
+        cmd.append(Cgroup.build_cmd_path('cgsnapshot'))
+        if controller is not None:
+            cmd.append(controller)
+
+        # ensure the deny list file exists
+        if config.args.container:
+            try:
+                config.container.run(
+                                        ['sudo',
+                                         'touch',
+                                         '/etc/cgsnapshot_blacklist.conf']
+                                    )
+            except RunError as re:
+                if re.ret == 0 and 'unable to resolve host' in re.stderr:
+                    pass
+        else:
+            Run.run(['sudo', 'touch', '/etc/cgsnapshot_blacklist.conf'])
+
+        try:
+            if config.args.container:
+                res = config.container.run(cmd)
+            else:
+                res = Run.run(cmd)
+        except RunError as re:
+            if re.ret == 0 and \
+               'neither blacklisted nor whitelisted' in re.stderr:
+                res = re.stdout
+            else:
+                raise(re)
+
+        # convert the cgsnapshot stdout to a dict of cgroup objects
+        return Cgroup.snapshot_to_dict(res)
+
+    @staticmethod
+    def set_cgrules_conf(config, line, append=True):
+        cmd = list()
+
+        cmd.append('sudo')
+        cmd.append('su')
+        cmd.append('-c')
+
+        if append:
+            redirect_str = '>>'
+        else:
+            redirect_str = '>'
+
+        subcmd = '"echo {} {} {}"'.format(line, redirect_str,
+                                          consts.CGRULES_FILE)
+        cmd.append(subcmd)
+
+        if config.args.container:
+            config.container.run(cmd, shell_bool=True)
+        else:
+            Run.run(cmd, shell_bool=True)
+
+    @staticmethod
+    def init_cgrules(config):
+        cmd = list()
+
+        cmd.append('sudo')
+        cmd.append('mkdir')
+        cmd.append('-p')
+        cmd.append('/etc/cgconfig.d')
+
+        try:
+            if config.args.container:
+                config.container.run(cmd, shell_bool=True)
+            else:
+                Run.run(cmd, shell_bool=True)
+        except RunError as re:
+            raise re
+
+        cmd2 = list()
+
+        cmd2.append('sudo')
+        cmd2.append('touch')
+        cmd2.append('/etc/cgconfig.conf')
+
+        if config.args.container:
+            config.container.run(cmd2, shell_bool=True)
+        else:
+            Run.run(cmd2, shell_bool=True)
+
+    # note that this runs cgrulesengd in this process and does not fork
+    # the daemon
+    @staticmethod
+    def __run_cgrules(config):
+        cmd = list()
+
+        cmd.append('sudo')
+        cmd.append(Cgroup.build_daemon_path('cgrulesengd'))
+        cmd.append('-d')
+        cmd.append('-n')
+
+        if config.args.container:
+            raise ValueError(
+                                'Running cgrules within a container is not '
+                                'supported'
+                            )
+        else:
+            Run.run(cmd, shell_bool=True)
+
+    def start_cgrules(self, config):
+        Cgroup.init_cgrules(config)
+
+        p = mp.Process(target=Cgroup.__run_cgrules,
+                       args=(config, ))
+        p.start()
+        time.sleep(2)
+
+        self.children.append(p)
+
+    def join_children(self, config):
+        # todo - make this smarter.  this is ugly, but it works for now
+        cmd = ['sudo', 'killall', 'cgrulesengd']
+        try:
+            if config.args.container:
+                config.container.run(cmd, shell_bool=True)
+            else:
+                Run.run(cmd, shell_bool=True)
+        except (RunError, ContainerError):
+            # ignore any errors during the kill command.  this is belt
+            # and suspenders code
+            pass
+
+        for child in self.children:
+            child.join(1)
+
+    @staticmethod
+    def configparser(config, load_file=None, load_dir=None, dflt_usr=None,
+                     dflt_grp=None, dperm=None, fperm=None, cghelp=False,
+                     tperm=None, tasks_usr=None, tasks_grp=None):
+        """cgconfigparser equivalent method
+
+        Returns:
+        str: The stdout result of cgconfigparser
+
+        The following variants of cgconfigparser are being tested by the
+        automated functional tests:
+
+        Command                                          Test Number
+        cgconfigparser -l conf_file                              017
+        cgconfigparser -L conf_dir                               018
+        cgconfigparser -l conf_file -a usr:grp -d mode -f mode   019
+        cgconfigparser -l conf_file -s mode -t usr:grp           020
+        cgconfigparser -h                                        021
+        cgconfigparser -l improper_conf_file                     021
+        """
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgconfigparser'))
+
+        if load_file is not None:
+            cmd.append('-l')
+            cmd.append(load_file)
+
+        if load_dir is not None:
+            cmd.append('-L')
+            cmd.append(load_dir)
+
+        if dflt_usr is not None and dflt_grp is not None:
+            cmd.append('-a')
+            cmd.append('{}:{}'.format(dflt_usr, dflt_grp))
+
+        if dperm is not None:
+            cmd.append('-d')
+            cmd.append(dperm)
+
+        if fperm is not None:
+            cmd.append('-f')
+            cmd.append(fperm)
+
+        if cghelp:
+            cmd.append('-h')
+
+        if tperm is not None:
+            cmd.append('-s')
+            cmd.append(tperm)
+
+        if tasks_usr is not None and tasks_grp is not None:
+            cmd.append('-t')
+            cmd.append('{}:{}'.format(tasks_usr, tasks_grp))
+
+        if config.args.container:
+            return config.container.run(cmd)
+        else:
+            return Run.run(cmd)
+
+    @staticmethod
+    def __get_controller_mount_point_v1(ctrl_name):
+        with open('/proc/mounts', 'r') as mntf:
+            for line in mntf.readlines():
+                mnt_path = line.split()[1]
+
+                if line.split()[0] == 'cgroup':
+                    for option in line.split()[3].split(','):
+                        if option == ctrl_name:
+                            return mnt_path
+
+        raise IndexError(
+                            'Unknown mount point for controller {}'
+                            ''.format(ctrl_name)
+                        )
+
+    @staticmethod
+    def __get_controller_mount_point_v2(ctrl_name):
+        with open('/proc/mounts', 'r') as mntf:
+            for line in mntf.readlines():
+                mnt_path = line.split()[1]
+
+                if line.split()[0] == 'cgroup2':
+                    ctrl_file = os.path.join(line.split()[1],
+                                             'cgroup.controllers')
+
+                    with open(ctrl_file, 'r') as ctrlf:
+                        controllers = ctrlf.readline()
+                        for controller in controllers.split():
+                            if controller == ctrl_name:
+                                return mnt_path
+
+        raise IndexError(
+                            'Unknown mount point for controller {}'
+                            ''.format(ctrl_name)
+                        )
+
+    @staticmethod
+    def get_controller_mount_point(ctrl_name):
+        vers = CgroupVersion.get_version(ctrl_name)
+
+        if vers == CgroupVersion.CGROUP_V1:
+            return Cgroup.__get_controller_mount_point_v1(ctrl_name)
+        elif vers == CgroupVersion.CGROUP_V2:
+            return Cgroup.__get_controller_mount_point_v2(ctrl_name)
+        else:
+            raise ValueError('Unsupported cgroup version')
+
+    @staticmethod
+    def clear(config, empty=False, cghelp=False, load_file=None,
+              load_dir=None):
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgclear'))
+
+        if empty:
+            cmd.append('-e')
+
+        if cghelp:
+            cmd.append('-h')
+
+        if load_file is not None:
+            cmd.append('-l')
+            cmd.append(load_file)
+
+        if load_dir is not None:
+            cmd.append('-L')
+            cmd.append(load_dir)
+
+        if config.args.container:
+            return config.container.run(cmd)
+        else:
+            return Run.run(cmd)
+
+    @staticmethod
+    def lssubsys(config, ls_all=False, cghelp=False, hierarchies=False,
+                 mount_points=False, all_mount_points=False):
+        cmd = list()
+
+        cmd.append(Cgroup.build_cmd_path('lssubsys'))
+
+        if ls_all:
+            cmd.append('-a')
+
+        if cghelp:
+            cmd.append('-h')
+
+        if hierarchies:
+            cmd.append('-i')
+
+        if mount_points:
+            cmd.append('-m')
+
+        if all_mount_points:
+            cmd.append('-M')
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            ret = Run.run(cmd)
+
+        return ret
+
+    @staticmethod
+    def get_cgroup_mounts(config, expand_v2_mounts=True):
+        mount_list = list()
+
+        with open('/proc/mounts') as mntf:
+            for line in mntf.readlines():
+                entry = line.split()
+
+                if entry[0] != 'cgroup' and entry[0] != 'cgroup2':
+                    continue
+
+                mount = CgroupMount(line)
+
+                if mount.version == CgroupVersion.CGROUP_V1 or \
+                   expand_v2_mounts is False:
+                    mount_list.append(mount)
+                    continue
+
+                with open(os.path.join(mount.mount_point,
+                                       'cgroup.controllers')) as ctrlf:
+                    for ctrlf_line in ctrlf.readlines():
+                        for ctrl in ctrlf_line.split():
+                            mount_copy = copy.deepcopy(mount)
+                            mount_copy.controller = ctrl
+                            mount_list.append(mount_copy)
+
+        return mount_list
+
+    @staticmethod
+    def lscgroup(config, cghelp=False, controller=None, path=None):
+        cmd = list()
+
+        cmd.append(Cgroup.build_cmd_path('lscgroup'))
+
+        if cghelp:
+            cmd.append('-h')
+
+        if controller is not None and path is not None:
+            if isinstance(controller, list):
+                for idx, ctrl in enumerate(controller):
+                    cmd.append('-g')
+                    cmd.append('{}:{}'.format(ctrl, path[idx]))
+            elif isinstance(controller, str):
+                cmd.append('-g')
+                cmd.append('{}:{}'.format(controller, path))
+            else:
+                raise ValueError('Unsupported controller value')
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            ret = Run.run(cmd)
+
+        return ret
+
+    # exec is a keyword in python, so let's name this function cgexec
+    @staticmethod
+    def cgexec(config, controller, cgname, cmdline, sticky=False,
+               cghelp=False):
+        """cgexec equivalent method
+        """
+        cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgexec'))
+        cmd.append('-g')
+        cmd.append('{}:{}'.format(controller, cgname))
+
+        if sticky:
+            cmd.append('--sticky')
+
+        if isinstance(cmdline, str):
+            cmd.append(cmdline)
+        elif isinstance(cmdline, list):
+            for entry in cmdline:
+                cmd.append(entry)
+
+        if cghelp:
+            cmd.append('-h')
+
+        if config.args.container:
+            return config.container.run(cmd, shell_bool=True)
+        else:
+            return Run.run(cmd, shell_bool=True)
+
+    @staticmethod
+    def get_pids_in_cgroup(config, cgroup, controller):
+        mounts = Cgroup.get_cgroup_mounts(config)
+
+        for mount in mounts:
+            if mount.controller == controller:
+                proc_file = os.path.join(
+                                            mount.mount_point,
+                                            cgroup,
+                                            'cgroup.procs'
+                                        )
+                cmd = ['cat', proc_file]
+
+                if config.args.container:
+                    return config.container.run(cmd, shell_bool=True)
+                else:
+                    return Run.run(cmd, shell_bool=True)
+
+        return None
+
+    @staticmethod
+    def get_and_validate(config, cgname, setting, expected_value):
+        """get the requested setting and validate the value received
+
+        This is a helper method for the functional tests and there is no
+        equivalent libcgroup command line interface.  This method will
+        raise a CgroupError if the comparison fails
+        """
+        value = Cgroup.get(config, controller=None, cgname=cgname,
+                           setting=setting, print_headers=False,
+                           values_only=True)
+
+        if value != expected_value:
+            raise CgroupError('cgget expected {} but received {}'.format(
+                              expected_value, value))
+
+    @staticmethod
+    def set_and_validate(config, cgname, setting, value):
+        """set the requested setting and validate the write
+
+        This is a helper method for the functional tests and there is no
+        equivalent libcgroup command line interface.  This method will
+        raise a CgroupError if the comparison fails
+        """
+        Cgroup.set(config, cgname, setting, value)
+        Cgroup.get_and_validate(config, cgname, setting, value)
+
+
+class CgroupError(Exception):
+    def __init__(self, message):
+        super(CgroupError, self).__init__(message)
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/config.py
+++ b/tests/ftests/config.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Config class for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from container import Container
+from process import Process
+import consts
+import utils
+import os
+
+
+class Config(object):
+    def __init__(self, args, container=None):
+        self.args = args
+        self.skip_list = []
+
+        if self.args.container:
+            if container:
+                self.container = container
+            else:
+                # Use the default container settings
+                self.container = Container(name=args.name,
+                                           stop_timeout=args.timeout,
+                                           arch=None,
+                                           distro=args.distro,
+                                           release=args.release)
+
+        self.process = Process()
+
+        self.ftest_dir = os.path.dirname(os.path.abspath(__file__))
+        self.libcg_dir = os.path.dirname(self.ftest_dir)
+
+        self.test_suite = consts.TESTS_RUN_ALL_SUITES
+        self.test_num = consts.TESTS_RUN_ALL
+        self.verbose = False
+
+    def __str__(self):
+        out_str = 'Configuration\n'
+        if self.args.container:
+            out_str += utils.indent(str(self.container), 4)
+        out_str += utils.indent(str(self.process), 4)
+
+        return out_str
+
+
+class ConfigError(Exception):
+    def __init__(self, message):
+        super(ConfigError, self).__init__(message)
+
+    def __str__(self):
+        out_str = 'ConfigError:\n\tmessage = {}'.format(self.message)
+        return out_str
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/consts.py
+++ b/tests/ftests/consts.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Constants for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+import os
+
+DEFAULT_LOG_FILE = 'libcgroup-ftests.log'
+
+LOG_CRITICAL = 1
+LOG_WARNING = 5
+LOG_DEBUG = 8
+DEFAULT_LOG_LEVEL = 5
+
+ftest_dir = os.path.dirname(os.path.abspath(__file__))
+tests_dir = os.path.dirname(ftest_dir)
+LIBCG_MOUNT_POINT = os.path.dirname(tests_dir)
+
+DEFAULT_CONTAINER_NAME = 'TestLibcg'
+DEFAULT_CONTAINER_DISTRO = 'ubuntu'
+DEFAULT_CONTAINER_RELEASE = '22.04'
+DEFAULT_CONTAINER_ARCH = 'amd64'
+DEFAULT_CONTAINER_STOP_TIMEOUT = 5
+
+TESTS_RUN_ALL = -1
+TESTS_RUN_ALL_SUITES = 'allsuites'
+TEST_PASSED = 'passed'
+TEST_FAILED = 'failed'
+TEST_SKIPPED = 'skipped'
+
+CGRULES_FILE = '/etc/cgrules.conf'
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/container.py
+++ b/tests/ftests/container.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Container class for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from run import Run, RunError
+from queue import Queue
+import threading as tp
+from log import Log
+import consts
+import time
+import os
+
+
+class Container(object):
+    def __init__(self, name, stop_timeout=None, arch=None, cfg_path=None,
+                 distro=None, release=None):
+        self.name = name
+        self.privileged = True
+
+        if stop_timeout:
+            self.stop_timeout = stop_timeout
+        else:
+            self.stop_timeout = consts.DEFAULT_CONTAINER_STOP_TIMEOUT
+
+        if arch:
+            self.arch = arch
+        else:
+            self.arch = consts.DEFAULT_CONTAINER_ARCH
+
+        if distro:
+            self.distro = distro
+        else:
+            self.distro = consts.DEFAULT_CONTAINER_DISTRO
+
+        if release:
+            self.release = release
+        else:
+            self.release = consts.DEFAULT_CONTAINER_RELEASE
+
+        ftest_dir = os.path.dirname(os.path.abspath(__file__))
+        tests_dir = os.path.dirname(ftest_dir)
+        # save off the path to the libcgroup source code
+        self.libcg_dir = os.path.dirname(tests_dir)
+
+    def __str__(self):
+        out_str = 'Container {}'.format(self.name)
+        out_str += '\n\tdistro = {}'.format(self.distro)
+        out_str += '\n\trelease = {}'.format(self.release)
+        out_str += '\n\tarch = {}'.format(self.arch)
+        out_str += '\n\tstop_timeout = {}\n'.format(self.stop_timeout)
+
+        return out_str
+
+    # configure the container to meet our needs
+    def config(self):
+        # map our UID and GID to the same UID/GID in the container
+        cmd = (
+                    'printf "uid {} 1000\ngid {} 1000" | sudo lxc config set '
+                    '{} raw.idmap -'
+                    ''.format(os.getuid(), os.getgid(), self.name)
+              )
+        Run.run(cmd, shell_bool=True)
+
+        # add the libcgroup root directory (where we did the build) into
+        # the container
+        cmd2 = list()
+        if self.privileged:
+            cmd2.append('sudo')
+        cmd2.append('lxc')
+        cmd2.append('config')
+        cmd2.append('device')
+        cmd2.append('add')
+        cmd2.append(self.name)
+        cmd2.append('libcgsrc')  # arbitrary name of device
+        cmd2.append('disk')
+        # to appease gcov, mount the libcgroup source at the same path as we
+        # built it.  This can be worked around someday by using
+        # GCOV_PREFIX_STRIP, but that was more difficult to setup than just
+        # doing this initially
+        cmd2.append('source={}'.format(self.libcg_dir))
+        cmd2.append('path={}'.format(self.libcg_dir))
+
+        return Run.run(cmd2)
+
+    def _init_container(self, q):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('init')
+
+        cmd.append('{}:{}'.format(self.distro, self.release))
+
+        cmd.append(self.name)
+
+        try:
+            Run.run(cmd)
+            q.put(True)
+        except Exception:  # noqa: E722
+            q.put(False)
+        except BaseException:  # noqa: E722
+            q.put(False)
+
+    def create(self):
+        # Github Actions sometimes has timeout issues with the LXC sockets.
+        # Try this command multiple times in an attempt to work around this
+        # limitation
+
+        queue = Queue()
+        sleep_time = 5
+        ret = False
+
+        for i in range(5):
+            thread = tp.Thread(target=self._init_container, args=(queue, ))
+            thread.start()
+
+            time_cnt = 0
+            while thread.is_alive():
+                time.sleep(sleep_time)
+                time_cnt += sleep_time
+                Log.log_debug('Waiting... {}'.format(time_cnt))
+
+            ret = queue.get()
+            if ret:
+                break
+            else:
+                try:
+                    self.delete()
+                except RunError:
+                    pass
+
+            thread.join()
+
+        if not ret:
+            raise ContainerError('Failed to create the container')
+
+    def delete(self):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('delete')
+
+        cmd.append(self.name)
+
+        return Run.run(cmd)
+
+    def run(self, cntnr_cmd, shell_bool=False):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('exec')
+
+        cmd.append(self.name)
+
+        cmd.append('--')
+
+        # concatenate the lxc exec command with the command to be run
+        # inside the container
+        if isinstance(cntnr_cmd, str):
+            cmd.append(cntnr_cmd)
+        elif isinstance(cntnr_cmd, list):
+            cmd = cmd + cntnr_cmd
+        else:
+            raise ContainerError('Unsupported command type')
+
+        return Run.run(cmd, shell_bool=shell_bool)
+
+    def start(self):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('start')
+
+        cmd.append(self.name)
+
+        return Run.run(cmd)
+
+    def stop(self, force=True):
+        cmd = list()
+
+        if self.privileged:
+            cmd.append('sudo')
+
+        cmd.append('lxc')
+        cmd.append('stop')
+
+        cmd.append(self.name)
+
+        if force:
+            cmd.append('-f')
+        else:
+            cmd.append('--timeout')
+            cmd.append(str(self.stop_timeout))
+
+        return Run.run(cmd)
+
+
+class ContainerError(Exception):
+    def __init__(self, message):
+        super(ContainerError, self).__init__(message)
+
+    def __str__(self):
+        out_str = 'ContainerError:\n\tmessage = {}'.format(self.message)
+        return out_str
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/controller.py
+++ b/tests/ftests/controller.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Cgroup class for the libcgroup functional tests
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from log import Log
+
+
+class Controller(object):
+    # The controller class closely mirrors libcgroup's struct cgroup_controller
+    def __init__(self, name):
+        self.name = name
+        # self.settings maps to
+        # struct control_value *values[CG_NV_MAX];
+        self.settings = dict()
+
+    def __str__(self):
+        out_str = 'Controller {}\n'.format(self.name)
+
+        for setting_key in self.settings:
+            out_str += '    {} = {}\n'.format(setting_key,
+                                              self.settings[setting_key])
+
+        return out_str
+
+    def __eq__(self, other):
+        if not isinstance(other, Controller):
+            return False
+
+        if not self.name == other.name:
+            return False
+
+        if not self.settings == other.settings:
+            self_keys = set(self.settings.keys())
+            other_keys = set(other.settings.keys())
+
+            added = other_keys - self_keys
+            if added is not None:
+                for key in added:
+                    Log.log_critical(
+                                        'Other contains {} = {}'
+                                        ''.format(key, other.settings[key])
+                                    )
+
+            removed = self_keys - other_keys
+            if removed is not None:
+                for key in removed:
+                    Log.log_critical(
+                                        'Self contains {} = {}'
+                                        ''.format(key, self.settings[key])
+                                    )
+
+            common = self_keys.intersection(other_keys)
+            for key in common:
+                if self.settings[key] != other.settings[key]:
+                    Log.log_critical(
+                                        'self{} = {} while other{} = {}'
+                                        ''.format(key, self.settings[key],
+                                                  key, other.settings[key])
+                                    )
+
+            return False
+
+        return True
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/ftests-nocontainer.sh
+++ b/tests/ftests/ftests-nocontainer.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-only
+
+START_DIR=$PWD
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [ "$START_DIR" != "$SCRIPT_DIR" ]; then
+	cp "$SCRIPT_DIR"/*.py "$START_DIR"
+fi
+
+if [ -d ../../src/python/build/lib.* ]; then
+	pushd ../../src/python/build/lib.*
+	export PYTHONPATH="$PYTHONPATH:$(pwd)"
+	popd
+fi
+
+./ftests.py -l 10 -L "$START_DIR/ftests-nocontainer.py.log" --no-container \
+	-n Libcg"$RANDOM"
+RET=$?
+
+if [ "$START_DIR" != "$SCRIPT_DIR" ]; then
+	rm -f "$START_DIR"/*.py
+	rm -fr "$START_DIR"/__pycache__
+	rm -f ftests-nocontainer.py.log
+fi
+
+exit $RET

--- a/tests/ftests/ftests.py
+++ b/tests/ftests/ftests.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Main entry point for the libcgroup functional tests
+#
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from config import Config
+from run import Run
+import datetime
+import argparse
+import consts
+import time
+import log
+import sys
+import os
+
+setup_time = 0.0
+teardown_time = 0.0
+
+Log = log.Log
+
+
+def parse_args():
+    parser = argparse.ArgumentParser("Libcgroup Functional Tests")
+    parser.add_argument(
+                            '-n', '--name',
+                            help='name of the container',
+                            required=False,
+                            type=str,
+                            default=consts.DEFAULT_CONTAINER_NAME
+                        )
+    parser.add_argument(
+                            '-d', '--distro',
+                            help='linux distribution to use as a template',
+                            required=False,
+                            type=str,
+                            default=None
+                        )
+    parser.add_argument(
+                            '-r', '--release',
+                            help="distribution release, e.g.'trusty'",
+                            required=False,
+                            type=str,
+                            default=None
+                        )
+    parser.add_argument(
+                            '-a', '--arch',
+                            help='processor architecture',
+                            required=False,
+                            type=str,
+                            default=None
+                        )
+    parser.add_argument(
+                            '-t', '--timeout',
+                            help='wait timeout (sec) before stopping the '
+                                 'container',
+                            required=False,
+                            type=int,
+                            default=None
+                        )
+
+    parser.add_argument(
+                            '-l', '--loglevel',
+                            help='log level',
+                            required=False,
+                            type=int,
+                            default=None
+                        )
+    parser.add_argument(
+                            '-L', '--logfile',
+                            help='log file',
+                            required=False,
+                            type=str,
+                            default=None
+                        )
+
+    parser.add_argument(
+                            '-N', '--num',
+                            help='Test number to run.  If unspecified, all '
+                                 'tests are run',
+                            required=False,
+                            default=consts.TESTS_RUN_ALL,
+                            type=int
+                        )
+    parser.add_argument(
+                            '-S', '--skip',
+                            help="Test number(s) to skip.  If unspecified, all"
+                                 " tests are run. To skip multiple tests, "
+                                 "separate them via a ',', e.g. '5,7,12'",
+                            required=False,
+                            default='',
+                            type=str
+                        )
+    parser.add_argument(
+                            '-s', '--suite',
+                            help='Test suite to run, e.g. cpuset',
+                            required=False,
+                            default=consts.TESTS_RUN_ALL_SUITES,
+                            type=str
+                        )
+
+    container_parser = parser.add_mutually_exclusive_group(required=False)
+    container_parser.add_argument(
+                                    '--container',
+                                    action='store_true',
+                                    help='Run the tests in a container. Note '
+                                         'that some tests cannot be run in a '
+                                         'container.',
+                                    dest='container'
+                                 )
+    container_parser.add_argument(
+                                    '--no-container',
+                                    action='store_false',
+                                    help='Do not run the tests in a container.'
+                                         ' Note that some tests are '
+                                         'destructive and will modify your '
+                                         'cgroup hierarchy.',
+                                    dest='container'
+                                 )
+    parser.set_defaults(container=True)
+
+    parser.add_argument(
+                            '-v', '--verbose',
+                            help='Print all information about this test run',
+                            default=True,
+                            required=False,
+                            action="store_false"
+                        )
+
+    config = Config(parser.parse_args())
+
+    if config.args.skip is None or config.args.skip == '':
+        pass
+    elif config.args.skip.find(',') < 0:
+        config.skip_list.append(int(config.args.skip))
+    else:
+        # multiple tests are being skipped
+        for test_num in config.args.skip.split(','):
+            config.skip_list.append(int(test_num))
+
+    if config.args.loglevel:
+        log.log_level = config.args.loglevel
+    if config.args.logfile:
+        log.log_file = config.args.logfile
+
+    return config
+
+
+# this function maps the container UID to the host UID.  By doing
+# this, we can write to a bind-mounted device - and thus generate
+# code coverage data in the LXD container
+def update_host_subuid():
+    subuid_line1 = 'lxd:{}:1'.format(os.getuid())
+    subuid_line2 = 'root:{}:1'.format(os.getuid())
+    found_line1 = False
+    found_line2 = False
+
+    with open('/etc/subuid') as ufile:
+        for line in ufile.readlines():
+            if line.strip() == subuid_line1:
+                found_line1 = True
+            elif line.strip() == subuid_line2:
+                found_line2 = True
+
+    if not found_line1:
+        Run.run('sudo sh -c "echo {} >> /etc/subuid"'.format(
+                subuid_line1), shell_bool=True)
+    if not found_line2:
+        Run.run('sudo sh -c "echo {} >> /etc/subuid"'.format(
+                subuid_line2), shell_bool=True)
+
+
+# this function maps the container GID to the host GID.  By doing
+# this, we can write to a bind-mounted device - and thus generate
+# code coverage data in the LXD container
+def update_host_subgid():
+    subgid_line1 = 'lxd:{}:1'.format(os.getgid())
+    subgid_line2 = 'root:{}:1'.format(os.getgid())
+    found_line1 = False
+    found_line2 = False
+
+    with open('/etc/subgid') as ufile:
+        for line in ufile.readlines():
+            if line.strip() == subgid_line1:
+                found_line1 = True
+            elif line.strip() == subgid_line2:
+                found_line2 = True
+
+    if not found_line1:
+        Run.run('sudo sh -c "echo {} >> /etc/subgid"'.format(
+                subgid_line1), shell_bool=True)
+    if not found_line2:
+        Run.run('sudo sh -c "echo {} >> /etc/subgid"'.format(
+                subgid_line2), shell_bool=True)
+
+
+def setup(config, do_teardown=True, record_time=False):
+    global setup_time
+
+    start_time = time.time()
+    if do_teardown:
+        # belt and suspenders here.  In case a previous run wasn't properly
+        # cleaned up, let's try and clean it up here
+        try:
+            teardown(config)
+        except Exception as e:
+            # log but ignore all exceptions
+            Log.log_debug(e)
+
+    if config.args.container:
+        # this command initializes the lxd storage, networking, etc.
+        Run.run(['sudo', 'lxd', 'init', '--auto'])
+        update_host_subuid()
+        update_host_subgid()
+
+        config.container.create()
+        config.container.config()
+        config.container.start()
+
+        # add the libcgroup library to the container's ld
+        libcgrp_lib_path = os.path.join(consts.LIBCG_MOUNT_POINT, 'src/.libs')
+        echo_cmd = ([
+                        'bash',
+                        '-c',
+                        'echo {} >> /etc/ld.so.conf.d/libcgroup.conf'
+                        ''.format(libcgrp_lib_path)
+                    ])
+        config.container.run(echo_cmd)
+        config.container.run('ldconfig')
+
+    if record_time:
+        setup_time = time.time() - start_time
+
+
+def run_tests(config):
+    passed_tests = []
+    failed_tests = []
+    skipped_tests = []
+    filename_max = 0
+
+    for root, dirs, filenames in os.walk(config.ftest_dir):
+        for filename in filenames:
+            if os.path.splitext(filename)[-1] != ".py":
+                # ignore non-python files
+                continue
+
+            filenum = filename.split('-')[0]
+
+            try:
+                filenum_int = int(filenum)
+            except ValueError:
+                # D'oh.  This file must not be a test.  Skip it
+                Log.log_debug(
+                                'Skipping {}.  It doesn\'t start with an int'
+                                ''.format(filename)
+                             )
+                continue
+
+            try:
+                filesuite = filename.split('-')[1]
+            except IndexError:
+                Log.log_error(
+                                'Skipping {}.  It doesn\'t conform to the '
+                                'filename format'
+                                ''.format(filename)
+                             )
+                continue
+
+            if config.args.suite == consts.TESTS_RUN_ALL_SUITES or \
+               config.args.suite == filesuite:
+                if config.args.num == consts.TESTS_RUN_ALL or \
+                   config.args.num == filenum_int:
+
+                    if filenum_int in config.skip_list:
+                        continue
+
+                    if len(filename) > filename_max:
+                        filename_max = len(filename)
+
+                    test = __import__(os.path.splitext(filename)[0])
+
+                    failure_cause = None
+                    start_time = time.time()
+                    try:
+                        Log.log_debug('Running test {}.'.format(filename))
+                        [ret, failure_cause] = test.main(config)
+                    except Exception as e:
+                        # catch all exceptions.  you never know when there's
+                        # a crummy test
+                        failure_cause = e
+                        Log.log_debug(e)
+                        ret = consts.TEST_FAILED
+                    finally:
+                        run_time = time.time() - start_time
+                        if ret == consts.TEST_PASSED:
+                            passed_tests.append([filename, run_time])
+                        elif ret == consts.TEST_FAILED:
+                            failed_tests.append([
+                                                 filename,
+                                                 run_time,
+                                                 failure_cause
+                                                 ])
+                        elif ret == consts.TEST_SKIPPED:
+                            skipped_tests.append([
+                                                  filename,
+                                                  run_time,
+                                                  failure_cause
+                                                  ])
+                        else:
+                            raise ValueError('Unexpected ret: {}'.format(ret))
+
+    passed_cnt = len(passed_tests)
+    failed_cnt = len(failed_tests)
+    skipped_cnt = len(skipped_tests)
+
+    print("-----------------------------------------------------------------")
+    print("Test Results:")
+    date_str = datetime.datetime.now().strftime('%b %d %H:%M:%S')
+    print(
+            '\t{}{}'.format(
+                                '{0: <35}'.format("Run Date:"),
+                                '{0: >15}'.format(date_str)
+                            )
+         )
+
+    test_str = "{} test(s)".format(passed_cnt)
+    print(
+            '\t{}{}'.format(
+                                '{0: <35}'.format("Passed:"),
+                                '{0: >15}'.format(test_str)
+                            )
+         )
+
+    test_str = "{} test(s)".format(skipped_cnt)
+    print(
+            '\t{}{}'.format(
+                                '{0: <35}'.format("Skipped:"),
+                                '{0: >15}'.format(test_str)
+                            )
+         )
+
+    test_str = "{} test(s)".format(failed_cnt)
+    print(
+            '\t{}{}'.format(
+                                '{0: <35}'.format("Failed:"),
+                                '{0: >15}'.format(test_str)
+                            )
+         )
+
+    for test in failed_tests:
+        print(
+                "\t\tTest:\t\t\t\t{} - {}"
+                ''.format(test[0], str(test[2]))
+             )
+    print("-----------------------------------------------------------------")
+
+    global setup_time
+    global teardown_time
+    if config.args.verbose:
+        print("Timing Results:")
+        print(
+                '\t{}{}'.format(
+                                    '{0: <{1}}'.format("Test", filename_max),
+                                    '{0: >15}'.format("Time (sec)")
+                                )
+             )
+        print(
+                # 15 is padding space of "Time (sec)"
+                '\t{}'.format('-' * (filename_max + 15))
+             )
+        time_str = "{0: 2.2f}".format(setup_time)
+        print(
+                '\t{}{}'.format(
+                                    '{0: <{1}}'.format('setup', filename_max),
+                                    '{0: >15}'.format(time_str)
+                                )
+             )
+
+        all_tests = passed_tests + skipped_tests + failed_tests
+        all_tests.sort()
+        for test in all_tests:
+            time_str = "{0: 2.2f}".format(test[1])
+            print(
+                    '\t{}{}'.format(
+                                        '{0: <{1}}'.format(test[0],
+                                                           filename_max),
+                                        '{0: >15}'.format(time_str)
+                                    )
+                  )
+        time_str = "{0: 2.2f}".format(teardown_time)
+        print(
+                '\t{}{}'
+                ''.format(
+                            '{0: <{1}}'.format('teardown', filename_max),
+                            '{0: >15}'.format(time_str)
+                          )
+             )
+
+        total_run_time = setup_time + teardown_time
+        for test in passed_tests:
+            total_run_time += test[1]
+        for test in failed_tests:
+            total_run_time += test[1]
+        total_str = "{0: 5.2f}".format(total_run_time)
+        print('\t{}'.format('-' * (filename_max + 15)))
+        print(
+                '\t{}{}'
+                ''.format(
+                            '{0: <{1}}'
+                            ''.format("Total Run Time", filename_max),
+                            '{0: >15}'.format(total_str)
+                         )
+              )
+
+    return [passed_cnt, failed_cnt, skipped_cnt]
+
+
+def teardown(config, record_time=False):
+    global teardown_time
+    start_time = time.time()
+
+    config.process.join_children(config)
+
+    if config.args.container:
+        try:
+            config.container.stop()
+        except Exception as e:
+            # log but ignore all exceptions
+            Log.log_debug(e)
+        try:
+            config.container.delete()
+        except Exception as e:
+            # log but ignore all exceptions
+            Log.log_debug(e)
+
+    if record_time:
+        teardown_time = time.time() - start_time
+
+
+def main(config):
+    AUTOMAKE_SKIPPED = 77
+    AUTOMAKE_HARD_ERROR = 99
+    AUTOMAKE_PASSED = 0
+
+    try:
+        setup(config, record_time=True)
+        [passed_cnt, failed_cnt, skipped_cnt] = run_tests(config)
+    finally:
+        teardown(config, record_time=True)
+
+    if failed_cnt > 0:
+        return failed_cnt
+    if passed_cnt > 0:
+        return AUTOMAKE_PASSED
+    if skipped_cnt > 0:
+        return AUTOMAKE_SKIPPED
+
+    return AUTOMAKE_HARD_ERROR
+
+
+if __name__ == '__main__':
+    config = parse_args()
+    sys.exit(main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/ftests.sh
+++ b/tests/ftests/ftests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-only
+
+START_DIR=$PWD
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [ "$START_DIR" != "$SCRIPT_DIR" ]; then
+	cp "$SCRIPT_DIR"/*.py "$START_DIR"
+fi
+
+if [ -d ../../src/python/build/lib.* ]; then
+	pushd ../../src/python/build/lib.*
+	export PYTHONPATH="$PYTHONPATH:$(pwd)"
+	popd
+fi
+
+./ftests.py -l 10 -L "$START_DIR/ftests.py.log" -n Libcg"$RANDOM"
+RET=$?
+
+if [ "$START_DIR" != "$SCRIPT_DIR" ]; then
+	rm -f "$START_DIR"/*.py
+	rm -fr "$START_DIR"/__pycache__
+	rm -f ftests.py.log
+fi
+
+exit $RET

--- a/tests/ftests/log.py
+++ b/tests/ftests/log.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Log class for the libcgroup functional tests
+#
+# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+import datetime
+import consts
+
+log_level = consts.DEFAULT_LOG_LEVEL
+log_file = consts.DEFAULT_LOG_FILE
+log_fd = None
+
+
+class Log(object):
+
+    @staticmethod
+    def log(msg, msg_level=consts.DEFAULT_LOG_LEVEL):
+        global log_level, log_file, log_fd
+
+        if log_level >= msg_level:
+            if log_fd is None:
+                Log.open_logfd(log_file)
+
+            timestamp = datetime.datetime.now().strftime('%b %d %H:%M:%S')
+            log_fd.write('{}: {}\n'.format(timestamp, msg))
+
+    @staticmethod
+    def open_logfd(log_file):
+        global log_fd
+
+        log_fd = open(log_file, 'a')
+
+    @staticmethod
+    def log_critical(msg):
+        Log.log('CRITICAL: {}'.format(msg), consts.LOG_CRITICAL)
+
+    @staticmethod
+    def log_warning(msg):
+        Log.log('WARNING: {}'.format(msg), consts.LOG_WARNING)
+
+    @staticmethod
+    def log_debug(msg):
+        Log.log('DEBUG: {}'.format(msg), consts.LOG_DEBUG)
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/process.py
+++ b/tests/ftests/process.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Cgroup class for the libcgroup functional tests
+#
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from container import ContainerError
+from cgroup import CgroupVersion
+import multiprocessing as mp
+from cgroup import Cgroup
+from run import RunError
+import threading as tp
+from run import Run
+import time
+
+
+class Process(object):
+    def __init__(self):
+        self.children = list()
+        self.children_pids = list()
+
+    def __str__(self):
+        out_str = 'Process Class\n'
+        out_str += '\tchildren = {}\n'.format(self.children)
+        out_str += '\tchildren_pids = {}\n'.format(self.children_pids)
+
+        return out_str
+
+    @staticmethod
+    def __thread_infinite_loop(config, sleep_time=1):
+        while 1:
+            time.sleep(sleep_time)
+
+    @staticmethod
+    def __infinite_loop(config, sleep_time=1):
+        cmd = ["/usr/bin/perl",
+               "-e",
+               "'while(1){{sleep({})}};'".format(sleep_time)
+               ]
+
+        try:
+            if config.args.container:
+                config.container.run(cmd, shell_bool=True)
+            else:
+                Run.run(cmd, shell_bool=True)
+        except RunError:
+            # when the process is killed, a RunError will be thrown.  let's
+            # catch and suppress it
+            pass
+
+    @staticmethod
+    def __cgexec_infinite_loop(config, controller, cgname, sleep_time=1):
+        cmd = ["/usr/bin/perl",
+               "-e",
+               "'while(1){{sleep({})}};'".format(sleep_time)
+               ]
+
+        try:
+            Cgroup.cgexec(config, controller, cgname, cmd)
+        except RunError:
+            # When this process is killed, it will throw a run error.
+            # Ignore it.
+            pass
+
+    def __save_child_pid(self, config, sleep_time):
+        # get the PID of the newly spawned infinite loop
+        cmd = (
+                "ps x | grep perl | grep 'sleep({})' | awk '{{print $1}}'"
+                "".format(sleep_time)
+              )
+
+        if config.args.container:
+            pid = config.container.run(cmd, shell_bool=True)
+        else:
+            pid = Run.run(cmd, shell_bool=True)
+
+            for _pid in pid.splitlines():
+                self.children_pids.append(_pid)
+
+            if pid.find('\n') >= 0:
+                # The second pid in the list contains the actual perl process
+                pid = pid.splitlines()[1]
+
+        if pid == '' or int(pid) <= 0:
+            raise ValueError(
+                                'Failed to get the pid of the child process:'
+                                '{}'
+                                ''.format(pid)
+                            )
+
+        return pid
+
+    def create_process(self, config):
+        # To allow for multiple processes to be created, each new process
+        # sleeps for a different amount of time.  This lets us uniquely find
+        # each process later in this function
+        sleep_time = len(self.children) + 1
+
+        p = mp.Process(target=Process.__infinite_loop,
+                       args=(config, sleep_time, ))
+        p.start()
+
+        # wait for the process to start.  If we don't wait, then the getpid
+        # logic below may not find the process
+        time.sleep(2)
+
+        pid = self.__save_child_pid(config, sleep_time)
+        self.children.append(p)
+
+        return pid
+
+    # Create a simple process in the requested cgroup
+    def create_process_in_cgroup(self, config, controller, cgname,
+                                 cgclassify=True):
+        if cgclassify:
+            child_pid = self.create_process(config)
+            Cgroup.classify(config, controller, cgname, child_pid)
+        else:
+            # use cgexec
+
+            # To allow for multiple processes to be created, each new process
+            # sleeps for a different amount of time.  This lets us uniquely
+            # find each process later in this function
+            sleep_time = len(self.children) + 1
+
+            p = mp.Process(target=Process.__cgexec_infinite_loop,
+                           args=(config, controller, cgname, sleep_time, ))
+            p.start()
+
+            self.children.append(p)
+
+    def create_threaded_process(self, config, threads_cnt):
+        threads = list()
+
+        for n in range(threads_cnt):
+            sleep_time = n + 1
+            thread = tp.Thread(target=Process.__thread_infinite_loop,
+                               args=(config, sleep_time, ))
+            threads.append(thread)
+
+        for thread in threads:
+            thread.start()
+
+    def create_threaded_process_in_cgroup(self, config, controller, cgname,
+                                          threads=2, cgclassify=True):
+
+        p = mp.Process(target=self.create_threaded_process,
+                       args=(config, threads, ))
+        p.start()
+
+        if cgclassify:
+            Cgroup.classify(config, controller, cgname, p.pid)
+
+        self.children.append(p)
+        self.children_pids.append(p.pid)
+
+        return p.pid
+
+    # The caller will block until all children are stopped.
+    def join_children(self, config):
+        for child in self.children:
+            child.join(1)
+
+        for child in self.children_pids:
+            try:
+                if config.args.container:
+                    config.container.run(['kill', str(child)])
+                else:
+                    Run.run(['kill', str(child)])
+            except (RunError, ContainerError):
+                # ignore any errors during the kill command.  this is belt
+                # and suspenders code
+                pass
+
+    @staticmethod
+    def __get_cgroup_v1(config, pid, controller):
+        cmd = list()
+
+        cmd.append('cat')
+        cmd.append('/proc/{}/cgroup'.format(pid))
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            ret = Run.run(cmd)
+
+        for line in ret.splitlines():
+            # cgroup v1 appears in /proc/{pid}/cgroup like the following:
+            # $ cat /proc/1/cgroup
+            # 12:memory:/
+            # 11:hugetlb:/
+            # 10:perf_event:/
+            # 9:rdma:/
+            # 8:devices:/
+            # 7:cpuset:/
+            # 6:blkio:/
+            # 5:cpu,cpuacct:/
+            # 4:pids:/
+            # 3:freezer:/
+            # 2:net_cls,net_prio:/
+            # 1:name=systemd:/init.scope
+            # 0::/init.scope
+            proc_controllers = line.split(':')[1]
+            if proc_controllers.find(',') >= 0:
+                for proc_controller in proc_controllers.split(','):
+                    if controller == proc_controller:
+                        return line.split(':')[2]
+            else:
+                if controller == proc_controllers:
+                    return line.split(':')[2]
+
+        raise ValueError('Could not get cgroup for pid {} and controller {}'.
+                         format(pid, controller))
+
+    @staticmethod
+    def __get_cgroup_v2(config, pid, controller):
+        cmd = list()
+
+        cmd.append('cat')
+        cmd.append('/proc/{}/cgroup'.format(pid))
+
+        if config.args.container:
+            ret = config.container.run(cmd)
+        else:
+            ret = Run.run(cmd)
+
+        for line in ret.splitlines():
+            # cgroup v2 appears in /proc/{pid}/cgroup like the following:
+            # $ cat /proc/1/cgroup
+            # 0::/init.scope
+            if line.find('::') < 0:
+                # we have identified this controller is cgroup v2,
+                # ignore any cgroup v1 controllers
+                continue
+
+            return line.split(':')[2]
+
+        raise ValueError(
+                            'Could not get cgroup for pid {} and controller {}'
+                            ''.format(pid, controller)
+                        )
+
+    # given a PID and a cgroup controller, what cgroup is this PID a member of
+    @staticmethod
+    def get_cgroup(config, pid, controller):
+        version = CgroupVersion.get_version(controller)
+
+        if version == CgroupVersion.CGROUP_V1:
+            return Process.__get_cgroup_v1(config, pid, controller)
+        elif version == CgroupVersion.CGROUP_V2:
+            return Process.__get_cgroup_v2(config, pid, controller)
+
+        raise ValueError("get_cgroup() shouldn't reach this point")
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/run.py
+++ b/tests/ftests/run.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Run class for the libcgroup functional tests
+#
+# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from log import Log
+import subprocess
+
+
+class Run(object):
+    @staticmethod
+    def run(command, shell_bool=False, ignore_profiling_errors=True):
+        if shell_bool:
+            if isinstance(command, str):
+                # nothing to do.  command is already formatted as a string
+                pass
+            elif isinstance(command, list):
+                command = ' '.join(command)
+            else:
+                raise ValueError('Unsupported command type')
+
+        subproc = subprocess.Popen(command, shell=shell_bool,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        out, err = subproc.communicate()
+        ret = subproc.returncode
+
+        out = out.strip().decode('UTF-8')
+        err = err.strip().decode('UTF-8')
+
+        if shell_bool:
+            Log.log_debug(
+                            'run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}'
+                            '\n\tstderr = {}'
+                            ''.format(command, ret, out, err)
+                         )
+        else:
+            Log.log_debug(
+                            'run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}'
+                            '\n\tstderr = {}'
+                            ''.format(' '.join(command), ret, out, err)
+                         )
+
+        if ret != 0:
+            raise RunError("Command '{}' failed".format(''.join(command)),
+                           command, ret, out, err)
+        if ret != 0 or len(err) > 0:
+            if err.find('WARNING: cgroup v2 is not fully supported yet') >= 0:
+                # LXD throws the above warning on systems that are fully
+                # running cgroup v2.  Ignore this warning, but fail if any
+                # other warnings/errors are raised
+                pass
+            elif ignore_profiling_errors and err.find('profiling') >= 0:
+                pass
+            else:
+                raise RunError("Command '{}' failed".format(''.join(command)),
+                               command, ret, out, err)
+
+        return out
+
+
+class RunError(Exception):
+    def __init__(self, message, command, ret, stdout, stderr):
+        super(RunError, self).__init__(message)
+
+        self.command = command
+        self.ret = ret
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __str__(self):
+        out_str = 'RunError:\n\tcommand = {}\n\tret = {}'.format(
+                  self.command, self.ret)
+        out_str += '\n\tstdout = {}\n\tstderr = {}'.format(self.stdout,
+                                                           self.stderr)
+        return out_str
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/utils.py
+++ b/tests/ftests/utils.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Utility functions for the libcgroup functional tests
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from run import Run
+
+
+# function to indent a block of text by cnt number of spaces
+def indent(in_str, cnt):
+    leading_indent = cnt * ' '
+    return ''.join(leading_indent + line for line in in_str.splitlines(True))
+
+
+def get_file_owner_uid(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append("'%u'")
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)
+
+
+def get_file_owner_username(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append("'%U'")
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)
+
+
+def get_file_owner_gid(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append("'%g'")
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)
+
+
+def get_file_owner_group_name(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append("'%G'")
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)
+
+
+def get_file_permissions(config, filename):
+    cmd = list()
+    cmd.append('stat')
+    cmd.append('-c')
+    cmd.append("'%a'")
+    cmd.append(filename)
+
+    if config.args.container:
+        return config.container.run(cmd, shell_bool=True)
+    else:
+        return Run.run(cmd, shell_bool=True)
+
+# vim: set et ts=4 sw=4:

--- a/tests/gunit/.gitignore
+++ b/tests/gunit/.gitignore
@@ -1,0 +1,6 @@
+*.log
+*.o
+*.trs
+
+gtest
+libgtest.la

--- a/tests/gunit/001-path.cpp
+++ b/tests/gunit/001-path.cpp
@@ -1,0 +1,164 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cg_build_path()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class BuildPathV1Test : public ::testing::Test {
+	protected:
+
+	/**
+	 * Setup this test case
+	 *
+	 * This test case calls cg_build_path() to generate various
+	 * cgroup paths.  The SetUp() routine creates a simple mount
+	 * table that can be used to verify cg_build_path() behavior.
+	 *
+	 * cg_mount_table for this test is as follows:
+	 *	name		mount_point			index
+	 *	-----------------------------------------------------
+	 *	controller0	/sys/fs/cgroup/controller0	0
+	 *	controller1	/sys/fs/cgroup/controller1	1
+	 *	controller2	/sys/fs/cgroup/controller2	2
+	 *	controller3	/sys/fs/cgroup/controller3	3
+	 *	controller4	/sys/fs/cgroup/controller4	4
+	 *	controller5	/sys/fs/cgroup/controller5	5
+	 *
+	 * Note that controllers 1 and 5 are also given namespaces
+	 */
+	void SetUp() override {
+		char NAMESPACE1[] = "ns1";
+		char NAMESPACE5[] = "ns5";
+		const int ENTRY_CNT = 6;
+		int i, ret;
+
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(cg_namespace_table, 0,
+			CG_CONTROLLER_MAX * sizeof(cg_namespace_table[0]));
+
+		// Populate the mount table
+		for (i = 0; i < ENTRY_CNT; i++) {
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
+				 "controller%d", i);
+			cg_mount_table[i].index = i;
+
+			ret = snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
+				 "/sys/fs/cgroup/%s", cg_mount_table[i].name);
+			ASSERT_LT(ret, sizeof(cg_mount_table[i].mount.path));
+
+			cg_mount_table[i].mount.next = NULL;
+		}
+
+		// Give a couple of the entries a namespace as well
+		cg_namespace_table[1] =	NAMESPACE1;
+		cg_namespace_table[5] =	NAMESPACE5;
+	}
+};
+
+/**
+ * No matching controller test
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMismatch test name
+ *
+ * This test will walk through the entire controller mount table
+ * and fail to find a match.
+ * https://github.com/libcgroup/libcgroup/blob/62f76650db84c0a25f76ece3a79d9d16a1e9f931/src/api.c#L1300
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMismatch)
+{
+	char *name = NULL;
+	char path[FILENAME_MAX];
+	/* type intentionally _does not_ match any controllers */
+	char type[] = "FOO";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, NULL);
+}
+
+/**
+ * Matching controller test
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMatch test name
+ *
+ * This test finds a matching controller in the mount table.  Both the
+ * namespace and the cgroup name are NULL.
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatch)
+{
+	char *name = NULL;
+	char path[FILENAME_MAX];
+	char type[] = "controller0";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, "/sys/fs/cgroup/controller0/");
+}
+
+/**
+ * Matching controller test with a cgroup name
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMatchWithName test name
+ *
+ * This test finds a matching controller in the mount table.  The
+ * namespace is NULL, but a valid cgroup name is provided.  This
+ * exercises the `if (name)` statement
+ * https://github.com/libcgroup/libcgroup/blob/62f76650db84c0a25f76ece3a79d9d16a1e9f931/src/api.c#L1289
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatchWithName)
+{
+	char name[] = "TomsCgroup1";
+	char path[FILENAME_MAX];
+	char type[] = "controller3";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, "/sys/fs/cgroup/controller3/TomsCgroup1/");
+}
+
+/**
+ * Matching controller test with a namespace
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMatchWithNs test name
+ *
+ * This test finds a matching controller in the mount table.  The
+ * namespace is valid, but the cgroup name is NULL.  This exercises
+ * exercises the `if (cg_namespace_table[i])` statement
+ * https://github.com/libcgroup/libcgroup/blob/62f76650db84c0a25f76ece3a79d9d16a1e9f931/src/api.c#L1278
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatchWithNs)
+{
+	char *name = NULL;
+	char path[FILENAME_MAX];
+	char type[] = "controller1";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, "/sys/fs/cgroup/controller1/ns1/");
+}
+
+/**
+ * Matching controller test with a namespace and a cgroup name
+ * @param BuildPathV1Test googletest test case name
+ * @param BuildPathV1_ControllerMatchWithNameAndNs test name
+ *
+ * This test finds a matching controller in the mount table.  Both the
+ * namespace and the cgroup name are valid.  This exercises both if
+ * statements in cg_build_path_locked().
+ */
+TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatchWithNameAndNs)
+{
+	char name[] = "TomsCgroup2";
+	char path[FILENAME_MAX];
+	char type[] = "controller5";
+	char *out;
+
+	out = cg_build_path(name, path, type);
+	ASSERT_STREQ(out, "/sys/fs/cgroup/controller5/ns5/TomsCgroup2/");
+}

--- a/tests/gunit/002-cgroup_parse_rules_options.cpp
+++ b/tests/gunit/002-cgroup_parse_rules_options.cpp
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_parse_rules_options()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class ParseRulesOptionsTest : public ::testing::Test {
+};
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_Ignore)
+{
+	struct cgroup_rule rule;
+	char options[] = "ignore";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(rule.is_ignore, true);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_IgnoreWithComma)
+{
+	struct cgroup_rule rule;
+	char options[] = "ignore,";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(rule.is_ignore, true);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_InvalidOption)
+{
+	struct cgroup_rule rule;
+	char options[] = "ignoretypo";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, -EINVAL);
+	ASSERT_EQ(rule.is_ignore, false);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_InvalidOption2)
+{
+	struct cgroup_rule rule;
+	char options[] = "ignore,foobar";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, -EINVAL);
+	ASSERT_EQ(rule.is_ignore, true);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_EmptyOptions)
+{
+	struct cgroup_rule rule;
+	char options[] = "";
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, -EINVAL);
+	ASSERT_EQ(rule.is_ignore, false);
+}
+
+TEST_F(ParseRulesOptionsTest, RulesOptions_NullOptions)
+{
+	struct cgroup_rule rule;
+	char *options = NULL;
+	int ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_parse_rules_options(options, &rule);
+	ASSERT_EQ(ret, -EINVAL);
+	ASSERT_EQ(rule.is_ignore, false);
+}

--- a/tests/gunit/003-cg_get_cgroups_from_proc_cgroups.cpp
+++ b/tests/gunit/003-cg_get_cgroups_from_proc_cgroups.cpp
@@ -1,0 +1,162 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cg_get_cgroups_from_proc_cgroups()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class GetCgroupsFromProcCgroupsTest : public ::testing::Test {
+};
+
+static void CreateCgroupProcFile(const char * const contents)
+{
+	FILE *f;
+
+	f = fopen(TEST_PROC_PID_CGROUP_FILE, "w");
+	ASSERT_NE(f, nullptr);
+
+	fprintf(f, "%s", contents);
+	fclose(f);
+}
+
+
+TEST_F(GetCgroupsFromProcCgroupsTest, ReadSingleLine)
+{
+#undef LIST_LEN
+#define LIST_LEN 3
+	char contents[] =
+		"5:pids:/user.slice/user-1000.slice/session-1.scope\n";
+	char *controller_list[LIST_LEN];
+	char *cgroup_list[LIST_LEN];
+	pid_t pid = 1234;
+	int ret, i;
+
+	for (i = 0; i < LIST_LEN; i++) {
+		controller_list[i] = NULL;
+		cgroup_list[i] = NULL;
+	}
+
+	CreateCgroupProcFile(contents);
+
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
+			controller_list, LIST_LEN);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(controller_list[0], "pids");
+	ASSERT_STREQ(cgroup_list[0],
+		     "user.slice/user-1000.slice/session-1.scope");
+}
+
+TEST_F(GetCgroupsFromProcCgroupsTest, ReadSingleLine2)
+{
+#undef LIST_LEN
+#define LIST_LEN 1
+	char contents[] =
+		"5:cpu,cpuacct:/\n";
+	char *controller_list[LIST_LEN];
+	char *cgroup_list[LIST_LEN];
+	pid_t pid = 1234;
+	int ret, i;
+
+	for (i = 0; i < LIST_LEN; i++) {
+		controller_list[i] = NULL;
+		cgroup_list[i] = NULL;
+	}
+
+	CreateCgroupProcFile(contents);
+
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
+			controller_list, LIST_LEN);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(controller_list[0], "cpu,cpuacct");
+	ASSERT_STREQ(cgroup_list[0], "/");
+}
+
+TEST_F(GetCgroupsFromProcCgroupsTest, ReadEmptyController)
+{
+#undef LIST_LEN
+#define LIST_LEN 1
+	char contents[] =
+		"0::/user.slice/user-1000.slice/session-1.scope\n";
+	char *controller_list[LIST_LEN];
+	char *cgroup_list[LIST_LEN];
+	pid_t pid = 1234;
+	int ret, i;
+
+	for (i = 0; i < LIST_LEN; i++) {
+		controller_list[i] = NULL;
+		cgroup_list[i] = NULL;
+	}
+
+	CreateCgroupProcFile(contents);
+
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
+			controller_list, LIST_LEN);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(controller_list[0], nullptr);
+	ASSERT_EQ(cgroup_list[0], nullptr);
+}
+
+TEST_F(GetCgroupsFromProcCgroupsTest, ReadExampleFile)
+{
+	char contents[] =
+		"12:memory:/user/johndoe/0\n"
+		"11:perf_event:/\n"
+		"10:rdma:/\n"
+		"9:blkio:/user.slice\n"
+		"8:cpu,cpuacct:/myCgroup\n"
+		"7:freezer:/user/johndoe/0\n"
+		"6:net_cls,net_prio:/\n"
+		"5:pids:/user.slice/user-1000.slice/session-1.scope\n"
+		"4:devices:/user.slice\n"
+		"3:cpuset:/\n"
+		"2:hugetlb:/\n"
+		"1:name=systemd:/user.slice/user-1000.slice/session-1.scope\n"
+		"0::/user.slice/user-1000.slice/session-1.scope\n";
+	char *controller_list[MAX_MNT_ELEMENTS];
+	char *cgroup_list[MAX_MNT_ELEMENTS];
+	pid_t pid = 5678;
+	int ret, i;
+
+	for (i = 0; i < MAX_MNT_ELEMENTS; i++) {
+		controller_list[i] = NULL;
+		cgroup_list[i] = NULL;
+	}
+
+	CreateCgroupProcFile(contents);
+
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
+			controller_list, MAX_MNT_ELEMENTS);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(controller_list[0], "memory");
+	ASSERT_STREQ(cgroup_list[0], "user/johndoe/0");
+	ASSERT_STREQ(controller_list[1], "perf_event");
+	ASSERT_STREQ(cgroup_list[1], "/");
+	ASSERT_STREQ(controller_list[2], "rdma");
+	ASSERT_STREQ(cgroup_list[2], "/");
+	ASSERT_STREQ(controller_list[3], "blkio");
+	ASSERT_STREQ(cgroup_list[3], "user.slice");
+	ASSERT_STREQ(controller_list[4], "cpu,cpuacct");
+	ASSERT_STREQ(cgroup_list[4], "myCgroup");
+	ASSERT_STREQ(controller_list[5], "freezer");
+	ASSERT_STREQ(cgroup_list[5], "user/johndoe/0");
+	ASSERT_STREQ(controller_list[6], "net_cls,net_prio");
+	ASSERT_STREQ(cgroup_list[6], "/");
+	ASSERT_STREQ(controller_list[7], "pids");
+	ASSERT_STREQ(cgroup_list[7], "user.slice/user-1000.slice/session-1.scope");
+	ASSERT_STREQ(controller_list[8], "devices");
+	ASSERT_STREQ(cgroup_list[8], "user.slice");
+	ASSERT_STREQ(controller_list[9], "cpuset");
+	ASSERT_STREQ(cgroup_list[9], "/");
+	ASSERT_STREQ(controller_list[10], "hugetlb");
+	ASSERT_STREQ(cgroup_list[10], "/");
+	ASSERT_STREQ(controller_list[11], "name=systemd");
+	ASSERT_STREQ(cgroup_list[11], "user.slice/user-1000.slice/session-1.scope");
+
+	ASSERT_EQ(controller_list[12], nullptr);
+	ASSERT_EQ(cgroup_list[12], nullptr);
+}

--- a/tests/gunit/004-cgroup_compare_ignore_rule.cpp
+++ b/tests/gunit/004-cgroup_compare_ignore_rule.cpp
@@ -1,0 +1,371 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_compare_ignore_rule()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class CgroupCompareIgnoreRuleTest : public ::testing::Test {
+};
+
+static void CreateCgroupProcFile(const char * const contents)
+{
+	FILE *f;
+
+	f = fopen(TEST_PROC_PID_CGROUP_FILE, "w");
+	ASSERT_NE(f, nullptr);
+
+	fprintf(f, "%s", contents);
+	fclose(f);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, NotAnIgnore)
+{
+	char procname[] = "myprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 1234;
+	bool ret;
+
+	rule.is_ignore = false;
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, SimpleMatch)
+{
+	char proc_file_contents[] =
+		"7:cpuacct:/SimpleMatchCgroup";
+	char rule_controller[] = "cpuacct";
+	char procname[] = "procfoo";
+	struct cgroup_rule rule;
+	pid_t pid = 2345;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "SimpleMatchCgroup");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, CgroupsDontMatch)
+{
+	char proc_file_contents[] =
+		"2:cpuacct:CloseButNotQuite";
+	char rule_controller[] = "cpuacct";
+	char procname[] = "procfoo2";
+	struct cgroup_rule rule;
+	pid_t pid = 4567;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "CloseButNotQuit");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, ControllersDontMatch)
+{
+	char proc_file_contents[] =
+		"5:memory:MyCgroup";
+	char rule_controller[] = "cpuacct";
+	char procname[] = "procfoo3";
+	struct cgroup_rule rule;
+	pid_t pid = 5678;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "MyCgroup");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, CombinedControllers)
+{
+	char proc_file_contents[] =
+		"13:cpu,cpuacct:/containercg";
+	char rule_controller[] = "cpuacct";
+	char procname[] = "docker";
+	struct cgroup_rule rule = {0};
+	pid_t pid = 6789;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	rule.controllers[1] = NULL;
+	sprintf(rule.destination, "containercg");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, MatchChildFolder)
+{
+	char proc_file_contents[] =
+		"7:cpuset:/parentcg/childcg/grandchildcg";
+	char rule_controller[] = "cpuset";
+	char procname[] = "childprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 7890;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "parentcg/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, MatchGrandchildFolder)
+{
+	char proc_file_contents[] =
+		"1:hugetlb:/parentcg/childcg/grandchildcg";
+	char rule_controller[] = "hugetlb";
+	char procname[] = "granchildprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 8901;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "parentcg/childcg/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+/**
+ * This test is designed to highlight the case where the user has not put a
+ * trailing slash at the end of the rule's destination.  By design, this will
+ * cause the rule to match a wide variety of cases.
+ *
+ * For example, given the rule destination of "Folder".  The following
+ * behavior would be observed:
+ *	Process Location	Matches the rule?
+ *	Folder			Yes
+ *	Folders			Yes
+ *	Folder/AnotherFolder	Yes
+ *	Folder2			Yes
+ *	Folder3/ChildFolder	Yes
+ *	Folde			No
+ */
+TEST_F(CgroupCompareIgnoreRuleTest, MatchSimilarChildFolder)
+{
+	char proc_file_contents[] =
+		"1:hugetlb:/parentcg/childcg2";
+	char rule_controller[] = "hugetlb";
+	char procname[] = "granchildprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 8901;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "parentcg/childcg");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, RealWorldMatch)
+{
+	char proc_file_contents[] =
+		"12:memory:/user/johndoe/0\n"
+		"11:perf_event:/\n"
+		"10:rdma:/\n"
+		"9:blkio:/user.slice\n"
+		"8:cpu,cpuacct:/myCgroup\n"
+		"7:freezer:/user/johndoe/0\n"
+		"6:net_cls,net_prio:/\n"
+		"5:pids:/user.slice/user-1000.slice/session-1.scope\n"
+		"4:devices:/user.slice\n"
+		"3:cpuset:/\n"
+		"2:hugetlb:/\n"
+		"1:name=systemd:/user.slice/user-1000.slice/session-1.scope\n"
+		"0::/user.slice/user-1000.slice/session-1.scope\n";
+	char rule_controller[] = "cpu";
+	char procname[] = "granchildprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 8901;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "myCgroup/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, RealWorldNoMatch)
+{
+	char proc_file_contents[] =
+		"12:memory:/user/johndoe/0\n"
+		"11:perf_event:/\n"
+		"10:rdma:/\n"
+		"9:blkio:/user.slice\n"
+		"8:cpu,cpuacct:/myCgroup\n"
+		"7:freezer:/user/johndoe/0\n"
+		"6:net_cls,net_prio:/NetCgroup\n"
+		"5:pids:/user.slice/user-1000.slice/session-1.scope\n"
+		"4:devices:/user.slice\n"
+		"3:cpuset:/\n"
+		"2:hugetlb:/\n"
+		"1:name=systemd:/user.slice/user-1000.slice/session-1.scope\n"
+		"0::/user.slice/user-1000.slice/session-1.scope\n";
+	char rule_controller[] = "net_cls";
+	char procname[] = "NotMatching";
+	struct cgroup_rule rule;
+	pid_t pid = 9012;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = NULL;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "NetCgroup2");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, SimilarFolderNoMatch)
+{
+	char proc_file_contents[] =
+		"4:memory:/folder1";
+	char rule_controller[] = "memory";
+	char procname[] = "childprocess";
+	struct cgroup_rule rule;
+	pid_t pid = 2345;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "folder/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, RootDestinationMatch)
+{
+	char proc_file_contents[] =
+		"2:freezer:/";
+	char rule_controller[] = "freezer";
+	char procname[] = "ANewProcess";
+	struct cgroup_rule rule;
+	pid_t pid = 3456;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, RootDestinationNoMatch)
+{
+	char proc_file_contents[] =
+		"2:freezer:/somerandomcg";
+	char rule_controller[] = "freezer";
+	char procname[] = "ANewProcess";
+	struct cgroup_rule rule;
+	pid_t pid = 3456;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "/");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, WildcardProcnameSimpleMatch)
+{
+	char proc_file_contents[] =
+		"7:cpuacct:/MatchCgroup";
+	char rule_controller[] = "cpuacct";
+	char rule_procname[] = "ssh*";
+	char procname[] = "sshd";
+	struct cgroup_rule rule;
+	pid_t pid = 1234;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = rule_procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "MatchCgroup");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(CgroupCompareIgnoreRuleTest, WildcardProcnameNoMatch)
+{
+	char proc_file_contents[] =
+		"7:cpuacct:/AnotherCgroup";
+	char rule_controller[] = "cpuacct";
+	char rule_procname[] = "httpd*";
+	char procname[] = "httpx";
+	struct cgroup_rule rule;
+	pid_t pid = 1234;
+	bool ret;
+
+	CreateCgroupProcFile(proc_file_contents);
+
+	rule.procname = rule_procname;
+	rule.is_ignore = true;
+	rule.controllers[0] = rule_controller;
+	sprintf(rule.destination, "AnotherCgroup");
+
+	ret = cgroup_compare_ignore_rule(&rule, pid, procname);
+	ASSERT_EQ(ret, false);
+}

--- a/tests/gunit/005-cgroup_compare_wildcard_procname.cpp
+++ b/tests/gunit/005-cgroup_compare_wildcard_procname.cpp
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_compare_wildcard_procname()
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class ProcnameWildcardTest : public ::testing::Test {
+};
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_NoAsterisk)
+{
+	char rule_procname[] = "systemd";
+	char procname[] = "bash";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskNoMatch)
+{
+	char rule_procname[] = "BobIsYour*";
+	char procname[] = "Linda";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskMatch)
+{
+	char rule_procname[] = "HelloWorl*";
+	char procname[] = "HelloWorld";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskNoMatch2)
+{
+	char rule_procname[] = "HelloW*";
+	char procname[] = "Hello";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskMatchExactly)
+{
+	char rule_procname[] = "strace*";
+	char procname[] = "strace";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, true);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_NoAsteriskMatchExactly)
+{
+	char rule_procname[] = "systemd-cgls";
+	char procname[] = "systemd-cgls";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, false);
+}
+
+TEST_F(ProcnameWildcardTest, ProcnameWildcard_AsteriskFirstChar)
+{
+	char rule_procname[] = "*";
+	char procname[] = "tomcat";
+	bool ret;
+
+	ret = cgroup_compare_wildcard_procname(rule_procname, procname);
+	ASSERT_EQ(ret, true);
+}

--- a/tests/gunit/006-cgroup_get_cgroup.cpp
+++ b/tests/gunit/006-cgroup_get_cgroup.cpp
@@ -1,0 +1,259 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_get_cgroup()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <bits/stdc++.h>
+#include <string>
+#include <vector>
+using namespace std;
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+#include "libcgroup-internal.h"
+
+#define MAX_NAMES 5
+
+enum ctrl_enum {
+	CTRL_CPU,
+	CTRL_FREEZER,
+	CTRL_MEMORY,
+	CTRL_CPUSET,
+	CTRL_NAMESPACES,
+	CTRL_NETNS,
+
+	CTRL_CNT
+};
+
+static const char * const PARENT_DIR = "test006cgroup";
+
+static const char * const CONTROLLERS[] = {
+	"cpu",
+	"freezer",
+	"memory",
+	"cpuset",
+	"namespaces",
+	"netns",
+};
+static const int CONTROLLERS_CNT =
+	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+
+static const char * const NAMES[][MAX_NAMES] = {
+	{"tasks", "cpu.shares", "cpu.weight", "cpu.foo", NULL},
+	{"tasks", NULL, NULL, NULL, NULL},
+	{"tasks", "memory.limit_in_bytes", "memory.memsw.limit_in_bytes", NULL, NULL},
+	{"tasks", "cpuset.exclusive", "cpuset.foo", "cpuset.bar", "cpuset.x"},
+	{"tasks", "namespaces.blah", NULL, NULL, NULL},
+	{"tasks", "netns.foo", "netns.bar", "netns.baz", NULL},
+};
+static const int NAMES_CNT = sizeof(NAMES) / sizeof(NAMES[0]);
+
+static const char * const VALUES[][MAX_NAMES] = {
+	{"1234", "512", "100", "abc123", NULL},
+	{"2345\n3456", NULL, NULL, NULL, NULL},
+	{"456\n678\n890", "8675309", "1024000", NULL, NULL},
+	{"\0", "1", "limit=32412039", "9223372036854771712", "partition"},
+	{"59832", "The Quick Brown Fox", NULL, NULL, NULL},
+	{"987\n654", "root", "/sys/fs", "0xdeadbeef", NULL},
+};
+static const int VALUES_CNT = sizeof(VALUES) / sizeof(VALUES[0]);
+
+static const char * const CG_NAME = "tomcatcg";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+class CgroupGetCgroupTest : public ::testing::Test {
+	protected:
+
+	void CreateNames(const char * const names[],
+			 const char * const values[],
+			 const char * const ctrl_name)
+	{
+		char tmp_path[FILENAME_MAX];
+		FILE *f;
+		int i;
+
+		for (i = 0; i < NAMES_CNT; i++) {
+			if (names[i] == NULL)
+				break;
+
+			memset(tmp_path, 0, sizeof(tmp_path));
+			snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s/%s",
+				 PARENT_DIR, ctrl_name, CG_NAME, names[i]);
+
+			f = fopen(tmp_path, "w");
+			ASSERT_NE(f, nullptr);
+
+			fprintf(f, "%s", values[i]);
+			fclose(f);
+		}
+	}
+
+	void SetUp() override
+	{
+		char tmp_path[FILENAME_MAX];
+		int i, j, names_len, ret;
+
+		ASSERT_EQ(NAMES_CNT, CONTROLLERS_CNT);
+		ASSERT_EQ(NAMES_CNT, VALUES_CNT);
+
+		ret = cgroup_init();
+		ASSERT_EQ(ret, 0);
+
+		ret = mkdir(PARENT_DIR, MODE);
+		ASSERT_EQ(ret, 0);
+
+		/*
+		 * Artificially populate the mount table with local
+		 * directories
+		 */
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
+
+		for (i = 0; i < CONTROLLERS_CNT; i++) {
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
+				 "%s", CONTROLLERS[i]);
+			snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
+				 "%s/%s", PARENT_DIR, CONTROLLERS[i]);
+			cg_mount_table[i].version = CGROUP_V1;
+
+			ret = mkdir(cg_mount_table[i].mount.path, MODE);
+			ASSERT_EQ(ret, 0);
+
+			/*
+			 * arbitrarily don't make the cgroup directory in
+			 * the freezer controller
+			 */
+			if (i == CTRL_FREEZER)
+				continue;
+
+			memset(tmp_path, 0, sizeof(tmp_path));
+			snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s",
+				 PARENT_DIR, CONTROLLERS[i], CG_NAME);
+			ret = mkdir(tmp_path, MODE);
+			ASSERT_EQ(ret, 0);
+
+			CreateNames(NAMES[i], VALUES[i], CONTROLLERS[i]);
+		}
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override
+	{
+		int ret = 0;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+static void vectorize_cg(const struct cgroup * const cg,
+			 vector<string>& cg_vec)
+{
+	const char *cgname, *cgcname, *value;
+	int i, j;
+
+	for (i = 0; i < cg->index; i++) {
+		for (j = 0; j < cg->controller[i]->index; j++) {
+			string cgname(cg->name);
+			string cgcname(cg->controller[i]->name);
+			string name(cg->controller[i]->values[j]->name);
+			string value(cg->controller[i]->values[j]->value);
+
+			cg_vec.push_back(cgcname + "+" + cgname + "+" +
+					 name + "+" + value);
+		}
+	}
+
+	sort(cg_vec.begin(), cg_vec.end());
+}
+
+static void vectorize_testdata(vector<string>& test_vec)
+{
+	string cgname(CG_NAME);
+	int i, j;
+
+	for (i = 0; i < CTRL_CNT; i++) {
+		for (j = 0; j < MAX_NAMES; j++) {
+			if (NAMES[i][j] == NULL)
+				continue;
+
+			if (strcmp(NAMES[i][j], "tasks") == 0)
+				/*
+				 * The tasks files isn't listed by
+				 * cgroup_get_cgroup()
+				 */
+				continue;
+
+			string cgcname(CONTROLLERS[i]);
+			string name(NAMES[i][j]);
+			string value(VALUES[i][j]);
+
+			test_vec.push_back(cgcname + "+" + cgname + "+" +
+					   name + "+" + value);
+		}
+	}
+
+	sort(test_vec.begin(), test_vec.end());
+}
+
+TEST_F(CgroupGetCgroupTest, CgroupGetCgroup1)
+{
+	vector<string> cg_vec, test_vec;
+	struct cgroup *cg = NULL;
+	int ret;
+
+	cg = cgroup_new_cgroup(CG_NAME);
+	ASSERT_NE(cg, nullptr);
+
+	ret = cgroup_get_cgroup(cg);
+	ASSERT_EQ(ret, 0);
+
+	vectorize_cg(cg, cg_vec);
+	vectorize_testdata(test_vec);
+
+	ASSERT_EQ(cg_vec, test_vec);
+
+	if (cg)
+		free(cg);
+}
+
+/*
+ * This test must be last because it makes destructive changes to the cgroup hierarchy
+ */
+TEST_F(CgroupGetCgroupTest, CgroupGetCgroup_NoTasksFile)
+{
+	char tmp_path[FILENAME_MAX];
+	struct cgroup *cg = NULL;
+	int ret;
+
+	snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s/tasks",
+		 PARENT_DIR, CONTROLLERS[CONTROLLERS_CNT - 1], CG_NAME);
+	ret = rmrf(tmp_path);
+	ASSERT_EQ(ret, 0);
+
+	cg = cgroup_new_cgroup(CG_NAME);
+	ASSERT_NE(cg, nullptr);
+
+	ret = cgroup_get_cgroup(cg);
+	ASSERT_EQ(ret, ECGOTHER);
+
+	if (cg)
+		free(cg);
+}

--- a/tests/gunit/007-cgroup_process_v1_mount.cpp
+++ b/tests/gunit/007-cgroup_process_v1_mount.cpp
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_process_v1_mnt()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <mntent.h>
+
+#include "gtest/gtest.h"
+#include "libcgroup-internal.h"
+
+static int mnt_tbl_idx = 0;
+
+class CgroupProcessV1MntTest : public ::testing::Test {
+};
+
+TEST_F(CgroupProcessV1MntTest, AddV1Mount)
+{
+	char *controllers[] = {"cpu", "memory", NULL};
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup",
+		.mnt_dir = "/sys/fs/cgroup/memory",
+		.mnt_type = "cgroup",
+		.mnt_opts = "rw,nosuid,nodev,noexec,relatime,seclabel,memory",
+	};
+	int ret;
+
+	ret = cgroup_process_v1_mnt(controllers, &ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 1);
+	ASSERT_STREQ(cg_mount_table[0].name, "memory");
+	ASSERT_STREQ(cg_mount_table[0].mount.path, ent.mnt_dir);
+}
+
+/* The AddV1Mount() test above added the memory controller to the
+ * cg_mount_table[].  Now let's add another mount point of the
+ * memory controller to test the duplicate mount handling
+ */
+TEST_F(CgroupProcessV1MntTest, AddV1Mount_Duplicate)
+{
+	char *controllers[] = {"cpu", "cpuset", "memory", NULL};
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup",
+		.mnt_dir = "/cgroup/memory",
+		.mnt_type = "cgroup",
+		.mnt_opts = "rw,nosuid,nodev,noexec,relatime,seclabel,memory",
+	};
+	int ret;
+
+	ASSERT_EQ(NULL, cg_mount_table[0].mount.next);
+
+	ret = cgroup_process_v1_mnt(controllers, &ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 1);
+	ASSERT_STREQ(cg_mount_table[0].mount.next->path, ent.mnt_dir);
+}
+
+TEST_F(CgroupProcessV1MntTest, AddV1NamedMount)
+{
+	char *controllers[] = {"cpu", "memory", "systemd", NULL};
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup",
+		.mnt_dir = "/sys/fs/cgroup/systemd",
+		.mnt_type = "cgroup",
+		.mnt_opts = "rw,nosuid,nodev,noexec,relatime,seclabel,name=systemd",
+	};
+	int ret;
+
+	ret = cgroup_process_v1_mnt(controllers, &ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 1);
+	ASSERT_STREQ(cg_mount_table[0].name, "memory");
+	/* The systemd hierarchy should not be mounted due to it being
+	 * excluded by the OPAQUE_HIERARCHY option
+	 */
+}

--- a/tests/gunit/008-cgroup_process_v2_mount.cpp
+++ b/tests/gunit/008-cgroup_process_v2_mount.cpp
@@ -1,0 +1,187 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_process_v2_mnt()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <ftw.h>
+#include <mntent.h>
+
+#include "gtest/gtest.h"
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test008cgroup";
+static const char * const PARENT2_DIR = "test008cgroup2";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+static const char * const CONTROLLERS[] = {
+	"cpuset",
+	"cpu",
+	"io",
+	"memory",
+	"pids",
+	"rdma",
+};
+static const int CONTROLLERS_CNT =
+	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+
+static int mnt_tbl_idx = 0;
+
+class CgroupProcessV2MntTest : public ::testing::Test {
+	protected:
+
+	void CreateHierarchy(const char * const dir)
+	{
+		char tmp_path[FILENAME_MAX];
+		int i, ret;
+		FILE *f;
+
+		ret = mkdir(dir, MODE);
+		ASSERT_EQ(ret, 0);
+
+		memset(tmp_path, 0, sizeof(tmp_path));
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.controllers",
+			 dir);
+
+		f = fopen(tmp_path, "w");
+		ASSERT_NE(f, nullptr);
+
+		for (i = 0; i < CONTROLLERS_CNT; i++)
+			fprintf(f, "%s ", CONTROLLERS[i]);
+
+		fclose(f);
+	}
+
+	void SetUp() override
+	{
+		char tmp_path[FILENAME_MAX];
+		int i, ret;
+		FILE *f;
+
+		CreateHierarchy(PARENT_DIR);
+
+		/* make another directory to test the duplicate logic */
+		CreateHierarchy(PARENT2_DIR);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override
+	{
+		int ret = 0;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+
+		ret = rmrf(PARENT2_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(CgroupProcessV2MntTest, AddV2Mount)
+{
+	char *mnt_dir = strdup(PARENT_DIR);
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup2",
+		.mnt_dir = mnt_dir,
+		.mnt_type = "cgroup2",
+		.mnt_opts = "rw,relatime,seclabel",
+	};
+	int ret;
+
+	ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 6);
+	ASSERT_STREQ(cg_mount_table[0].name, "cpuset");
+	ASSERT_STREQ(cg_mount_table[1].name, "cpu");
+	ASSERT_STREQ(cg_mount_table[2].name, "io");
+	ASSERT_STREQ(cg_mount_table[3].name, "memory");
+	ASSERT_STREQ(cg_mount_table[4].name, "pids");
+	ASSERT_STREQ(cg_mount_table[5].name, "rdma");
+
+	ASSERT_STREQ(cg_mount_table[0].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[1].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[2].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[3].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[4].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[5].mount.path, ent.mnt_dir);
+}
+
+TEST_F(CgroupProcessV2MntTest, AddV2Mount_Duplicate)
+{
+	char *mnt_dir = strdup(PARENT2_DIR);
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup2",
+		.mnt_dir = mnt_dir,
+		.mnt_type = "cgroup2",
+		.mnt_opts = "rw,relatime,seclabel",
+	};
+	int ret;
+
+	ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(mnt_tbl_idx, 6);
+	ASSERT_STREQ(cg_mount_table[0].name, "cpuset");
+	ASSERT_STREQ(cg_mount_table[1].name, "cpu");
+	ASSERT_STREQ(cg_mount_table[2].name, "io");
+	ASSERT_STREQ(cg_mount_table[3].name, "memory");
+	ASSERT_STREQ(cg_mount_table[4].name, "pids");
+	ASSERT_STREQ(cg_mount_table[5].name, "rdma");
+
+	ASSERT_STREQ(cg_mount_table[0].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[1].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[2].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[3].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[4].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[5].mount.next->path, ent.mnt_dir);
+}
+
+/*
+ * This test must be last because it makes destructive changes to the cgroup hierarchy
+ */
+TEST_F(CgroupProcessV2MntTest, EmptyControllersFile)
+{
+	char tmp_path[FILENAME_MAX];
+	char *mnt_dir = strdup(PARENT_DIR);
+	struct mntent ent = (struct mntent) {
+		.mnt_fsname = "cgroup2",
+		.mnt_dir = mnt_dir,
+		.mnt_type = "cgroup2",
+		.mnt_opts = "rw,relatime,seclabel",
+	};
+	FILE *f;
+	int ret;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.controllers",
+		 PARENT_DIR);
+
+	/* clear the cgroup.controllers file */
+	f = fopen(tmp_path, "w");
+	ASSERT_NE(f, nullptr);
+	fclose(f);
+
+	/* reset the mount table count */
+	mnt_tbl_idx = 0;
+
+	ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
+
+	ASSERT_EQ(ret, ECGEOF);
+	ASSERT_EQ(mnt_tbl_idx, 0);
+}

--- a/tests/gunit/009-cgroup_set_values_recursive.cpp
+++ b/tests/gunit/009-cgroup_set_values_recursive.cpp
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_set_values_recursive()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test009cgroup/";
+
+static const char * const NAMES[] = {
+	"cpu.weight",
+	"cpu.weight.nice",
+	"cpu.foo",
+	"cpu.bar"
+};
+static const int NAMES_CNT = sizeof(NAMES) / sizeof(NAMES[0]);
+
+static const char * const VALUES[] = {
+	"999",
+	"15",
+	"random",
+	"data"
+};
+static const int VALUES_CNT = sizeof(VALUES) / sizeof(VALUES[0]);
+
+
+class SetValuesRecursiveTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override {
+		char tmp_path[FILENAME_MAX];
+		int ret, i;
+		FILE *f;
+
+		ASSERT_EQ(NAMES_CNT, VALUES_CNT);
+
+		ret = mkdir(PARENT_DIR, S_IRWXU | S_IRWXG | S_IRWXO);
+		ASSERT_EQ(ret, 0);
+
+		for (i = 0; i < NAMES_CNT; i++) {
+			memset(tmp_path, 0, sizeof(tmp_path));
+			ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+				       PARENT_DIR, NAMES[i]);
+			ASSERT_GT(ret, 0);
+
+			f = fopen(tmp_path, "w");
+			fclose(f);
+		}
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override {
+		int ret;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(SetValuesRecursiveTest, SuccessfulSetValues)
+{
+	char tmp_path[FILENAME_MAX], buf[4092];
+	struct cgroup_controller ctrlr = {0};
+	int ret, i;
+	char *val;
+	FILE *f;
+
+	ret = snprintf(ctrlr.name, CONTROL_NAMELEN_MAX, "cpu");
+	ASSERT_GT(ret, 0);
+
+	for (i = 0; i < NAMES_CNT; i++) {
+		ctrlr.values[i] = (struct control_value *)calloc(1,
+					sizeof(struct control_value));
+		ASSERT_NE(ctrlr.values[i], nullptr);
+
+		strncpy(ctrlr.values[i]->name, NAMES[i], FILENAME_MAX);
+		strncpy(ctrlr.values[i]->value, VALUES[i],
+			CG_CONTROL_VALUE_MAX);
+		if (i == 0)
+			ctrlr.values[i]->dirty = true;
+		else
+			ctrlr.values[i]->dirty = false;
+		ctrlr.index++;
+	}
+
+	ret = cgroup_set_values_recursive(PARENT_DIR, &ctrlr, true);
+	ASSERT_EQ(ret, 0);
+
+	for (i = 0; i < NAMES_CNT; i++) {
+		memset(tmp_path, 0, sizeof(tmp_path));
+		ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+			       PARENT_DIR, NAMES[i]);
+		ASSERT_GT(ret, 0);
+
+		f = fopen(tmp_path, "r");
+		ASSERT_NE(f, nullptr);
+
+		val = fgets(buf, sizeof(buf), f);
+		ASSERT_NE(val, nullptr);
+		ASSERT_STREQ(buf, VALUES[i]);
+		fclose(f);
+	}
+}

--- a/tests/gunit/010-cgroup_chown_chmod_tasks.cpp
+++ b/tests/gunit/010-cgroup_chown_chmod_tasks.cpp
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_chown_chmod_tasks()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test010cgroup";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+class ChownChmodTasksTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override {
+		char tasks_path[FILENAME_MAX];
+		int ret;
+		FILE *f;
+
+		ret = mkdir(PARENT_DIR, MODE);
+		ASSERT_EQ(ret, 0);
+
+		memset(tasks_path, 0, sizeof(tasks_path));
+		ret = snprintf(tasks_path, FILENAME_MAX - 1, "%s/tasks",
+			       PARENT_DIR);
+		ASSERT_GT(ret, 0);
+
+		f = fopen(tasks_path, "w");
+		fclose(f);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override {
+		int ret;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(ChownChmodTasksTest, SuccessfulChownChmod)
+{
+	mode_t mode = S_IRUSR | S_IWUSR | S_IWGRP | S_IROTH;
+	char tasks_path[FILENAME_MAX];
+	uid_t uid = getuid();
+	gid_t gid = getgid();
+	struct stat statbuf;
+	int ret;
+
+	ret = cgroup_chown_chmod_tasks(PARENT_DIR, uid, gid, mode);
+	ASSERT_EQ(ret, 0);
+
+	memset(tasks_path, 0, sizeof(tasks_path));
+	ret = snprintf(tasks_path, FILENAME_MAX - 1, "%s/tasks",
+		       PARENT_DIR);
+	ASSERT_GT(ret, 0);
+
+	ret = stat(tasks_path, &statbuf);
+	ASSERT_EQ(ret, 0);
+
+	ASSERT_EQ(statbuf.st_uid, uid);
+	ASSERT_EQ(statbuf.st_gid, gid);
+	ASSERT_EQ(statbuf.st_mode & 0777, mode);
+}

--- a/tests/gunit/011-cgroupv2_subtree_control.cpp
+++ b/tests/gunit/011-cgroupv2_subtree_control.cpp
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroupv2_subtree_control()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test011cgroup/";
+static const char * const SUBTREE_FILE = "cgroup.subtree_control";
+
+
+class SubtreeControlTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override {
+		char tmp_path[FILENAME_MAX];
+		int ret, i;
+		FILE *f;
+
+		ret = mkdir(PARENT_DIR, S_IRWXU | S_IRWXG | S_IRWXO);
+		ASSERT_EQ(ret, 0);
+
+		memset(tmp_path, 0, sizeof(tmp_path));
+		ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+			       PARENT_DIR, SUBTREE_FILE);
+		ASSERT_GT(ret, 0);
+
+		f = fopen(tmp_path, "w");
+		fclose(f);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf) {
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override {
+		int ret;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(SubtreeControlTest, AddController)
+{
+	char tmp_path[FILENAME_MAX], buf[4092];
+	char ctrlr_name[] = "cpu";
+	int ret;
+	FILE *f;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+		       PARENT_DIR, SUBTREE_FILE);
+	ASSERT_GT(ret, 0);
+
+	/* erase the contents of the file */
+	f = fopen(tmp_path, "w");
+	fclose(f);
+
+	ret = cgroupv2_subtree_control(PARENT_DIR, ctrlr_name, true);
+	ASSERT_EQ(ret, 0);
+
+	f = fopen(tmp_path, "r");
+	ASSERT_NE(f, nullptr);
+
+	while (fgets(buf, sizeof(buf), f))
+		ASSERT_STREQ(buf, "+cpu");
+	fclose(f);
+}
+
+TEST_F(SubtreeControlTest, RemoveController)
+{
+	char tmp_path[FILENAME_MAX], buf[4092];
+	char ctrlr_name[] = "memory";
+	int ret;
+	FILE *f;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+		       PARENT_DIR, SUBTREE_FILE);
+	ASSERT_GT(ret, 0);
+
+	/* erase the contents of the file */
+	f = fopen(tmp_path, "w");
+	fclose(f);
+
+	ret = cgroupv2_subtree_control(PARENT_DIR, ctrlr_name, false);
+	ASSERT_EQ(ret, 0);
+
+	f = fopen(tmp_path, "r");
+	ASSERT_NE(f, nullptr);
+
+	while (fgets(buf, sizeof(buf), f))
+		ASSERT_STREQ(buf, "-memory");
+	fclose(f);
+}

--- a/tests/gunit/012-cgroup_create_cgroup.cpp
+++ b/tests/gunit/012-cgroup_create_cgroup.cpp
@@ -1,0 +1,219 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_create_cgroup()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <dirent.h>
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test012cgroup";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+static const char * const CONTROLLERS[] = {
+	"cpu",
+	"freezer",
+	"memory",
+	"cpuset",
+	"namespaces",
+	"netns",
+};
+static const int CONTROLLERS_CNT =
+	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+
+static cg_version_t VERSIONS[] = {
+	CGROUP_V1,
+	CGROUP_V2,
+	CGROUP_V2,
+	CGROUP_V1,
+	CGROUP_V1,
+	CGROUP_V2,
+};
+static const int VERSIONS_CNT =
+	sizeof(VERSIONS) / sizeof(VERSIONS[0]);
+
+class CgroupCreateCgroupTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override
+	{
+		char tmp_path[FILENAME_MAX];
+		int ret, i;
+		FILE *f;
+
+		ASSERT_EQ(VERSIONS_CNT, CONTROLLERS_CNT);
+
+		ret = mkdir(PARENT_DIR, MODE);
+		ASSERT_EQ(ret, 0);
+
+		/*
+		 * Artificially populate the mount table with local
+		 * directories
+		 */
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
+
+		for (i = 0; i < CONTROLLERS_CNT; i++) {
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
+				 "%s", CONTROLLERS[i]);
+			cg_mount_table[i].version = VERSIONS[i];
+
+			switch (VERSIONS[i]) {
+			case CGROUP_V1:
+				snprintf(cg_mount_table[i].mount.path,
+					 FILENAME_MAX, "%s/%s", PARENT_DIR,
+					 CONTROLLERS[i]);
+
+				ret = mkdir(cg_mount_table[i].mount.path, MODE);
+				ASSERT_EQ(ret, 0);
+				break;
+			case CGROUP_V2:
+				snprintf(cg_mount_table[i].mount.path,
+					 FILENAME_MAX, "%s", PARENT_DIR);
+
+				memset(tmp_path, 0, sizeof(tmp_path));
+				snprintf(tmp_path, FILENAME_MAX - 1,
+					 "%s/cgroup.subtree_control",
+					 PARENT_DIR);
+
+				f = fopen(tmp_path, "w");
+				ASSERT_NE(f, nullptr);
+				fclose(f);
+				break;
+			default:
+				/* we shouldn't get here.  fail the test */
+				ASSERT_TRUE(false);
+			}
+		}
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override
+	{
+		int ret = 0;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+static void verify_cgroup_created(const char * const cg_name,
+				  const char * const ctrl)
+{
+	char tmp_path[FILENAME_MAX];
+	DIR *dir;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+
+	if (ctrl)
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s",
+			 PARENT_DIR, ctrl, cg_name);
+	else
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s",
+			 PARENT_DIR, cg_name);
+
+	dir = opendir(tmp_path);
+	ASSERT_NE(dir, nullptr);
+	closedir(dir);
+}
+
+static void verify_subtree_contents(const char * const expected)
+{
+	char tmp_path[FILENAME_MAX], buf[4092];
+	FILE *f;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.subtree_control",
+		 PARENT_DIR);
+	f = fopen(tmp_path, "r");
+	ASSERT_NE(f, nullptr);
+
+	while (fgets(buf, sizeof(buf), f))
+		ASSERT_STREQ(buf, expected);
+	fclose(f);
+}
+
+TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1)
+{
+	struct cgroup_controller *ctrl;
+	struct cgroup *cg = NULL;
+	const char * const ctrl_name = "cpu";
+	const char * const cg_name = "MyV1Cgroup";
+	int ret;
+
+	cg = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cg, nullptr);
+
+	ctrl = cgroup_add_controller(cg, ctrl_name);
+	ASSERT_NE(ctrl, nullptr);
+
+	ret = cgroup_create_cgroup(cg, 1);
+	ASSERT_EQ(ret, 0);
+
+	verify_cgroup_created(cg_name, ctrl_name);
+}
+
+TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV2)
+{
+	struct cgroup_controller *ctrl;
+	struct cgroup *cg = NULL;
+	const char * const ctrl_name = "freezer";
+	const char * const cg_name = "MyV2Cgroup";
+	int ret;
+
+	cg = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cg, nullptr);
+
+	ctrl = cgroup_add_controller(cg, ctrl_name);
+	ASSERT_NE(ctrl, nullptr);
+
+	ret = cgroup_create_cgroup(cg, 0);
+	ASSERT_EQ(ret, 0);
+
+	verify_cgroup_created(cg_name, NULL);
+	verify_subtree_contents("+freezer");
+}
+
+TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1AndV2)
+{
+	struct cgroup_controller *ctrl;
+	struct cgroup *cg = NULL;
+	const char * const ctrl1_name = "memory";
+	const char * const ctrl2_name = "cpuset";
+	const char * const cg_name = "MyV1AndV2Cgroup";
+	int ret;
+
+	cg = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cg, nullptr);
+
+	ctrl = cgroup_add_controller(cg, ctrl1_name);
+	ASSERT_NE(ctrl, nullptr);
+	ctrl = NULL;
+	ctrl = cgroup_add_controller(cg, ctrl2_name);
+	ASSERT_NE(ctrl, nullptr);
+
+	ret = cgroup_create_cgroup(cg, 1);
+	ASSERT_EQ(ret, 0);
+
+	verify_cgroup_created(cg_name, NULL);
+	verify_cgroup_created(cg_name, ctrl2_name);
+	verify_subtree_contents("+memory");
+}

--- a/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
+++ b/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
@@ -1,0 +1,149 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroup_build_tasks_procs_path()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class BuildTasksProcPathTest : public ::testing::Test {
+	protected:
+
+	/**
+	 * Setup this test case
+	 *
+	 * This test case calls cg_build_path() to generate various
+	 * cgroup paths.  The SetUp() routine creates a simple mount
+	 * table that can be used to verify cg_build_path() behavior.
+	 *
+	 * cg_mount_table for this test is as follows:
+	 *	name		mount_point		   index  version
+	 *	----------------------------------------------------------
+	 *	controller0	/sys/fs/cgroup/controller0     0      UNK
+	 *	controller1	/sys/fs/cgroup/controller1     1        2
+	 *	controller2	/sys/fs/cgroup/controller2     2        1
+	 *	controller3	/sys/fs/cgroup/controller3     3        2
+	 *	controller4	/sys/fs/cgroup/controller4     4        1
+	 *	controller5	/sys/fs/cgroup/controller5     5        2
+	 *
+	 * Note that controllers 1 and 4 are also given namespaces
+	 */
+	void SetUp() override {
+		char NAMESPACE1[] = "ns1";
+		char NAMESPACE4[] = "ns4";
+		const int ENTRY_CNT = 6;
+		int i, ret;
+
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(cg_namespace_table, 0,
+			CG_CONTROLLER_MAX * sizeof(cg_namespace_table[0]));
+
+		// Populate the mount table
+		for (i = 0; i < ENTRY_CNT; i++) {
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
+				 "controller%d", i);
+			cg_mount_table[i].index = i;
+
+			ret = snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
+				 "/sys/fs/cgroup/%s", cg_mount_table[i].name);
+			ASSERT_LT(ret, sizeof(cg_mount_table[i].mount.path));
+
+			cg_mount_table[i].mount.next = NULL;
+
+			if (i == 0)
+				cg_mount_table[i].version = CGROUP_UNK;
+			else
+				cg_mount_table[i].version =
+					(cg_version_t)((i % 2) + 1);
+		}
+
+		// Give a couple of the entries a namespace as well
+		cg_namespace_table[1] =	NAMESPACE1;
+		cg_namespace_table[4] =	NAMESPACE4;
+	}
+};
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_ControllerNotFound)
+{
+	char ctrlname[] = "InvalidCtrlr";
+	char path[FILENAME_MAX];
+	char cgname[] = "foo";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, ECGOTHER);
+	ASSERT_STREQ(path, "\0");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_UnknownCgVersion)
+{
+	char ctrlname[] = "controller0";
+	char path[FILENAME_MAX];
+	char cgname[] = "bar";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, ECGOTHER);
+	ASSERT_STREQ(path, "\0");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1)
+{
+	char ctrlname[] = "controller2";
+	char path[FILENAME_MAX];
+	char cgname[] = "Container7";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(path, "/sys/fs/cgroup/controller2/Container7/tasks");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2)
+{
+	char ctrlname[] = "controller3";
+	struct cgroup_controller ctrlr = {0};
+	char path[FILENAME_MAX];
+	char cgname[] = "tomcat";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(path, "/sys/fs/cgroup/controller3/tomcat/cgroup.procs");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1WithNs)
+{
+	char ctrlname[] = "controller4";
+	struct cgroup_controller ctrlr = {0};
+	char path[FILENAME_MAX];
+	char cgname[] = "database12";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(path, "/sys/fs/cgroup/controller4/ns4/database12/tasks");
+}
+
+TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2WithNs)
+{
+	char ctrlname[] = "controller1";
+	struct cgroup_controller ctrlr = {0};
+	char path[FILENAME_MAX];
+	char cgname[] = "server";
+	int ret;
+
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+					    ctrlname);
+	ASSERT_EQ(ret, 0);
+	ASSERT_STREQ(path, "/sys/fs/cgroup/controller1/ns1/server/cgroup.procs");
+}

--- a/tests/gunit/014-cgroupv2_get_subtree_control.cpp
+++ b/tests/gunit/014-cgroupv2_get_subtree_control.cpp
@@ -1,0 +1,157 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroupv2_get_subtree_control()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <fcntl.h>
+#include <ftw.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test013cgroup/";
+static const char * const SUBTREE_FILE = "cgroup.subtree_control";
+
+
+class GetSubtreeControlTest : public ::testing::Test {
+	protected:
+
+	void SetUp() override {
+		char tmp_path[FILENAME_MAX];
+		int ret, i;
+		FILE *f;
+
+		ret = mkdir(PARENT_DIR, S_IRWXU | S_IRWXG | S_IRWXO);
+		ASSERT_EQ(ret, 0);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf) {
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override {
+		int ret;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+static void write_subtree_file(const char * const contents, ssize_t len)
+{
+	char tmp_path[FILENAME_MAX];
+	ssize_t bytes_written;
+	int ret, fd;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s%s",
+		       PARENT_DIR, SUBTREE_FILE);
+	ASSERT_GT(ret, 0);
+
+	fd = open(tmp_path, O_WRONLY | O_TRUNC | O_CREAT, S_IRWXU | S_IRWXG);
+	ASSERT_GT(fd, 0);
+
+	bytes_written = write(fd, contents, len);
+	ASSERT_EQ(bytes_written, len);
+	close(fd);
+}
+
+TEST_F(GetSubtreeControlTest, SingleControllerEnabled)
+{
+	char ctrlr_name[] = "cpu";
+	char subtree_contents[] = "cpu\n";
+	bool enabled = false;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(enabled, true);
+}
+
+TEST_F(GetSubtreeControlTest, SingleControllerNoMatch)
+{
+	char ctrlr_name[] = "cpu";
+	char subtree_contents[] = "cpuset\n";
+	bool enabled = true;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, ECGROUPNOTMOUNTED);
+	ASSERT_EQ(enabled, false);
+}
+
+TEST_F(GetSubtreeControlTest, SingleControllerNoMatch2)
+{
+	char ctrlr_name[] = "cpuset";
+	char subtree_contents[] = "cpu\n";
+	bool enabled = true;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, ECGROUPNOTMOUNTED);
+	ASSERT_EQ(enabled, false);
+}
+
+TEST_F(GetSubtreeControlTest, MultipleControllersEnabled)
+{
+	char ctrlr_name[] = "cpu";
+	char subtree_contents[] = "cpu cpuset io memory pids\n";
+	bool enabled = false;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(enabled, true);
+}
+
+TEST_F(GetSubtreeControlTest, MultipleControllersEnabled2)
+{
+	char ctrlr_name[] = "pids";
+	char subtree_contents[] = "cpu cpuset io memory pids\n";
+	bool enabled = false;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(enabled, true);
+}
+
+TEST_F(GetSubtreeControlTest, MultipleControllersNoMatch)
+{
+	char ctrlr_name[] = "network";
+	char subtree_contents[] = "cpu cpuset io memory pids\n";
+	bool enabled = true;
+	int ret;
+
+	write_subtree_file(subtree_contents, strlen(subtree_contents));
+
+	ret = cgroupv2_get_subtree_control(PARENT_DIR, ctrlr_name, &enabled);
+	ASSERT_EQ(ret, ECGROUPNOTMOUNTED);
+	ASSERT_EQ(enabled, false);
+}

--- a/tests/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/tests/gunit/015-cgroupv2_controller_enabled.cpp
@@ -1,0 +1,172 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for cgroupv2_controller_enabled()
+ *
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <ftw.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+static const char * const PARENT_DIR = "test015cgroup";
+static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;
+
+static const char * const CHILD_DIRS[] = {
+	"test1-v1cgroup",
+	"test2-rootcgroup",
+	"test3-ctrlrenabled",
+	"test4-ctrlrdisabled",
+};
+static const int CHILD_DIRS_CNT =
+	sizeof(CHILD_DIRS) / sizeof(CHILD_DIRS[0]);
+
+static const char * const CONTROLLERS[] = {
+	"cpu",
+	"cpuset",
+	"io",
+	"memory",
+	"net_cls",
+	"pids",
+};
+static const int CONTROLLERS_CNT =
+	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+
+static const enum cg_version_t VERSIONS[] = {
+	CGROUP_V2,
+	CGROUP_V1,
+	CGROUP_V2,
+	CGROUP_V2,
+	CGROUP_V2,
+	CGROUP_V2,
+};
+static const int VERSIONS_CNT =
+	sizeof(VERSIONS) / sizeof(VERSIONS[0]);
+
+class CgroupV2ControllerEnabled : public ::testing::Test {
+	protected:
+
+	void InitChildDir(const char dirname[])
+	{
+		char tmp_path[FILENAME_MAX] = {0};
+		int ret;
+
+		/* create the directory */
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s",
+			 PARENT_DIR, dirname);
+		ret = mkdir(tmp_path, MODE);
+		ASSERT_EQ(ret, 0);
+	}
+
+	void InitMountTable(void)
+	{
+		char tmp_path[FILENAME_MAX] = {0};
+		int ret, i;
+		FILE *f;
+
+		ASSERT_EQ(VERSIONS_CNT, CONTROLLERS_CNT);
+
+		snprintf(tmp_path, FILENAME_MAX - 1,
+			 "%s/cgroup.subtree_control", PARENT_DIR);
+
+		f = fopen(tmp_path, "w");
+		ASSERT_NE(f, nullptr);
+		fprintf(f, "cpu io memory pids\n");
+		fclose(f);
+
+		/*
+		 * Artificially populate the mount table with local
+		 * directories
+		 */
+		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
+		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
+
+		for (i = 0; i < CONTROLLERS_CNT; i++) {
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
+				 "%s", CONTROLLERS[i]);
+			snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
+				 "%s", PARENT_DIR);
+			cg_mount_table[i].version = VERSIONS[i];
+		}
+	}
+
+	void SetUp() override
+	{
+		int ret, i;
+
+		ret = mkdir(PARENT_DIR, MODE);
+		ASSERT_EQ(ret, 0);
+
+		InitMountTable();
+
+		for (i = 0; i < CHILD_DIRS_CNT; i++)
+			InitChildDir(CHILD_DIRS[i]);
+	}
+
+	/*
+	 * https://stackoverflow.com/questions/5467725/how-to-delete-a-directory-and-its-contents-in-posix-c
+	 */
+	static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
+		      struct FTW *ftwbuf)
+	{
+		return remove(fpath);
+	}
+
+	int rmrf(const char * const path)
+	{
+		return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+	}
+
+	void TearDown() override
+	{
+		int ret = 0;
+
+		ret = rmrf(PARENT_DIR);
+		ASSERT_EQ(ret, 0);
+	}
+};
+
+TEST_F(CgroupV2ControllerEnabled, CgroupV1Controller)
+{
+	char ctrlr_name[] = "cpuset";
+	char cg_name[] = "foo";
+	int ret;
+
+	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ASSERT_EQ(ret, 0);
+}
+
+TEST_F(CgroupV2ControllerEnabled, RootCgroup)
+{
+	char ctrlr_name[] = "cpu";
+	char cg_name[] = "/";
+	int ret;
+
+	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ASSERT_EQ(ret, 0);
+}
+
+TEST_F(CgroupV2ControllerEnabled, ControllerEnabled)
+{
+	char ctrlr_name[] = "pids";
+	char cg_name[] = "test3-ctrlrenabled";
+	int ret;
+
+	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ASSERT_EQ(ret, 0);
+}
+
+TEST_F(CgroupV2ControllerEnabled, ControllerDisabled)
+{
+	char ctrlr_name[] = "net_cls";
+	char cg_name[] = "test4-ctrlrdisabled";
+	int ret;
+
+	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ASSERT_EQ(ret, ECGROUPNOTMOUNTED);
+}

--- a/tests/gunit/016-cgset_parse_r_flag.cpp
+++ b/tests/gunit/016-cgset_parse_r_flag.cpp
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for parse_r_flag() in cgset
+ *
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+#include "tools-common.h"
+
+static const char * const PARENT_DIR = "test016cgset/";
+
+static const char * const NAME = "io.max";
+static const char * const VALUE = "\"8:16 wbps=1024\"";
+
+class CgsetParseRFlagTest : public ::testing::Test {
+};
+
+TEST_F(CgsetParseRFlagTest, EqualCharInValue)
+{
+	struct control_value name_value;
+	char name_value_str[4092];
+	int ret;
+
+	ret = snprintf(name_value_str, sizeof(name_value_str) -1,
+		       "%s=%s", NAME, VALUE);
+	ASSERT_GT(ret, 0);
+
+	ret = parse_r_flag("cgset", name_value_str, &name_value);
+	ASSERT_EQ(ret, 0);
+
+	ASSERT_STREQ(name_value.name, NAME);
+	ASSERT_STREQ(name_value.value, VALUE);
+}

--- a/tests/gunit/Makefile.am
+++ b/tests/gunit/Makefile.am
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# libcgroup googletests Makefile.am
+#
+# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+AM_CPPFLAGS = -I$(top_srcdir)/include \
+	      -I$(top_srcdir)/src \
+	      -I$(top_srcdir)/src/tools \
+	      -I$(top_srcdir)/googletest/googletest/include \
+	      -I$(top_srcdir)/googletest/googletest \
+	      -std=c++11 \
+	      -Wno-write-strings \
+	      -DSTATIC= \
+	      -DUNIT_TEST
+LDADD = $(top_builddir)/src/.libs/libcgroupfortesting.la \
+	$(top_builddir)/src/tools/.libs/libcgset.la
+
+EXTRA_DIST = $(top_srcdir)/googletest/googletest/libgtest.so \
+	     $(top_srcdir)/googletest/googletest/libgtest_main.so \
+	     $(top_srcdir)/googletest/googletest/include \
+	     libcgroup_unittest.map
+
+check_PROGRAMS = gtest
+TESTS = gtest
+
+gtest_SOURCES = gtest.cpp \
+		001-path.cpp \
+		002-cgroup_parse_rules_options.cpp \
+		003-cg_get_cgroups_from_proc_cgroups.cpp \
+		004-cgroup_compare_ignore_rule.cpp \
+		005-cgroup_compare_wildcard_procname.cpp \
+		006-cgroup_get_cgroup.cpp \
+		007-cgroup_process_v1_mount.cpp \
+		008-cgroup_process_v2_mount.cpp \
+		009-cgroup_set_values_recursive.cpp \
+		010-cgroup_chown_chmod_tasks.cpp \
+		011-cgroupv2_subtree_control.cpp \
+		012-cgroup_create_cgroup.cpp \
+		013-cgroup_build_tasks_procs_path.cpp \
+		014-cgroupv2_get_subtree_control.cpp \
+		015-cgroupv2_controller_enabled.cpp \
+		016-cgset_parse_r_flag.cpp
+gtest_LDFLAGS = -L$(top_srcdir)/googletest/googletest -l:libgtest.so \
+		-rpath $(abs_top_srcdir)/googletest/googletest
+
+clean-local:
+	${RM} test-procpidcgroup

--- a/tests/gunit/gtest.cpp
+++ b/tests/gunit/gtest.cpp
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest main entry point
+ *
+ * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/gunit/libcgroup_unittest.map
+++ b/tests/gunit/libcgroup_unittest.map
@@ -1,0 +1,130 @@
+CGROUP_0.32 {
+global:
+	cgroup_init;
+	cgroup_attach_task;
+	cgroup_modify_cgroup;
+	cgroup_create_cgroup;
+	cgroup_delete_cgroup;
+	cgroup_attach_task_pid;
+	cgroup_get_cgroup;
+	cgroup_create_cgroup_from_parent;
+	cgroup_copy_cgroup;
+	cgroup_change_cgroup_uid_gid;
+	cgroup_change_cgroup_path;
+	cgroup_new_cgroup;
+	cgroup_add_controller;
+	cgroup_free;
+	cgroup_free_controllers;
+	cgroup_add_value_string;
+	cgroup_add_value_int64;
+	cgroup_add_value_uint64;
+	cgroup_add_value_bool;
+	cgroup_compare_cgroup;
+	cgroup_compare_controllers;
+	cgroup_set_uid_gid;
+	cgroup_get_uid_gid;
+	cgroup_get_value_string;
+	cgroup_set_value_string;
+	cgroup_get_value_int64;
+	cgroup_set_value_int64;
+	cgroup_get_value_uint64;
+	cgroup_set_value_uint64;
+	cgroup_get_value_bool;
+	cgroup_set_value_bool;
+	cgroup_change_cgroup_uid_gid_flags;
+	cgroup_print_rules_config;
+	cgroup_reload_cached_rules;
+	cgroup_init_rules_cache;
+	cgroup_get_current_controller_path;
+	cgroup_config_load_config;
+	*;
+};
+
+CGROUP_0.32.1 {
+global:
+	cgroup_strerror;
+} CGROUP_0.32;
+
+CGROUP_0.33 {
+global:
+	cgroup_get_last_errno;
+	cgroup_walk_tree_begin;
+	cgroup_walk_tree_next;
+	cgroup_walk_tree_end;
+} CGROUP_0.32.1;
+
+CGROUP_0.34 {
+global:
+	cgroup_get_task_begin;
+	cgroup_get_task_end;
+	cgroup_get_task_next;
+	cgroup_read_stats_begin;
+	cgroup_read_stats_next;
+	cgroup_read_stats_end;
+	cgroup_walk_tree_set_flags;
+	cgroup_get_controller_end;
+	cgroup_get_controller_next;
+	cgroup_get_controller_begin;
+	cgroup_unload_cgroups;
+	cgroup_get_controller;
+	cgroup_get_uid_gid_from_procfs;
+	cgroup_get_subsys_mount_point;
+	cgroup_get_procname_from_procfs;
+	cgroup_register_unchanged_process;
+	cgroup_change_cgroup_flags;
+} CGROUP_0.33;
+
+CGROUP_0.35 {
+global:
+	create_cgroup_from_name_value_pairs;
+	cgroup_delete_cgroup_ext;
+	cgroup_get_all_controller_begin;
+	cgroup_get_all_controller_next;
+	cgroup_get_all_controller_end;
+	cgroup_get_value_name_count;
+	cgroup_get_value_name;
+} CGROUP_0.34;
+
+CGROUP_0.36 {
+} CGROUP_0.35;
+
+CGROUP_0.37 {
+	cgroup_get_procs;
+	cgroup_read_value_begin;
+	cgroup_read_value_next;
+	cgroup_read_value_end;
+	cg_chmod_recursive;
+} CGROUP_0.36;
+
+CGROUP_0.38 {
+       cgroup_get_subsys_mount_point_begin;
+       cgroup_get_subsys_mount_point_next;
+       cgroup_get_subsys_mount_point_end;
+       cgroup_set_permissions;
+       cgroup_config_unload_config;
+       cgroup_config_set_default;
+} CGROUP_0.37;
+
+CGROUP_0.39 {
+	cgroup_reload_cached_templates;
+	cgroup_init_templates_cache;
+	cgroup_config_create_template_group;
+	cgroup_change_all_cgroups;
+	cgroup_set_logger;
+	cgroup_set_default_logger;
+	cgroup_set_loglevel;
+	cgroup_log;
+	cgroup_parse_log_level_str;
+} CGROUP_0.38;
+
+CGROUP_0.40 {
+	cgroup_templates_cache_set_source_files;
+	cgroup_load_templates_cache_from_files;
+} CGROUP_0.39;
+
+CGROUP_0.41 {
+} CGROUP_0.40;
+
+CGROUP_0.42 {
+	cgroup_add_all_controllers;
+} CGROUP_0.41;


### PR DESCRIPTION
Merge the libcgroup-tests repo back into the main libcgroup repo. The submodules logic has been deleted and the tests are now directly hosted within the libcgroup repo. This pull request is for the release-3.0 branch