### PR TITLE
Add initial systemd support

### DIFF
--- a/.github/actions/setup-libcgroup/action.yml
+++ b/.github/actions/setup-libcgroup/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
   - run: sudo apt-get update
     shell: bash
-  - run: sudo apt-get install libpam-dev lcov python3-pip python3-dev cmake bison flex byacc g++ autoconf automake libtool -y
+  - run: sudo apt-get install libpam-dev lcov python3-pip python3-dev cmake bison flex byacc g++ autoconf automake libtool libsystemd-dev -y
     shell: bash
   - run: sudo pip install cython
     shell: bash

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,6 +24,6 @@ autoreconf -fi
 rm -fr autom4te.cache
 
 CFLAGS="$CFLAGS -g -O0" ./configure --sysconfdir=/etc --localstatedir=/var \
-	--enable-opaque-hierarchy="name=systemd"
+	--enable-opaque-hierarchy="name=systemd" --enable-systemd --enable-python
 
 make clean

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,18 @@ AC_DEFINE_UNQUOTED([ENABLE_PYTHON],
 	[$(test "$enable_python" = yes && echo 1 || echo 0)],
 	[Python bindings build flag.])
 
+AC_ARG_ENABLE([systemd],
+	[AS_HELP_STRING([--enable-systemd],[enable systemd support [default=yes]])],
+	[
+		if test "x$enableval" = xno; then
+			with_systemd=false
+		else
+			with_systemd=true
+		fi
+	],
+	[with_systemd=true])
+AM_CONDITIONAL([WITH_SYSTEMD], [test x$with_systemd = xtrue])
+
 AC_ARG_ENABLE([initscript-install],
 	[AS_HELP_STRING([--enable-initscript-install],[install init scripts [default=no]])],
 	[

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -3,3 +3,7 @@ nobase_include_HEADERS = libcgroup.h libcgroup/error.h libcgroup/init.h \
 			 libcgroup/groups.h libcgroup/tasks.h \
 			 libcgroup/iterators.h libcgroup/config.h \
 			 libcgroup/log.h libcgroup/tools.h
+
+if WITH_SYSTEMD
+nobase_include_HEADERS += libcgroup/systemd.h
+endif

--- a/include/libcgroup.h
+++ b/include/libcgroup.h
@@ -18,6 +18,7 @@
 #include <libcgroup/config.h>
 #include <libcgroup/log.h>
 #include <libcgroup/tools.h>
+#include <libcgroup/systemd.h>
 
 #undef _LIBCGROUP_H_INSIDE
 

--- a/include/libcgroup/systemd.h
+++ b/include/libcgroup/systemd.h
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+#ifndef _LIBCGROUP_SYSTEMD_H
+#define _LIBCGROUP_SYSTEMD_H
+
+#ifndef _LIBCGROUP_H_INSIDE
+#error "Only <libcgroup.h> should be included directly."
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum cgroup_systemd_mode_t {
+	CGROUP_SYSTEMD_MODE_FAIL = 0,
+	CGROUP_SYSTEMD_MODE_REPLACE,
+	CGROUP_SYSTEMD_MODE_ISOLATE,
+	CGROUP_SYSTEMD_MODE_IGNORE_DEPS,
+	CGROUP_SYSTEMD_MODE_IGNORE_REQS,
+
+	CGROUP_SYSTEMD_MODE_CNT,
+	CGROUP_SYSTEMD_MODE_DFLT = CGROUP_SYSTEMD_MODE_REPLACE
+};
+
+/**
+ * Options associated with creating a systemd scope
+ */
+struct cgroup_systemd_scope_opts {
+	/** should systemd delegate this cgroup or not.  1 == yes, 0 == no */
+	int delegated;
+	/** systemd behavior when the scope already exists */
+	enum cgroup_systemd_mode_t mode;
+	/** pid to be placed in the cgroup.  if 0, libcgroup will create a dummy process */
+	pid_t pid;
+};
+
+/**
+ * Populate the scope options structure with default values
+ *
+ * @param opts Scope creation options structure instance.  Must already be allocated
+ *
+ * @return 0 on success and > 0 on error
+ */
+int cgroup_set_default_scope_opts(struct cgroup_systemd_scope_opts * const opts);
+
+/**
+ * Create a systemd scope under the specified slice
+ *
+ * @param scope_name Name of the scope, must end in .scope
+ * @param slice_name Name of the slice, must end in .slice
+ * @param opts Scope creation options structure instance
+ *
+ * @return 0 on success and > 0 on error
+ */
+int cgroup_create_scope(const char * const scope_name, const char * const slice_name,
+			const struct cgroup_systemd_scope_opts * const opts);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* _LIBCGROUP_SYSTEMD_H */

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,4 @@
+libcgroup_systemd_idle_thread
 lex.c
 parse.c
 parse.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,22 +18,43 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 VERSION_NUMBER = $(LIBRARY_VERSION_MAJOR):$(LIBRARY_VERSION_MINOR):$(LIBRARY_VERSION_RELEASE)
 TESTING_MAP_FILE = $(top_srcdir)/tests/gunit/libcgroup_unittest.map
 
+if WITH_SYSTEMD
+libcgroup_systemd_idle_thread_SOURCES = libcgroup_systemd_idle_thread.c
+bin_PROGRAMS = libcgroup_systemd_idle_thread
+endif
+
 lib_LTLIBRARIES = libcgroup.la
 libcgroup_la_SOURCES = parse.h parse.y lex.l api.c config.c libcgroup-internal.h libcgroup.map \
 		       wrapper.c log.c abstraction-common.c abstraction-common.h \
 		       abstraction-map.c abstraction-map.h abstraction-cpu.c abstraction-cpuset.c \
 		       tools/cgxget.c tools/cgxset.c
+if WITH_SYSTEMD
+libcgroup_la_SOURCES += systemd.c
+endif
+
 libcgroup_la_LIBADD = -lpthread $(CODE_COVERAGE_LIBS)
 libcgroup_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC=static -DLIBCG_LIB -fPIC
+
 libcgroup_la_LDFLAGS = -Wl,--version-script,$(srcdir)/libcgroup.map \
 		       -version-number $(VERSION_NUMBER)
+if WITH_SYSTEMD
+libcgroup_la_LDFLAGS += -lsystemd
+endif
 
 noinst_LTLIBRARIES = libcgroupfortesting.la
 libcgroupfortesting_la_SOURCES = parse.h parse.y lex.l api.c config.c libcgroup-internal.h \
 				 libcgroup.map wrapper.c log.c abstraction-common.c \
 				 abstraction-common.h abstraction-map.c abstraction-map.h \
 				 abstraction-cpu.c abstraction-cpuset.c
+if WITH_SYSTEMD
+libcgroupfortesting_la_SOURCES += systemd.c
+endif
+
 libcgroupfortesting_la_LIBADD = -lpthread $(CODE_COVERAGE_LIBS)
 libcgroupfortesting_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC= -DUNIT_TEST
+
 libcgroupfortesting_la_LDFLAGS = -Wl,--version-script,$(TESTING_MAP_FILE) \
 				 -version-number $(VERSION_NUMBER)
+if WITH_SYSTEMD
+libcgroupfortesting_la_LDFLAGS += -lsystemd
+endif

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -149,4 +149,6 @@ CGROUP_3.0 {
 
 	/* libcgroup 3.0.1 */
 	cgroup_setup_mode;
+	cgroup_create_scope;
+	cgroup_set_default_scope_opts;
 } CGROUP_2.0;

--- a/src/libcgroup_systemd_idle_thread.c
+++ b/src/libcgroup_systemd_idle_thread.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+
+#define SECS_PER_DAY   (60 * 60 *24)
+
+int main(void)
+{
+	while(1)
+		sleep(1 * SECS_PER_DAY);
+
+	return 0;
+}

--- a/src/python/cgroup.pxd
+++ b/src/python/cgroup.pxd
@@ -8,6 +8,8 @@
 
 # cython: language_level = 3str
 
+from posix.types cimport pid_t
+
 cdef extern from "libcgroup.h":
     cdef struct cgroup:
         pass
@@ -31,6 +33,18 @@ cdef extern from "libcgroup.h":
         unsigned int major
         unsigned int minor
         unsigned int release
+
+    cdef enum cgroup_systemd_mode_t:
+        CGROUP_SYSTEMD_MODE_FAIL
+        CGROUP_SYSTEMD_MODE_REPLACE
+        CGROUP_SYSTEMD_MODE_ISOLATE
+        CGROUP_SYSTEMD_MODE_IGNORE_DEPS
+        CGROUP_SYSTEMD_MODE_IGNORE_REQS
+
+    cdef struct cgroup_systemd_scope_opts:
+        int delegated
+        cgroup_systemd_mode_t mode
+        pid_t pid
 
     int cgroup_init()
     const cgroup_library_version * cgroup_version()
@@ -61,5 +75,8 @@ cdef extern from "libcgroup.h":
                                  char ***mount_paths)
 
     cg_setup_mode_t cgroup_setup_mode()
+
+    int cgroup_create_scope(const char * const scope_name, const char * const slice_name,
+                            const cgroup_systemd_scope_opts * const opts)
 
 # vim: set et ts=4 sw=4:

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -26,7 +26,8 @@ setup(
             Extension(
                       'libcgroup', ['libcgroup.pyx'],
                       # unable to handle libtool libraries directly
-                      extra_objects=['../.libs/libcgroup.a']
+                      extra_objects=['../.libs/libcgroup.a'],
+                      libraries=['systemd']
                      ),
              ])
 )

--- a/src/systemd.c
+++ b/src/systemd.c
@@ -1,0 +1,283 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ * Author: Silvia Chapa <silvia.chapa@oracle.com>
+ */
+
+#include <libcgroup-internal.h>
+#include <systemd/sd-bus.h>
+#include <libcgroup.h>
+#include <unistd.h>
+#include <assert.h>
+#include <errno.h>
+
+#define USEC_PER_SEC 1000000
+
+static const char * const modes[] = {
+	"fail",			/* CGROUP_SYSTEMD_MODE_FAIL */
+	"replace",		/* CGROUP_SYSTEMD_MODE_REPLACE */
+	"isolate",		/* CGROUP_SYSTEMD_MODE_ISOLATE */
+	"ignore-dependencies",	/* CGROUP_SYSTEMD_MODE_IGNORE_DEPS */
+	"ignore-requirements",	/* CGROUP_SYSTEMD_MODE_IGNORE_REQS */
+};
+static_assert((sizeof(modes) / sizeof(modes[0])) == CGROUP_SYSTEMD_MODE_CNT,
+	      "modes[] array must be same length as CGROUP_SYSTEMD_MODE_CNT");
+
+static const char * const sender = "org.freedesktop.systemd1";
+static const char * const path = "/org/freedesktop/systemd1";
+static const char * const interface = "org.freedesktop.systemd1.Manager";
+
+int cgroup_set_default_scope_opts(struct cgroup_systemd_scope_opts * const opts)
+{
+	if (!opts)
+		return ECGINVAL;
+
+	opts->delegated = 1;
+	opts->mode = CGROUP_SYSTEMD_MODE_FAIL;
+	opts->pid = -1;
+
+	return 0;
+}
+
+/*
+ * Returns time elapsed in usec
+ *
+ * Inspired-by: https://github.com/cockpit-project/cockpit/blob/main/src/tls/socket-io.c#L39
+ */
+static int64_t elapsed_time(const struct timespec * const start, const struct timespec * const end)
+{
+	int64_t elapsed = (end->tv_sec - start->tv_sec) * 1000000 +
+			  (end->tv_nsec - start->tv_nsec) / 1000;
+
+	assert(elapsed >= 0);
+
+	return elapsed;
+}
+
+static int job_removed_callback(sd_bus_message *message, void *user_data, sd_bus_error *error)
+{
+	const char *result, *msg_path, *scope_name;
+	const char **job_path = user_data;
+	int ret;
+
+	ret = sd_bus_message_read(message, "uoss", NULL, &msg_path, &scope_name, &result);
+	if (ret < 0) {
+		cgroup_err("callback message read failed: %d\n", errno);
+		return 0;
+	}
+
+	if (*job_path == NULL || strcmp(msg_path, *job_path) != 0) {
+		cgroup_dbg("Received a systemd signal, but it was not our message\n");
+		return 0;
+	}
+
+	cgroup_dbg("Received JobRemoved signal for scope %s.  Result: %s\n", scope_name, result);
+
+	/*
+	 * Use the job_path pointer as a way to inform the original thread that the job has
+	 * completed.
+	 */
+	*job_path = NULL;
+	return 0;
+}
+
+int cgroup_create_scope(const char * const scope_name, const char * const slice_name,
+			const struct cgroup_systemd_scope_opts * const opts)
+{
+	sd_bus_message *msg = NULL, *reply = NULL;
+	sd_bus_error error = SD_BUS_ERROR_NULL;
+	const char *job_path = NULL;
+	struct timespec start, now;
+	sd_bus *bus = NULL;
+	pid_t child_pid;
+	int ret = 0;
+
+	if (!scope_name || !slice_name || !opts)
+		return ECGINVAL;
+
+	if (strcmp(&scope_name[strlen(scope_name) - strlen(".scope")], ".scope") != 0)
+		cgroup_warn("scope doesn't have expected suffix\n");
+	if (strcmp(&slice_name[strlen(slice_name) - strlen(".slice")], ".slice") != 0)
+		cgroup_warn("slice doesn't have expected suffix\n");
+
+	if (opts->mode >= CGROUP_SYSTEMD_MODE_CNT) {
+		cgroup_err("invalid systemd mode: %d\n", opts->mode);
+		return ECGINVAL;
+	}
+
+	if (opts->mode == CGROUP_SYSTEMD_MODE_ISOLATE ||
+	    opts->mode == CGROUP_SYSTEMD_MODE_IGNORE_DEPS ||
+	    opts->mode == CGROUP_SYSTEMD_MODE_IGNORE_REQS) {
+		cgroup_err("unsupported systemd mode: %d\n", opts->mode);
+		return ECGINVAL;
+	}
+
+	if (opts->pid < 0) {
+		child_pid = fork();
+		if (child_pid < 0) {
+			cgroup_err("fork failed: %d\n", errno);
+			return ECGOTHER;
+		}
+
+		if (child_pid == 0) {
+			char *args[] = {"libcgroup_systemd_idle_thread", NULL};
+
+			/*
+			 * Have the child sleep forever.  Systemd will delete the scope if
+			 * there isn't a running process in it.
+			 */
+			execvp("libcgroup_systemd_idle_thread", args);
+			/* The child process should never get here */
+			cgroup_err("failed to create system idle thread.\n");
+			return ECGOTHER;
+		}
+
+		cgroup_dbg("created libcgroup_system_idle thread pid %d\n", child_pid);
+	} else {
+		child_pid = opts->pid;
+	}
+	cgroup_dbg("pid %d will be placed in scope %s\n", child_pid, scope_name);
+
+	ret = sd_bus_default_system(&bus);
+	if (ret < 0) {
+		cgroup_err("failed to open the system bus: %d\n", errno);
+		goto out;
+	}
+
+	ret = sd_bus_match_signal(bus, NULL, sender, path, interface,
+				  "JobRemoved", job_removed_callback, &job_path);
+	if (ret < 0) {
+		cgroup_err("failed to install match callback: %d\n", errno);
+		goto out;
+	}
+
+	ret = sd_bus_message_new_method_call(bus, &msg, sender, path, interface,
+					     "StartTransientUnit");
+	if (ret < 0) {
+		cgroup_err("failed to create the systemd msg: %d\n", errno);
+		goto out;
+	}
+
+	ret = sd_bus_message_append(msg, "ss", scope_name, modes[opts->mode]);
+	if (ret < 0) {
+		cgroup_err("failed to append the scope name: %d\n", errno);
+		goto out;
+	}
+
+	ret = sd_bus_message_open_container(msg, 'a', "(sv)");
+	if (ret < 0) {
+		cgroup_err("failed to open container: %d\n", errno);
+		goto out;
+	}
+
+	ret = sd_bus_message_append(msg, "(sv)", "Description", "s",
+				    "scope created by libcgroup");
+	if (ret < 0) {
+		cgroup_err("failed to append the description: %d\n", errno);
+		goto out;
+	}
+
+	ret = sd_bus_message_append(msg, "(sv)", "PIDs", "au", 1, child_pid);
+	if (ret < 0) {
+		cgroup_err("failed to append the PID: %d\n", errno);
+		goto out;
+	}
+
+	ret = sd_bus_message_append(msg, "(sv)", "Slice", "s", slice_name);
+	if (ret < 0) {
+		cgroup_err("failed to append the slice: %d\n", errno);
+		goto out;
+	}
+
+	if (opts->delegated == 1) {
+		ret = sd_bus_message_append(msg, "(sv)", "Delegate", "b", 1);
+		if (ret < 0) {
+			cgroup_err("failed to append delegate: %d\n", errno);
+			goto out;
+		}
+	}
+
+	ret = sd_bus_message_close_container(msg);
+	if (ret < 0) {
+		cgroup_err("failed to close the container: %d\n", errno);
+		goto out;
+	}
+
+	ret = sd_bus_message_append(msg, "a(sa(sv))", 0);
+	if (ret < 0) {
+		cgroup_err("failed to append aux structure: %d\n", errno);
+		goto out;
+	}
+
+	ret = sd_bus_call(bus, msg, 0, &error, &reply);
+	if (ret < 0) {
+		cgroup_err("sd_bus_call() failed: %d\n",
+			   sd_bus_message_get_errno(msg));
+		cgroup_err("error message: %s\n", error.message);
+		goto out;
+	}
+
+	/* Receive the job_path from systemd */
+	ret = sd_bus_message_read(reply, "o", &job_path);
+	if (ret < 0) {
+		cgroup_err("failed to read reply: %d\n", errno);
+		goto out;
+	}
+
+	cgroup_dbg("job_path = %s\n", job_path);
+
+	ret = clock_gettime(CLOCK_MONOTONIC, &start);
+	if (ret < 0) {
+		cgroup_err("Failed to get time: %d\n", errno);
+		ret = ECGFAIL;
+		goto out;
+	}
+
+	/* The callback will null out the job_path pointer on completion */
+	while(job_path) {
+		ret = sd_bus_process(bus, NULL);
+		if (ret < 0) {
+			cgroup_err("failed to process the sd bus: %d\n", errno);
+			goto out;
+		}
+
+		if (ret == 0) {
+			/*
+			 * Per the sd_bus_wait() man page, call this function after sd_bus_process
+			 * returns zero. The wait time (usec) was somewhat arbitrarily chosen
+			 */
+			ret = sd_bus_wait(bus, 10);
+			if (ret < 0) {
+				cgroup_err("failed to wait for sd bus: %d\n", errno);
+				goto out;
+			}
+		}
+
+		ret = clock_gettime(CLOCK_MONOTONIC, &now);
+		if (ret < 0) {
+			cgroup_err("Failed to get time: %d\n", errno);
+			ret = ECGFAIL;
+			goto out;
+		}
+
+		if (elapsed_time(&start, &now) > USEC_PER_SEC) {
+			cgroup_err("The create scope command timed out\n");
+			ret = ECGFAIL;
+			goto out;
+		}
+	}
+
+	ret = 0;
+
+out:
+	if (ret && opts->pid < 0)
+		kill(child_pid, SIGTERM);
+
+	sd_bus_error_free(&error);
+	sd_bus_message_unref(msg);
+	sd_bus_message_unref(reply);
+	sd_bus_unref(bus);
+
+	return ret;
+}

--- a/tests/ftests/049-sudo-systemd_create_scope.py
+++ b/tests/ftests/049-sudo-systemd_create_scope.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Create a systemd scope
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli
+from cgroup import CgroupVersion
+from run import Run, RunError
+from libcgroup import Cgroup
+from systemd import Systemd
+import ftests
+import consts
+import sys
+import os
+
+SLICE = 'libcgtests.slice'
+SCOPE = '049delegated.scope'
+
+# Which controller isn't all that important, but it is important that we
+# have a cgroup v2 controller
+CONTROLLER = 'cpu'
+
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v2'
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    pass
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.create_scope(scope_name=SCOPE, slice_name=SLICE)
+
+    if not Systemd.is_delegated(config, SCOPE):
+        result = consts.TEST_FAILED
+        cause = 'Cgroup is not delegated'
+
+    return result, cause
+
+
+def teardown(config, result):
+    pid = CgroupCli.get(config, cgname=os.path.join(SLICE, SCOPE), setting='cgroup.procs',
+                        print_headers=False, values_only=True)
+    if pid is not None:
+        Run.run(['kill', '-9', str(pid)], shell_bool=True)
+
+    if result != consts.TEST_PASSED:
+        # Something went wrong.  Let's force the removal of the cgroups just to be safe.
+        # Note that this should remove the cgroup, but it won't remove it from systemd's
+        # internal caches, so the system may not return to its 'pristine' prior-to-this-test
+        # state
+        try:
+            CgroupCli.delete(config, None, os.path.join(SLICE, SCOPE))
+        except RunError:
+            pass
+    else:
+        # There is no need to remove the scope.  systemd should automatically remove it
+        # once there are no processes inside of it
+        pass
+
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        result = consts.TEST_FAILED
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config, result)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/050-sudo-systemd_create_scope2.py
+++ b/tests/ftests/050-sudo-systemd_create_scope2.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Create a systemd scope with an existing PID
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli
+from cgroup import CgroupVersion
+from run import Run, RunError
+from libcgroup import Cgroup
+from systemd import Systemd
+import ftests
+import consts
+import sys
+import os
+
+SLICE = 'libcgtests.slice'
+SCOPE = '050delegated.scope'
+pid = None
+
+# Which controller isn't all that important, but it is important that we
+# have a cgroup v2 controller
+CONTROLLER = 'cpu'
+
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v2'
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    pass
+
+
+def test(config):
+    global pid
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = int(config.process.create_process(config))
+    Cgroup.create_scope(SCOPE, slice_name=SLICE, pid=pid)
+
+    if not Systemd.is_delegated(config, SCOPE):
+        result = consts.TEST_FAILED
+        cause = 'Cgroup is not delegated'
+
+    return result, cause
+
+
+def teardown(config, result):
+    global pid
+
+    if pid is not None:
+        Run.run(['kill', '-9', str(pid)], shell_bool=True)
+
+    if result != consts.TEST_PASSED:
+        # Something went wrong.  Let's force the removal of the cgroups just to be safe.
+        # Note that this should remove the cgroup, but it won't remove it from systemd's
+        # internal caches, so the system may not return to its 'pristine' prior-to-this-test
+        # state
+        try:
+            CgroupCli.delete(config, None, os.path.join(SLICE, SCOPE))
+        except RunError:
+            pass
+    else:
+        # There is no need to remove the scope.  systemd should automatically remove it
+        # once there are no processes inside of it
+        pass
+
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        result = consts.TEST_FAILED
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config, result)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -19,6 +19,7 @@ EXTRA_DIST_PYTHON_UTILS = \
 			  log.py \
 			  process.py \
 			  run.py \
+			  systemd.py \
 			  utils.py
 
 EXTRA_DIST_PYTHON_TESTS = \
@@ -63,7 +64,15 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  041-pybindings-library_version.py \
 			  042-cgxget-unmappable.py \
 			  043-cgcreate-empty_controller.py \
-			  044-pybindings-cgcreate_empty_controller.py
+			  044-pybindings-cgcreate_empty_controller.py \
+			  045-pybindings-list_mount_points.py \
+			  046-cgexec-empty_controller.py \
+			  047-cgcreate-delete_cgrp_shared_mnt.py \
+			  048-pybindings-get_cgroup_mode.py \
+			  049-sudo-systemd_create_scope.py \
+			  050-sudo-systemd_create_scope2.py
+# Intentionally omit the stress test from the extra dist
+# 999-stress-cgroup_init.py
 
 EXTRA_DIST = README.md ftests.sh ftests-nocontainer.sh \
 	     ${EXTRA_DIST_PYTHON_UTILS} ${EXTRA_DIST_PYTHON_TESTS}

--- a/tests/ftests/ftests-nocontainer.sh
+++ b/tests/ftests/ftests-nocontainer.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # SPDX-License-Identifier: LGPL-2.1-only
 
+AUTOMAKE_SKIPPED=77
+AUTOMAKE_HARD_ERROR=99
+
 START_DIR=$PWD
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
@@ -16,12 +19,41 @@ fi
 
 ./ftests.py -l 10 -L "$START_DIR/ftests-nocontainer.py.log" --no-container \
 	-n Libcg"$RANDOM"
-RET=$?
+RET1=$?
+
+pushd ../../src || exit $AUTOMAKE_HARD_ERROR
+PATH="$PATH:$(pwd)"
+export PATH
+popd || exit $AUTOMAKE_HARD_ERROR
+
+sudo PATH=$PATH PYTHONPATH=$PYTHONPATH ./ftests.py -l 10 -s "sudo" \
+	-L "$START_DIR/ftests-nocontainer.py.sudo.log" --no-container -n Libcg"$RANDOM"
+RET2=$?
 
 if [ "$START_DIR" != "$SCRIPT_DIR" ]; then
 	rm -f "$START_DIR"/*.py
 	rm -fr "$START_DIR"/__pycache__
 	rm -f ftests-nocontainer.py.log
+	rm -f ftests-nocontainer.py.sudo.log
 fi
 
-exit $RET
+
+if [[ $RET1 -ne $AUTOMAKE_SKIPPED ]] && [[ $RET1 -ne 0 ]]; then
+	# always return errors from the first test run
+	exit $RET1
+fi
+if [[ $RET2 -ne $AUTOMAKE_SKIPPED ]] && [[ $RET2 -ne 0 ]]; then
+	# return errors from the second test run
+	exit $RET2
+fi
+
+if [[ $RET1 -eq 0 ]] || [[ $RET2 -eq 0 ]]; then
+	exit 0
+fi
+
+if [[ $RET1 -eq $AUTOMAKE_SKIPPED ]] || [[ $RET2 -eq $AUTOMAKE_SKIPPED ]]; then
+	exit $AUTOMAKE_SKIPPED
+fi
+
+# I don't think we should ever get here, but better safe than sorry
+exit $AUTOMAKE_HARD_ERROR

--- a/tests/ftests/ftests.py
+++ b/tests/ftests/ftests.py
@@ -274,6 +274,14 @@ def run_tests(config):
                 if config.args.num == consts.TESTS_RUN_ALL or \
                    config.args.num == filenum_int:
 
+
+                    if config.args.suite == consts.TESTS_RUN_ALL_SUITES and \
+                       filesuite == 'sudo':
+                        # Don't run the 'sudo' tests if all tests have been specified.
+                        # The sudo tests must be run as sudo and thus need to be separately
+                        # invoked.
+                        continue
+
                     if filenum_int in config.skip_list:
                         continue
 

--- a/tests/ftests/systemd.py
+++ b/tests/ftests/systemd.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Systemd class for the libcgroup functional tests
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from run import Run, RunError
+
+
+class Systemd(object):
+    @staticmethod
+    def is_delegated(config, scope_name):
+        cmd = ['systemctl', 'show', '-P', 'Delegate', scope_name]
+        try:
+            out = Run.run(cmd, shell_bool=True)
+
+            if out == 'yes':
+                return True
+            else:
+                return False
+        except RunError as re:
+            if re.stderr.find('invalid option') >= 0:
+                # This version of systemd is too old for the '-P' flag.  At this time, I don't
+                # think there's a way to verify the scope is delegated.  Lie and return true
+                # until we figure out something better :(
+                return True
+            raise re


### PR DESCRIPTION
Add a C API, `cgroup_create_scope()`, and the associated python binding, `Cgroup.create_scope()`, to create a cgroup that's a valid systemd scope.  If the user has requested it to be delegated, then systemd will relinquish management of this cgroup and its children.

Future pull requests will add hooks into the existing C APIs, CLI tools, etc. as necessary.