### PR TITLE
tools/cgget: fix segfault in get_cv_value() [v2.0.2]

### DIFF
--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -462,7 +462,7 @@ static int get_cv_value(struct control_value * const cv,
 {
 	bool is_multiline = false;
 	char tmp_line[LL_MAX];
-	void *handle, *tmp;
+	void *tmp, *handle = NULL;
 	int ret;
 
 	ret = cgroup_read_value_begin(controller_name, cg_name, cv->name,


### PR DESCRIPTION
cgget segfaults on v2.0.2 branch, with:
```
cgget: cannot find controller 'incal' in group '016cgget'
Fatal error: glibc detected an invalid stdio handle
Aborted (core dumped)
```
It was caught by `ftests/016-cgget-invalid_options.py` on Ubuntu 22.04 (gcc version 11.2.0),
a simple reproducer on the v2.0.2 branch:
`$ sudo ./src/tools/cgget -n -v -r invalid.setting 016cgget` assuming 016cgget cgroup exists.

It is due to the invalid controller name passed to the `cgroup_read_value_begin()`,
which returns failure and callee `get_cv_value()` in the error clean up path, does a
`fclose(handle)`. `If (handle != NULL)` succeeds because it's uninitialized and has
some garbage value. Fix this by initializing the handle to NULL.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>