### PR TITLE
Use Automake DIST_SUBDIRS [v3.0+]

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,1 +1,4 @@
 DIST_SUBDIRS = ftests gunit
+if WITH_TESTS
+SUBDIRS = $(DIST_SUBDIRS)
+endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = ftests gunit
+DIST_SUBDIRS = ftests gunit


### PR DESCRIPTION
This patchset, has two patches. Where the first one introduces `DIST_SUBDIRS`
to ship the directories/sub-directories as part of the tarball created using make dist*
and use SUBDIRS to add build conditions.

The second patch is built upon the usage of `DIST_SUBDIRS`, where the building
and testing `SUBDIRS` directories (ftests/gunit) are guarded using `WITH_TESTS` in
the top-level `Makefile.am`. The WITH_TESTS is passed when `./configure` is passed
`--enable-tests` to the Makefile.
