### PR TITLE
tools/cgdelete: add check for the cmdline arguments [v2.0.2]

### DIFF
--- a/src/tools/cgdelete.c
+++ b/src/tools/cgdelete.c
@@ -139,6 +139,11 @@ int main(int argc, char *argv[])
 	struct cgroup *cgroup;
 	struct cgroup_controller *cgc;
 
+	if (argc < 2) {
+		usage(1,  argv[0]);
+		exit (1);
+	}
+
 	/* initialize libcg */
 	ret = cgroup_init();
 	if (ret) {


### PR DESCRIPTION
Like other tools, throw an error and exit, if the minimum required arguments are not passed.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>