### PR TITLE
tools/cgdelete: add check for the cmdline arguments [v3.0+]

### DIFF
--- a/src/tools/cgdelete.c
+++ b/src/tools/cgdelete.c
@@ -123,6 +123,11 @@ int main(int argc, char *argv[])
 	int i, j, c;
 	int skip;
 
+	if (argc < 2) {
+		usage(1, argv[0]);
+		exit (1);
+	}
+
 	/* initialize libcg */
 	ret = cgroup_init();
 	if (ret) {


### PR DESCRIPTION
Like other tools, throw an error and exit if the minimum required arguments are not passed.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>