### PR TITLE
configure: introduce --enable-samples option [v3.0+]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,18 @@ AC_ARG_ENABLE([tests],
        [with_tests=true])
 AM_CONDITIONAL([WITH_TESTS], [test x$with_tests = xtrue])
 
+AC_ARG_ENABLE([samples],
+      [AS_HELP_STRING([--enable-samples],[compile libcgroup samples C programs [default=no]])],
+      [
+		if test "x$enableval" == xno; then
+			with_samples=false
+		else
+			with_samples=true
+		fi
+       ],
+       [with_samples=false])
+AM_CONDITIONAL([WITH_SAMPLES], [test x$with_samples = xtrue])
+
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC

--- a/samples/c/Makefile.am
+++ b/samples/c/Makefile.am
@@ -1,11 +1,12 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 LDADD = $(top_builddir)/src/.libs/libcgroup.la
 
-# Uncomment to build the sample programs.
-#noinst_PROGRAMS = setuid walk_test read_stats walk_task get_controller	\
-#		  get_mount_point proctest get_all_controller		\
-#		  get_variable_names test_named_hierarchy		\
-#		  get_procs wrapper_test logger empty_cgroup_v2
+if WITH_SAMPLES
+
+noinst_PROGRAMS = setuid walk_test read_stats walk_task get_controller	\
+		  get_mount_point proctest get_all_controller		\
+		  get_variable_names test_named_hierarchy		\
+		  get_procs wrapper_test logger empty_cgroup_v2
 
 setuid_SOURCES=setuid.c
 walk_test_SOURCES=walk_test.c
@@ -21,3 +22,5 @@ get_procs_SOURCES=get_procs.c
 wrapper_test_SOURCES=wrapper_test.c
 logger_SOURCES=logger.c
 empty_cgroup_v2_SOURCES=empty_cgroup_v2.c
+
+endif


### PR DESCRIPTION
Running ./bootstrap.sh step, throws a bunch of warnings related to samples/c:

```
samples/c/Makefile.am:23: warning: variable 'empty_cgroup_v2_SOURCES' is defined but no program or
samples/c/Makefile.am:23: library has 'empty_cgroup_v2' as canonical name (possible typo)
samples/c/Makefile.am:17: warning: variable 'get_all_controller_SOURCES' is defined but no program or
samples/c/Makefile.am:17: library has 'get_all_controller' as canonical name (possible typo)
samples/c/Makefile.am:14: warning: variable 'get_controller_SOURCES' is defined but no program or
samples/c/Makefile.am:14: library has 'get_controller' as canonical name (possible typo)
samples/c/Makefile.am:15: warning: variable 'get_mount_point_SOURCES' is defined but no program or
samples/c/Makefile.am:15: library has 'get_mount_point' as canonical name (possible typo)
samples/c/Makefile.am:20: warning: variable 'get_procs_SOURCES' is defined but no program or
samples/c/Makefile.am:20: library has 'get_procs' as canonical name (possible typo)
samples/c/Makefile.am:18: warning: variable 'get_variable_names_SOURCES' is defined but no program or
samples/c/Makefile.am:18: library has 'get_variable_names' as canonical name (possible typo)
samples/c/Makefile.am:22: warning: variable 'logger_SOURCES' is defined but no program or
samples/c/Makefile.am:22: library has 'logger' as canonical name (possible typo)
samples/c/Makefile.am:16: warning: variable 'proctest_SOURCES' is defined but no program or
samples/c/Makefile.am:16: library has 'proctest' as canonical name (possible typo)
samples/c/Makefile.am:12: warning: variable 'read_stats_SOURCES' is defined but no program or
samples/c/Makefile.am:12: library has 'read_stats' as canonical name (possible typo)
samples/c/Makefile.am:10: warning: variable 'setuid_SOURCES' is defined but no program or
samples/c/Makefile.am:10: library has 'setuid' as canonical name (possible typo)
samples/c/Makefile.am:19: warning: variable 'test_named_hierarchy_SOURCES' is defined but no program or
samples/c/Makefile.am:19: library has 'test_named_hierarchy' as canonical name (possible typo)
samples/c/Makefile.am:13: warning: variable 'walk_task_SOURCES' is defined but no program or
samples/c/Makefile.am:13: library has 'walk_task' as canonical name (possible typo)
samples/c/Makefile.am:11: warning: variable 'walk_test_SOURCES' is defined but no program or
samples/c/Makefile.am:11: library has 'walk_test' as canonical name (possible typo)
samples/c/Makefile.am:21: warning: variable 'wrapper_test_SOURCES' is defined but no program or
samples/c/Makefile.am:21: library has 'wrapper_test' as canonical name (possible typo)
src/Makefile.am: installing 'build-aux/depcomp'
```
fix this by introducing the `--enable-samples` option at configure, which by default is disabled. If the user wishes to run the sample code, they can build them by passing the configure option.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>