### PR TITLE
[RFC] Introduce a new API to find the cgroup setup mode

### DIFF
--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -23,6 +23,13 @@ enum cg_version_t {
 	CGROUP_DISK = 0xFF,
 };
 
+enum cg_setup_mode_t {
+	CGROUP_MODE_UNKNOWN = 0,
+	CGROUP_MODE_LEGACY,
+	CGROUP_MODE_HYBRID,
+	CGROUP_MODE_UNIFIED,
+};
+
 /**
  * Flags for cgroup_delete_cgroup_ext().
  */
@@ -635,6 +642,12 @@ int cgroup_list_mount_points(const enum cg_version_t cgrp_version,
  */
 int cgroup_get_controller_version(const char * const controller,
 				  enum cg_version_t * const version);
+
+/**
+ * Finds the current group setup mode (legacy/unified/hybrid).
+ * Returns unknown of failure and setup mode on success.
+ */
+enum cg_setup_mode_t cgroup_setup_mode(void);
 
 /**
  * @}

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -146,4 +146,7 @@ CGROUP_3.0 {
 	cgroup_cgxset;
 	cgroup_version;
 	cgroup_list_mount_points;
+
+	/* libcgroup 3.0.1 */
+	cgroup_setup_mode;
 } CGROUP_2.0;


### PR DESCRIPTION
This patchset introduces a new API `cgroup_setup_mode()` to
detect the current cgroup setup mode (Legacy/Unified/Hybrid).
The setup will depend on the Linux Kernel's grub command line
the system/VM is booted with.

One use case for this is, the users can enable or disable features
in their applications depending upon the cgroup setup. Like some
controllers are only available on cgroup v2, so they might need to
set/get settings for those available controllers only.

The second patch, adds a new switch (-m) to `cgget`, that will print
the current cgroup mode the system/VM has booted it.