### PR TITLE
configure: fix bashim of --enable-samples option [v3.0+]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,7 +149,7 @@ AM_CONDITIONAL([WITH_TESTS], [test x$with_tests = xtrue])
 AC_ARG_ENABLE([samples],
       [AS_HELP_STRING([--enable-samples],[compile libcgroup samples C programs [default=no]])],
       [
-		if test "x$enableval" == xno; then
+		if test "x$enableval" = xno; then
 			with_samples=false
 		else
 			with_samples=true


### PR DESCRIPTION
Make the `--enable-samples` option's bash code POSIX-complaint.
There might be warnings issued while running configure on other shells
like `/bin/sh`, those default on Debian systems.

Fixes: 6197ca3d693f ("configure: introduce --enable-samples option")
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>