### PR TITLE
Introduce a new API to find the cgroup setup mode (v2)

### DIFF
--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -23,6 +23,13 @@ enum cg_version_t {
 	CGROUP_DISK = 0xFF,
 };
 
+enum cg_setup_mode_t {
+	CGROUP_MODE_UNK = 0,
+	CGROUP_MODE_LEGACY,
+	CGROUP_MODE_HYBRID,
+	CGROUP_MODE_UNIFIED,
+};
+
 /**
  * Flags for cgroup_delete_cgroup_ext().
  */
@@ -635,6 +642,13 @@ int cgroup_list_mount_points(const enum cg_version_t cgrp_version,
  */
 int cgroup_get_controller_version(const char * const controller,
 				  enum cg_version_t * const version);
+
+/**
+ * Get the current group setup mode (legacy/unified/hybrid)
+ *
+ * @return CGROUP_MODE_UNK on failure and setup mode on success
+ */
+enum cg_setup_mode_t cgroup_setup_mode(void);
 
 /**
  * @}

--- a/src/api.c
+++ b/src/api.c
@@ -43,6 +43,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/vfs.h>
 
 #include <linux/un.h>
 
@@ -6117,4 +6118,54 @@ err:
 const struct cgroup_library_version *cgroup_version(void)
 {
 	return &library_version;
+}
+
+/**
+ * Finds the current cgroup setup mode (legacy/unified/hybrid).
+ * Returns unknown of failure and setup mode on success.
+ */
+enum cg_setup_mode_t cgroup_setup_mode(void)
+{
+#define CGROUP2_SUPER_MAGIC	0x63677270
+#define CGROUP_SUPER_MAGIC	0x27E0EB
+
+	unsigned int cg_setup_mode_bitmask = 0U;
+	enum cg_setup_mode_t setup_mode;
+	struct statfs cgrp_buf;
+	int i, ret = 0;
+
+	if (!cgroup_initialized) {
+		return ECGROUPNOTINITIALIZED;
+	}
+
+	setup_mode = CGROUP_MODE_UNK;
+
+	pthread_rwlock_wrlock(&cg_mount_table_lock);
+	for (i = 0; cg_mount_table[i].name[0] != '\0'; i++) {
+		ret = statfs(cg_mount_table[i].mount.path, &cgrp_buf);
+		if (ret) {
+			setup_mode = CGROUP_MODE_UNK;
+			cgroup_err("Failed to get stats of '%s'\n", cg_mount_table[i].mount.path);
+			goto out;
+		}
+
+		if (cgrp_buf.f_type == CGROUP2_SUPER_MAGIC)
+			cg_setup_mode_bitmask |= (1U << 0);
+		else if (cgrp_buf.f_type == CGROUP_SUPER_MAGIC)
+			cg_setup_mode_bitmask |= (1U << 1);
+	}
+
+	if (cg_cgroup_v2_empty_mount_paths)
+		cg_setup_mode_bitmask |= (1U << 0);
+
+	if (cg_setup_mode_bitmask & (1U << 0) && cg_setup_mode_bitmask & (1U << 1))
+		setup_mode = CGROUP_MODE_HYBRID;
+	else if (cg_setup_mode_bitmask & (1U << 0))
+		setup_mode = CGROUP_MODE_UNIFIED;
+	else if (cg_setup_mode_bitmask & (1U << 1))
+		setup_mode = CGROUP_MODE_LEGACY;
+
+out:
+	pthread_rwlock_unlock(&cg_mount_table_lock);
+	return setup_mode;
 }

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -146,4 +146,7 @@ CGROUP_3.0 {
 	cgroup_cgxset;
 	cgroup_version;
 	cgroup_list_mount_points;
+
+	/* libcgroup 3.0.1 */
+	cgroup_setup_mode;
 } CGROUP_2.0;

--- a/src/python/cgroup.pxd
+++ b/src/python/cgroup.pxd
@@ -21,6 +21,12 @@ cdef extern from "libcgroup.h":
         CGROUP_V2
         CGROUP_DISK
 
+    cdef enum cg_setup_mode_t:
+        CGROUP_MODE_UNK
+        CGROUP_MODE_LEGACY
+        CGROUP_MODE_HYBRID
+        CGROUP_MODE_UNIFIED
+
     cdef struct cgroup_library_version:
         unsigned int major
         unsigned int minor
@@ -53,5 +59,7 @@ cdef extern from "libcgroup.h":
 
     int cgroup_list_mount_points(const cg_version_t cgrp_version,
                                  char ***mount_paths)
+
+    cg_setup_mode_t cgroup_setup_mode()
 
 # vim: set et ts=4 sw=4:

--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -22,6 +22,12 @@ cdef class Version:
     CGROUP_V2 = cgroup.CGROUP_V2
     CGROUP_DISK = cgroup.CGROUP_DISK
 
+cdef class Mode:
+    CGROUP_MODE_UNK = cgroup.CGROUP_MODE_UNK
+    CGROUP_MODE_LEGACY = cgroup.CGROUP_MODE_LEGACY
+    CGROUP_MODE_HYBRID = cgroup.CGROUP_MODE_HYBRID
+    CGROUP_MODE_UNIFIED = cgroup.CGROUP_MODE_UNIFIED
+
 def c_str(string):
     return bytes(string, "ascii")
 
@@ -309,6 +315,16 @@ cdef class Cgroup:
             mount_points.append(<str>(a[i]).decode("utf-8"))
             i = i + 1
         return mount_points
+
+    @staticmethod
+    def cgroup_mode():
+        """Get the cgroup mode (legacy, hybrid, or unified)
+
+        Return:
+        The cgroup mode enumeration
+        """
+        Cgroup.cgroup_init()
+        return cgroup.cgroup_setup_mode()
 
     def __dealloc__(self):
         cgroup.cgroup_free(&self._cgp);

--- a/tests/ftests/048-pybindings-get_cgroup_mode.py
+++ b/tests/ftests/048-pybindings-get_cgroup_mode.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Test to get the cgroup mode
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli
+from libcgroup import Cgroup
+import consts
+import ftests
+import sys
+import os
+
+
+def prereqs(config):
+    return consts.TEST_PASSED, None
+
+
+def setup(config):
+    return consts.TEST_PASSED, None
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    mode1 = Cgroup.cgroup_mode()
+    mode2 = CgroupCli.get_cgroup_mode(config)
+
+    if mode1 != mode2:
+        result = consts.TEST_FAILED
+        cause = 'mode mismatch: libcgroup mode: {}, tests mode: {}'.format(mode1, mode2)
+
+    return result, cause
+
+
+def teardown(config):
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
This patchset introduces a new API `cgroup_setup_mode()` to
detect the current cgroup setup mode (Legacy/Unified/Hybrid).
The setup will depend on the Linux Kernel's grub command line
the system/VM is booted with.

One use case for this is, the users can enable or disable features
in their applications depending upon the cgroup setup. Like some
controllers are only available on cgroup v2, so they might need to
set/get settings for those available controllers only.

The second patch, adds a new switch (-m) to `cgget`, that will print
the current cgroup mode the system/VM has booted it.

Changes from v1 -> v2:
* Add python bindings
* Add functional test
* Address review comments from v1

v1 patchset is available here:
https://github.com/libcgroup/libcgroup/pull/260