### PR TITLE
api.c: fix resource leak in cg_chmod_path() [v3.0+]

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -247,7 +247,7 @@ fail:
 	cgroup_warn("cannot change permissions of file %s: %s\n", path, strerror(errno));
 	last_errno = errno;
 
-	if (fd > 0)
+	if (fd > -1)
 		close(fd);
 
 	return ECGOTHER;


### PR DESCRIPTION
Fix resource leak, reported by Coverity Tool:
```
CID 276160 (#1 of 1): Resource leak (RESOURCE_LEAK)10. leaked_handle:
Handle variable fd going out of scope leaks the handle.
```
In cg_chmod_path(), the file descriptor checks for fd > 0, Coverity warns about the
possibility of the file descriptor being 0, fix it by changing the check from '0' -> '-1'.

Fixes: 91cf2e4b7ceb ("api.c: fix file open in cg_chmod_path()")
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>