### PR TITLE
Add Python lint to the Github Workflow [v3.0+]

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,6 +60,21 @@ jobs:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  flake8-lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: flake8 Lint
+        uses: reviewdog/action-flake8@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   doxygen:
     name: Doxygen
     # Only run Doxygen against the main branch


### PR DESCRIPTION
The Python lint in the GitHub workflow, was previously part of the `libcgroup-test`
repo, which hosted most of the python source code.  Now that `libcgroup-test`
is part of `libcgroup` repo, let's add the lint workflow here too. Also, the `flake8`
Python lint tool, allows us to tweak the checks by customizing and extending the
rules the lint should operate. To begin with, let's add our own rule to allow a
100-character width in the sources.