### PR TITLE
GitHub actions/workflow: Adopt SPDX License tag [v3.0+]

### DIFF
--- a/.github/actions/code-coverage/action.yml
+++ b/.github/actions/code-coverage/action.yml
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Action to collate the libcgroup code coverage data
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 name: Collate code coverage results

--- a/.github/actions/setup-libcgroup/action.yml
+++ b/.github/actions/setup-libcgroup/action.yml
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Action to setup the libcgroup directory
 #
 # Copyright (c) 2020-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 name: Setup the libcgroup directory

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Continuous Integration Workflow for libcgroup
 #
 # Copyright (c) 2020-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 name: Continuous Integration


### PR DESCRIPTION
Adopt SPDX license tag for all the yml files, those already have
LGPL 2.1 boilerplate in them and those missing license information.
All the files in the project fall under the project license, hence
explicitly adding LGPL-2.1-only identifier to the files missing license
information. Adopting SPDX license helps the compliance tools to
determine the license and also helps in reducing the repetitive license
boilerplate across source files.