### PR TITLE
[RFC] Add systemd configuration support to cgconfig.conf

### DIFF
--- a/include/libcgroup/systemd.h
+++ b/include/libcgroup/systemd.h
@@ -33,6 +33,17 @@ struct cgroup_systemd_scope_opts {
 	pid_t pid;
 };
 
+/*
+ * cgroup systemd settings
+ */
+struct cgroup_systemd_opts {
+	char	slice_name[FILENAME_MAX];
+	char	scope_name[FILENAME_MAX];
+	int	setdefault;
+	pid_t	pid;
+	struct cgroup_systemd_opts *next;
+};
+
 /**
  * Populate the scope options structure with default values
  *
@@ -68,6 +79,45 @@ int cgroup_create_scope(const char * const scope_name, const char * const slice_
  */
 int cgroup_create_scope2(struct cgroup *cgroup, int ignore_ownership,
 			 const struct cgroup_systemd_scope_opts * const opts);
+
+/**
+ * Parse the systemd default cgroup's relative path from
+ * /var/run/libcgroup/systemd and set it as default delegation cgroup
+ * path, if available.
+ *
+ * The path is relative to cgroup root (default: /sys/fs/cgroup)
+ */
+void cgroup_set_default_systemd_cgroup(void);
+
+/**
+ * Parse the systemd delegation settings from the configuration file
+ * and allocate a new cgroup_systemd_opts object.
+ * This function internally calls cgroup_add_systemd_opts() to add the conf and
+ * value to the newly allocated cgroup_systemd_opts object.
+ *
+ * @param conf Name of the systemd delegate setting read from configuration file.
+ * @param value The value of the conf systemd delegate setting.
+ *
+ * @return 1 on success and 0 on error
+ */
+int cgroup_alloc_systemd_opts(const char * const conf, const char * const value);
+
+/**
+ * Parse the systemd delegation settings from the configuration file
+ * and add the conf and value to the last allocated cgroup_systemd_opts object
+ * (tail) allocated by cgroup_alloc_systemd_opts()
+ *
+ * @param conf Name of the systemd delegate setting read from configuration file.
+ * @param value The value of the conf systemd delegate setting.
+ *
+ * @return 1 on success and 0 on error
+ */
+int cgroup_add_systemd_opts(const char * const conf, const char * const value);
+
+/**
+ * Free the cgroup_systemd_opts objects allocated by cgroup_alloc_systemd_opts()
+ */
+void cgroup_cleanup_systemd_opts(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/samples/config/cgconfig_systemd.conf
+++ b/samples/config/cgconfig_systemd.conf
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+#systemd {
+#        slice = database.slice;
+#        scope = db.scope;
+#        setdefault = yes;
+#}
+#
+#systemd {
+#        slice = database.slice;
+#        scope = house_keeping.scope;
+#        pid = 3456;
+#}
+#
+#systemd {
+#        slice = others.slice;
+#        scope = server.scope;
+#}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,6 +39,7 @@ libcgroup_la_LDFLAGS = -Wl,--version-script,$(srcdir)/libcgroup.map \
 		       -version-number $(VERSION_NUMBER)
 if WITH_SYSTEMD
 libcgroup_la_LDFLAGS += -lsystemd
+libcgroup_la_CFLAGS += -DWITH_SYSTEMD
 endif
 
 noinst_LTLIBRARIES = libcgroupfortesting.la

--- a/src/api.c
+++ b/src/api.c
@@ -97,6 +97,11 @@ struct cg_mount_table_s cg_mount_table[CG_CONTROLLER_MAX];
 /* Cgroup v2 mount paths, with empty controllers */
 struct cg_mount_point *cg_cgroup_v2_empty_mount_paths;
 
+#ifdef WITH_SYSTEMD
+/* Default systemd path name. Length: <name>.slice/<name>.scope */
+char systemd_default_cgroup[FILENAME_MAX * 2 + 1];
+#endif
+
 const char * const cgroup_strerror_codes[] = {
 	"Cgroup is not compiled in",
 	"Cgroup is not mounted",

--- a/src/api.c
+++ b/src/api.c
@@ -1680,7 +1680,24 @@ static char *cg_concat_path(const char *pref, const char *suf, char *path)
 /* path value have to have size at least FILENAME_MAX */
 char *cg_build_path_locked(const char *name, char *path, const char *type)
 {
-	int i, ret;
+	/*
+	 * len is the allocation size for path, that stores:
+	 * cg_mount_table[i].mount.path + '/' + cg_namespace_table[i] + '/'
+	 */
+	int i, ret, len = (FILENAME_MAX * 2) + 2;
+	char *_path;
+
+	/*
+	 * Recent gcc are unhappy when sizeof(dest) <= sizeof(src) with
+	 * snprintf()'s.  Alternative is to use multiple strncpy()/strcat(),
+	 * work around it by allocating large temporary buffer _path and
+	 * copying the constructed _path into path.
+	 */
+	_path = malloc(len);
+	if (!_path) {
+		cgroup_err("Failed to allocate memory for _path\n");
+		return NULL;
+	}
 
 	/*
 	 * If no type is specified, and there's a valid cgroup v2 mount, then
@@ -1689,21 +1706,26 @@ char *cg_build_path_locked(const char *name, char *path, const char *type)
 	 * any controller.
 	 */
 	if (!type && strlen(cg_cgroup_v2_mount_path) > 0) {
-		ret = snprintf(path, FILENAME_MAX, "%s/", cg_cgroup_v2_mount_path);
+		ret = snprintf(_path, len, "%s/", cg_cgroup_v2_mount_path);
 		if (ret >= FILENAME_MAX)
-			cgroup_dbg("filename too long: %s/", cg_cgroup_v2_mount_path);
+			cgroup_dbg("filename too long: %s", _path);
+
+		strncpy(path, _path, FILENAME_MAX - 1);
+		path[FILENAME_MAX - 1] = '\0';
 
 		if (name) {
 			char *tmp;
 
 			tmp = strdup(path);
-			if (tmp == NULL)
-				return NULL;
+			if (tmp == NULL) {
+				path = NULL;
+				goto out;
+			}
 
 			cg_concat_path(tmp, name, path);
 			free(tmp);
 		}
-		return path;
+		goto out;
 	}
 
 	for (i = 0; cg_mount_table[i].name[0] != '\0'; i++) {
@@ -1717,23 +1739,17 @@ char *cg_build_path_locked(const char *name, char *path, const char *type)
 		    (type && strcmp(type, CGROUP_FILE_PREFIX) == 0 &&
 		     cg_mount_table[i].version == CGROUP_V2)) {
 
-			if (cg_namespace_table[i]) {
-				ret = snprintf(path, FILENAME_MAX, "%s/%s/",
-						cg_mount_table[i].mount.path,
-						cg_namespace_table[i]);
-				if (ret >= FILENAME_MAX) {
-					cgroup_dbg("filename too long:%s/%s/",
-						   cg_mount_table[i].mount.path,
-						   cg_namespace_table[i]);
-				}
-			} else {
-				ret = snprintf(path, FILENAME_MAX, "%s/",
-					       cg_mount_table[i].mount.path);
-				if (ret >= FILENAME_MAX) {
-					cgroup_dbg("filename too long:%s/",
-						   cg_mount_table[i].mount.path);
-				}
-			}
+			if (cg_namespace_table[i])
+				ret = snprintf(_path, len, "%s/%s/", cg_mount_table[i].mount.path,
+					       cg_namespace_table[i]);
+			else
+				ret = snprintf(_path, len, "%s/", cg_mount_table[i].mount.path);
+
+			if (ret >= FILENAME_MAX)
+				cgroup_dbg("filename too long: %s", _path);
+
+			strncpy(path, _path, FILENAME_MAX - 1);
+			path[FILENAME_MAX - 1] = '\0';
 
 			if (name) {
 				char *tmp;
@@ -1745,10 +1761,16 @@ char *cg_build_path_locked(const char *name, char *path, const char *type)
 				cg_concat_path(tmp, name, path);
 				free(tmp);
 			}
-			return path;
+			goto out;
 		}
 	}
-	return NULL;
+	path = NULL;
+
+out:
+	if (_path)
+		free(_path);
+
+	return path;
 }
 
 char *cg_build_path(const char *name, char *path, const char *type)

--- a/src/config.c
+++ b/src/config.c
@@ -19,6 +19,7 @@
 
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
+#include <libcgroup/systemd.h>
 
 #include <pthread.h>
 #include <assert.h>
@@ -90,6 +91,26 @@ static struct cgroup_string_list *template_files;
 
 /* Needed for the type while mounting cgroupfs. */
 #define CGROUP_FILESYSTEM "cgroup"
+
+#ifdef WITH_SYSTEMD
+/* Directory that holds dynamically created internal libcgroup files */
+static const char * const systemd_def_cgrp_file_dir = "/var/run/libcgroup/";
+
+/* File that stores the relative delegated systemd cgroup path */
+static const char * const systemd_default_cgroup_file = "/var/run/libcgroup/systemd";
+
+/* Lock that protects systemd_default_cgroup_file */
+static pthread_rwlock_t systemd_default_cgroup_lock = PTHREAD_RWLOCK_INITIALIZER;
+
+/*
+ * cgroup_systemd_opts is dynamically allocated, hence having head
+ * and tail helps in traversing.
+ */
+static struct cgroup_systemd_opts *cgroup_systemd_opts_head;
+static struct cgroup_systemd_opts *cgroup_systemd_opts_tail;
+
+static int config_create_slice_scope(char * const tmp_systemd_default_cgroup);
+#endif
 
 /*
  * NOTE: All these functions return 1 on success and not 0 as is the
@@ -971,6 +992,8 @@ static void cgroup_free_config(void)
 		config_template_table = NULL;
 	}
 	config_template_table_index = 0;
+
+	cgroup_cleanup_systemd_opts();
 }
 
 /**
@@ -1081,6 +1104,10 @@ static void cgroup_config_sort_groups(void)
  */
 int cgroup_config_load_config(const char *pathname)
 {
+#ifdef WITH_SYSTEMD
+	/* slice[FILENAME_MAX] + '/' + scope[FILENAME_MAX] */
+	char tmp_systemd_default_cgroup[FILENAME_MAX * 2 + 1] = "\0";
+#endif
 	int namespace_enabled = 0;
 	int mount_enabled = 0;
 	int error;
@@ -1126,11 +1153,34 @@ int cgroup_config_load_config(const char *pathname)
 	if (error)
 		goto err_mnt;
 
+#ifdef WITH_SYSTEMD
+	error = config_create_slice_scope(tmp_systemd_default_cgroup);
+	if (!error) {
+		error = ECGROUPPARSEFAIL;
+		goto err_mnt;
+	}
+#endif
+
 	cgroup_config_apply_default();
 	error = cgroup_config_create_groups();
 	cgroup_dbg("creating all cgroups now, error=%d\n", error);
 	if (error)
 		goto err_grp;
+
+#ifdef WITH_SYSTEMD
+	/*
+	 * Setting up systemd_default_cgroup, during creation
+	 * of slice/scopes, clobbers the path returned by cg_build_path(),
+	 * by appending the systemd_default_cgroup to it and
+	 * its required only after all of the slices/scopes are created.
+	 * The user might also set delegate in more than one systemd
+	 * delegate settings, in that case the last parsed one overwrites
+	 * the systemd_default_cgroup.
+	 */
+	if (strlen(tmp_systemd_default_cgroup))
+		snprintf(systemd_default_cgroup, sizeof(systemd_default_cgroup),
+			 "%s", tmp_systemd_default_cgroup);
+#endif
 
 	cgroup_free_config();
 
@@ -1807,3 +1857,236 @@ end:
 	cgroup_free(&aux_cgroup);
 	return ret;
 }
+
+#ifdef WITH_SYSTEMD
+int cgroup_add_systemd_opts(const char * const config, const char * const value)
+{
+	struct cgroup_systemd_opts *curr = cgroup_systemd_opts_tail;
+	int len;
+
+	if (strcmp(config, "slice") == 0) {
+		snprintf(curr->slice_name, FILENAME_MAX, "%s", value);
+
+		len = strlen(curr->slice_name) - 6;
+		if (strcmp(curr->slice_name + len, ".slice"))
+			goto err;
+
+	} else if (strcmp(config, "scope") == 0) {
+		snprintf(curr->scope_name, FILENAME_MAX, "%s", value);
+
+		len = strlen(curr->scope_name) - 6;
+		if (strcmp(curr->scope_name + len, ".scope"))
+			goto err;
+
+	} else if (strcmp(config, "setdefault") == 0 && strcasecmp(value, "yes") == 0) {
+		curr->setdefault = 1;
+	} else if (strcmp(config, "pid") == 0) {
+		/*
+		 * If the atoi() fails, the pid value is zero and also
+		 * avoid allowing init task (systemd).
+		 */
+		curr->pid = atoi(value);
+		if (curr->pid <= 1)
+			goto err;
+	} else
+		goto err;
+
+	return 1;
+err:
+	cgroup_err("Invalid systemd configuration %s value %s\n", config, value);
+	cgroup_cleanup_systemd_opts();
+	return 0;
+}
+
+int cgroup_alloc_systemd_opts(const char * const config, const char * const value)
+{
+	struct cgroup_systemd_opts *new_cgrp_systemd_opts;
+
+	/*
+	 * check for the allowed systemd configurations. We don't
+	 * check for values, they will be checked by systemd anyway.
+	 */
+	if (strcmp(config, "slice") != 0 &&
+	    strcmp(config, "scope") != 0 &&
+	    strcmp(config, "setdefault") != 0 &&
+	    strcmp(config, "pid") != 0) {
+		cgroup_err("Invalid systemd configuration %s\n", config);
+		goto err;
+	}
+
+	new_cgrp_systemd_opts = calloc(1, sizeof(struct cgroup_systemd_opts));
+	if (!new_cgrp_systemd_opts) {
+		cgroup_err("Failed to allocate memory for cgroup_systemd_opts\n");
+		goto err;
+	}
+
+	if (!cgroup_systemd_opts_head)
+		cgroup_systemd_opts_tail = cgroup_systemd_opts_head = new_cgrp_systemd_opts;
+	else {
+		cgroup_systemd_opts_tail->next = new_cgrp_systemd_opts;
+		cgroup_systemd_opts_tail = new_cgrp_systemd_opts;
+	}
+
+	return cgroup_add_systemd_opts(config, value);
+err:
+	cgroup_cleanup_systemd_opts();
+	return 0;
+}
+
+void cgroup_cleanup_systemd_opts(void)
+{
+	struct cgroup_systemd_opts *curr, *next;
+
+	for (curr = cgroup_systemd_opts_head; curr; curr = next) {
+		next = curr->next;
+		free(curr);
+	}
+
+	cgroup_systemd_opts_head = cgroup_systemd_opts_tail = NULL;
+}
+
+/*
+ * Helper function to remove the systemd_default_cgroup_file.
+ * systemd_default_cgroup_lock is expected to be held by the
+ * caller.
+ */
+static int remove_systemd_default_cgroup_file(void)
+{
+	int ret;
+
+	ret = unlink(systemd_default_cgroup_file);
+	if (ret < 0 && errno != ENOENT) {
+		cgroup_err("Failed to remove %s\n", systemd_default_cgroup_file);
+		return 0;
+	}
+
+	return 1;
+}
+/*
+ * Helper function to create systemd_default_cgroup_file and write systemd
+ * default cgroup slice/scope into it.  This file will be read by
+ * cgroup_set_default_systemd_cgroup() for setting
+ * systemd_default_cgroup used to form the cgroup path.
+ */
+static int cgroup_write_systemd_default_cgroup(const char * const slice,
+					       const char * const scope)
+{
+	FILE *systemd_def_cgrp_f;
+	int ret, len;
+
+	pthread_rwlock_wrlock(&systemd_default_cgroup_lock);
+
+	ret = mkdir(systemd_def_cgrp_file_dir, 0755);
+	if (ret != 0 && errno != EEXIST) {
+		cgroup_err("Failed to create directory %s\n", systemd_def_cgrp_file_dir);
+		ret = 0;
+		goto out;
+	}
+
+	systemd_def_cgrp_f = fopen(systemd_default_cgroup_file, "w");
+	if (!systemd_def_cgrp_f) {
+		cgroup_err("Failed to create file %s\n", systemd_default_cgroup_file);
+		ret = 0;
+		goto out;
+	}
+
+	len = strlen(slice) + strlen(scope) + 1;
+
+	ret = fprintf(systemd_def_cgrp_f, "%s/%s", slice, scope);
+	fclose(systemd_def_cgrp_f);
+	if  (ret != len) {
+		cgroup_err("Incomplete systemd default cgroup written to %s\n",
+			   systemd_default_cgroup_file);
+		ret = remove_systemd_default_cgroup_file();
+		/* Ignore the return value, we are already in error path */
+		ret = 0;
+		goto out;
+	}
+
+	ret = 1;
+out:
+	pthread_rwlock_unlock(&systemd_default_cgroup_lock);
+	return ret;
+}
+
+/**
+ * Create the systemd slice and scope. The slice/scope are parsed and available in
+ * the cgroup_systemd_opts_head list. This function skips the slice and scope creation
+ * if previously created.
+ *
+ * Returns 1 on success and 0 on failure.
+ */
+static int config_create_slice_scope(char * const tmp_systemd_default_cgroup)
+{
+	struct cgroup_systemd_opts *curr, *def = NULL;
+	struct cgroup_systemd_scope_opts scope_opts;
+	int ret = 0;
+
+	if (!tmp_systemd_default_cgroup)
+		return 0;
+
+	if (cgroup_set_default_scope_opts(&scope_opts))
+		return 0;
+
+	pthread_rwlock_wrlock(&systemd_default_cgroup_lock);
+	ret = remove_systemd_default_cgroup_file();
+	pthread_rwlock_unlock(&systemd_default_cgroup_lock);
+	if (!ret)
+		return 0;
+
+	for (curr = cgroup_systemd_opts_head; curr; curr = curr->next) {
+
+		if (!strlen(curr->slice_name)) {
+			cgroup_err("Invalid systemd setting, missing slice name.\n");
+			goto err;
+		}
+
+		if (!strlen(curr->scope_name)) {
+			cgroup_err("Invalid systemd setting, missing scope name.\n");
+			goto err;
+		}
+
+		/* incase of multiple delegate configurations, set it to latest scope */
+		if (curr->setdefault)
+			def = curr;
+
+		if (curr->pid)
+			scope_opts.pid = curr->pid;
+
+		ret = cgroup_create_scope(curr->scope_name, curr->slice_name, &scope_opts);
+		if (ret)
+			goto err;
+
+		cgroup_dbg("Created systemd slice %s scope %s default %d pid %d\n",
+			   curr->slice_name, curr->scope_name, curr->setdefault, curr->pid);
+	}
+
+	if (def) {
+		if (!cgroup_write_systemd_default_cgroup(def->slice_name, def->scope_name))
+			goto err;
+
+		snprintf(tmp_systemd_default_cgroup, sizeof(systemd_default_cgroup),
+			 "%s/%s", def->slice_name, def->scope_name);
+
+		cgroup_dbg("Setting/Writing systemd default cgroup %s to file %s\n",
+			   tmp_systemd_default_cgroup, systemd_default_cgroup_file);
+
+	}
+
+	return 1;
+err:
+	return 0;
+}
+#else
+int cgroup_add_systemd_opts(const char * const config, const char * const value)
+{
+	return 1;
+}
+
+int cgroup_alloc_systemd_opts(const char * const config, const char * const value)
+{
+	return 1;
+}
+
+void cgroup_cleanup_systemd_opts(void) { }
+#endif

--- a/src/lex.l
+++ b/src/lex.l
@@ -36,6 +36,7 @@ jmp_buf parser_error_env;
 "group"		{return GROUP;}
 "namespace"	{return NAMESPACE;}
 "template"	{return TEMPLATE;}
+"systemd"     	{return SYSTEMD;}
 "default"	{yylval.name = strdup(yytext); return DEFAULT;}
 [a-zA-Z0-9_\-\/\.\,\%\@\\]+ {yylval.name = strdup(yytext); return ID;}
 \"[^"]*\" {yylval.name = strdup(yytext+1); yylval.name[strlen(yylval.name)-1] = '\0'; return ID; }

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -240,6 +240,12 @@ extern pthread_rwlock_t cg_mount_table_lock;
 extern __thread char *cg_namespace_table[CG_CONTROLLER_MAX];
 
 /*
+ * Default systemd cgroup used by the cg_build_path_locked() and tools
+ * setting the default cgroup path.
+ */
+extern char systemd_default_cgroup[FILENAME_MAX * 2 + 1];
+
+/*
  * config related API
  */
 int cgroup_config_insert_cgroup(char *cg_name);

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -155,4 +155,5 @@ CGROUP_3.0 {
 	cgroup_get_controller_by_index;
 	cgroup_get_controller_name;
 	cgroup_create_scope2;
+	cgroup_set_default_systemd_cgroup;
 } CGROUP_2.0;

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -5,6 +5,10 @@ LDADD = $(top_builddir)/src/libcgroup.la -lpthread
 
 if WITH_TOOLS
 
+if WITH_SYSTEMD
+EXTRA_CFLAGS = -DWITH_SYSTEMD
+endif
+
 bin_PROGRAMS = cgexec cgclassify cgcreate cgset cgxset cgget cgxget cgdelete \
 	       lssubsys lscgroup cgsnapshot
 
@@ -14,44 +18,44 @@ noinst_LTLIBRARIES = libcgset.la
 
 cgexec_SOURCES = cgexec.c tools-common.c tools-common.h
 cgexec_LIBS = $(CODE_COVERAGE_LIBS)
-cgexec_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+cgexec_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS)
 
 cgclassify_SOURCES = cgclassify.c tools-common.c tools-common.h
 cgclassify_LIBS = $(CODE_COVERAGE_LIBS)
-cgclassify_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+cgclassify_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS)
 
 cgcreate_SOURCES = cgcreate.c tools-common.c tools-common.h
 cgcreate_LIBS = $(CODE_COVERAGE_LIBS)
-cgcreate_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+cgcreate_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS)
 
 libcgset_la_SOURCES = cgset.c tools-common.c tools-common.h
 libcgset_la_LIBADD = $(CODE_COVERAGE_LIBS)
-libcgset_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC= -DUNIT_TEST
+libcgset_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS) -DSTATIC= -DUNIT_TEST
 libcgset_la_LDFLAGS = -Wl,--no-undefined $(LDADD)
 
 cgset_SOURCES = cgset.c tools-common.c tools-common.h
 cgset_LIBS = $(CODE_COVERAGE_LIBS)
-cgset_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC=static
+cgset_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS) -DSTATIC=static
 
 cgxset_SOURCES = cgxset.c tools-common.c tools-common.h
 cgxset_LIBS = $(CODE_COVERAGE_LIBS)
-cgxset_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC=static
+cgxset_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS) -DSTATIC=static
 
 cgget_SOURCES = cgget.c tools-common.c tools-common.h
 cgget_LIBS = $(CODE_COVERAGE_LIBS)
-cgget_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+cgget_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS)
 
 cgxget_SOURCES = cgxget.c tools-common.c tools-common.h
 cgxget_LIBS = $(CODE_COVERAGE_LIBS)
-cgxget_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+cgxget_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS)
 
 cgconfigparser_SOURCES = cgconfig.c tools-common.c tools-common.h
 cgconfigparser_LIBS = $(CODE_COVERAGE_LIBS)
-cgconfigparser_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+cgconfigparser_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS)
 
 cgdelete_SOURCES = cgdelete.c tools-common.c tools-common.h
 cgdelete_LIBS = $(CODE_COVERAGE_LIBS)
-cgdelete_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+cgdelete_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS)
 
 lssubsys_SOURCES = lssubsys.c
 lssubsys_LIBS = $(CODE_COVERAGE_LIBS)
@@ -59,11 +63,11 @@ lssubsys_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 
 lscgroup_SOURCES = tools-common.c lscgroup.c
 lscgroup_LIBS = $(CODE_COVERAGE_LIBS)
-lscgroup_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+lscgroup_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS)
 
 cgsnapshot_SOURCES = cgsnapshot.c
 cgsnapshot_LIBS = $(CODE_COVERAGE_LIBS)
-cgsnapshot_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+cgsnapshot_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(EXTRA_CFLAGS)
 
 install-exec-hook:
 	chmod u+s $(DESTDIR)$(bindir)/cgexec

--- a/src/tools/cgexec.c
+++ b/src/tools/cgexec.c
@@ -49,11 +49,15 @@ static void usage(int status, const char *program_name)
 	info("  -h, --help			Display this help\n");
 	info("  --sticky			cgred daemon does not ");
 	info("change pidlist and children tasks\n");
+#ifdef WITH_SYSTEMD
+	info("  -b				Ignore default systemd delegate hierarchy\n");
+#endif
 }
 
 int main(int argc, char *argv[])
 {
 	struct cgroup_group_spec *cgroup_list[CG_HIER_MAX];
+	int ignore_default_systemd_delegate_slice = 0;
 	int cg_specified = 0;
 	int flag_child = 0;
 	int i, ret = 0;
@@ -63,9 +67,16 @@ int main(int argc, char *argv[])
 	int c;
 
 	memset(cgroup_list, 0, sizeof(cgroup_list));
-
+#ifdef WITH_SYSTEMD
+	while ((c = getopt_long(argc, argv, "+g:shb", longopts, NULL)) > 0) {
+		switch (c) {
+		case 'b':
+			ignore_default_systemd_delegate_slice = 1;
+			break;
+#else
 	while ((c = getopt_long(argc, argv, "+g:sh", longopts, NULL)) > 0) {
 		switch (c) {
+#endif
 		case 'g':
 			ret = parse_cgroup_spec(cgroup_list, optarg, CG_HIER_MAX);
 			if (ret) {
@@ -98,6 +109,10 @@ int main(int argc, char *argv[])
 		err("libcgroup initialization failed: %s\n", cgroup_strerror(ret));
 		return ret;
 	}
+
+	/* this is false always for disable-systemd */
+	if (!ignore_default_systemd_delegate_slice)
+		cgroup_set_default_systemd_cgroup();
 
 	/* Just for debugging purposes. */
 	uid = geteuid();

--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -10,10 +10,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <libgen.h>
 #include <stdio.h>
 
 #define MODE_SHOW_HEADERS	1
 #define MODE_SHOW_NAMES		2
+#define MODE_SYSTEMD_DELEGATE	4
 
 #define LL_MAX			100
 
@@ -44,6 +46,9 @@ static void usage(int status, const char *program_name)
 	info("  -v, --values-only		Print only values, not ");
 	info("parameter names\n");
 	info("  -m				Display the cgroup mode\n");
+#ifdef WITH_SYSTEMD
+	info("  -b				Ignore default systemd delegate hierarchy\n");
+#endif
 }
 
 static int get_controller_from_name(const char * const name, char **controller)
@@ -398,8 +403,16 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * c
 	int c;
 
 	/* Parse arguments. */
+#ifdef WITH_SYSTEMD
+	while ((c = getopt_long(argc, argv, "r:hnvg:amb", long_options, NULL)) > 0) {
+		switch (c) {
+		case 'b':
+			*mode = (*mode) & (INT_MAX ^ MODE_SYSTEMD_DELEGATE);
+			break;
+#else
 	while ((c = getopt_long(argc, argv, "r:hnvg:am", long_options, NULL)) > 0) {
 		switch (c) {
+#endif
 		case 'h':
 			usage(0, argv[0]);
 			exit(0);
@@ -563,7 +576,10 @@ static int fill_empty_controller(struct cgroup * const cg, struct cgroup_control
 	struct dirent *ctrl_dir = NULL;
 	bool found_mount = false;
 	int i, path_len, ret = 0;
-	char path[FILENAME_MAX];
+	char path[FILENAME_MAX] = { '\0' };
+#ifdef WITH_SYSTEMD
+	char tmp[FILENAME_MAX] = { '\0' };
+#endif
 	DIR *dir = NULL;
 
 	pthread_rwlock_rdlock(&cg_mount_table_lock);
@@ -583,6 +599,35 @@ static int fill_empty_controller(struct cgroup * const cg, struct cgroup_control
 		goto out;
 
 	path_len = strlen(path);
+#ifdef WITH_SYSTEMD
+	/*
+	 * If the user has set a slice/scope as delegate in the
+	 * cgconfig.conf file, every path constructed will have the
+	 * systemd_default_cgroup slice/scope suffixed to it.
+	 *
+	 * We need to trim the slice/scope from the path, incase of
+	 * user providing /<cgroup-name> as the cgroup name in the command
+	 * line:
+	 * cgget -g cpu:/foo
+	 */
+	if (cg->name[0] == '/' && cg->name[1] != '\0' &&
+	    strncmp(path + (path_len - 7), ".scope/", 7) == 0) {
+		snprintf(tmp, FILENAME_MAX, "%s", dirname(path));
+		strncpy(path, tmp, FILENAME_MAX - 1);
+		path[FILENAME_MAX - 1] = '\0';
+
+		path_len = strlen(path);
+		if (strncmp(path + (path_len - 6), ".slice", 6) == 0) {
+			snprintf(tmp, FILENAME_MAX, "%s", dirname(path));
+			strncpy(path, tmp, FILENAME_MAX - 1);
+			path[FILENAME_MAX - 1] = '\0';
+		} else {
+			cgroup_dbg("Malformed path %s (expected slice name)\n", path);
+			ret = ECGOTHER;
+			goto out;
+		}
+	}
+#endif
 	strncat(path, cg->name, FILENAME_MAX - path_len - 1);
 	path[sizeof(path) - 1] = '\0';
 
@@ -725,7 +770,7 @@ static void print_cgroups(struct cgroup *cg_list[], int cg_list_len, int mode)
 
 int main(int argc, char *argv[])
 {
-	int mode = MODE_SHOW_NAMES | MODE_SHOW_HEADERS;
+	int mode = MODE_SHOW_NAMES | MODE_SHOW_HEADERS | MODE_SYSTEMD_DELEGATE;
 	struct cgroup **cg_list = NULL;
 	int cg_list_len = 0;
 	int ret = 0, i;
@@ -745,6 +790,10 @@ int main(int argc, char *argv[])
 	ret = parse_opts(argc, argv, &cg_list, &cg_list_len, &mode);
 	if (ret)
 		goto err;
+
+	/* this is false always for disable-systemd */
+	if (mode & MODE_SYSTEMD_DELEGATE)
+		cgroup_set_default_systemd_cgroup();
 
 	ret = get_values(cg_list, cg_list_len);
 	if (ret)

--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -68,6 +68,10 @@ static void usage(int status, const char *program_name)
 	info("  -r, --variable <name>			Define parameter to set\n");
 	info("  --copy-from <source_cgroup_path>	Control group whose ");
 	info("parameters will be copied\n");
+#ifdef WITH_SYSTEMD
+	info("  -b					Ignore default systemd ");
+	info("delegate hierarchy\n");
+#endif
 }
 #endif /* !UNIT_TEST */
 
@@ -121,6 +125,7 @@ err:
 #ifndef UNIT_TEST
 int main(int argc, char *argv[])
 {
+	int ignore_default_systemd_delegate_slice = 0;
 	struct control_value *name_value = NULL;
 	int nv_number = 0;
 	int nv_max = 0;
@@ -139,8 +144,16 @@ int main(int argc, char *argv[])
 	}
 
 	/* parse arguments */
+#ifdef WITH_SYSTEMD
+	while ((c = getopt_long (argc, argv, "r:hb", long_options, NULL)) != -1) {
+		switch (c) {
+		case 'b':
+			ignore_default_systemd_delegate_slice = 1;
+			break;
+#else
 	while ((c = getopt_long (argc, argv, "r:h", long_options, NULL)) != -1) {
 		switch (c) {
+#endif
 		case 'h':
 			usage(0, argv[0]);
 			ret = 0;
@@ -208,6 +221,10 @@ int main(int argc, char *argv[])
 		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		goto err;
 	}
+
+	/* this is false always for disable-systemd */
+	if (!ignore_default_systemd_delegate_slice)
+		cgroup_set_default_systemd_cgroup();
 
 	/* copy the name-value pairs from -r options */
 	if ((flags & FL_RULES) != 0) {

--- a/tests/ftests/060-sudo-cgconfigparser-systemd.py
+++ b/tests/ftests/060-sudo-cgconfigparser-systemd.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgconfigparser functionality test - systemd configurations
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+
+from run import Run, RunError
+from systemd import Systemd
+from cgroup import Cgroup
+import consts
+import ftests
+import time
+import sys
+import os
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = '060_cg_in_scope'
+OTHER_CGNAME = '060_cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test060.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '060cgconfig.conf')
+
+CONFIGURATIONS = [
+        # [ 'systemd configuration file', 'Excepted error substring']
+        ['systemd {\n}', 'Error: failed to parse file'],
+
+        ['systemd {\n\tslice = libcgroup;\n}',
+            'Error: Invalid systemd configuration slice value libcgroup'],
+
+        ['systemd {\n\tscope = test060;\n}',
+            'Error: Invalid systemd configuration scope value test060'],
+
+        ['systemd {\n\tslice = libcgroup.slice;\n}',
+            'Error: Invalid systemd setting, missing scope name'],
+
+        ['systemd {\n\tscope = test060.scope;\n}',
+            'Error: Invalid systemd setting, missing slice name'],
+
+        ['systemd {\n\tsetdefault = yes;\n}',
+            'Error: Invalid systemd setting, missing slice name'],
+
+        ['systemd {\n\tpid = 123;\n}',
+            'Error: Invalid systemd setting, missing slice name'],
+
+        ['systemd {\n\tInvalid = Invalid;\n}',
+            'Error: Invalid systemd configuration Invalid'],
+
+        ['systemd {\n\tslice = libcgroup.slice;\n\tsetdefault = yes;\n\t}',
+            'Error: Invalid systemd setting, missing scope name'],
+
+        ['systemd {\n\tscope = test060.scope;\n\tsetdefault = yes;\n\t}',
+            'Error: Invalid systemd setting, missing slice name'],
+
+        ['systemd {\n\tslice = libcgroup.slice;\n\tscope = test060.scope;\n\t'
+            'setdefault = invalid;\n\t}',
+            'Error: Invalid systemd configuration setdefault'],
+
+        ['systemd {\n\tslice = libcgroup.slice;\n\tscope = test060.scope;\n\t'
+            'setdefault = yes;\n\tpid = abc;\n}',
+            'Error: Invalid systemd configuration pid'],
+]
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    return consts.TEST_PASSED, None
+
+
+def write_conf_file(config, configurations):
+    f = open(CONFIG_FILE_NAME, 'w')
+    f.write(configurations)
+    f.close()
+
+
+def test_invalid_configurations(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    # Try parsing invalid systemd configurations from CONFIGURATION table
+    # and none of them is excepted to pass.
+    for configuration in CONFIGURATIONS:
+        write_conf_file(config, configuration[0])
+
+        try:
+            Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+        except RunError as re:
+            if configuration[1] not in re.stdout:
+                result = consts.TEST_FAILED
+                tmp_cause = (
+                            'Unexpected error {}, while parsing configuration:'
+                            '\n{}'.format(re.stdout, configuration[0])
+                        )
+                cause = '\n'.join(filter(None, [cause, tmp_cause]))
+        else:
+            result = consts.TEST_FAILED
+            tmp_cause = (
+                        'Creation of systemd default slice/scope, erroneously succeeded with'
+                        'configuration:\n{}'.format(configuration[0])
+                    )
+            cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    result, cause = test_invalid_configurations(config)
+    if result == consts.TEST_FAILED:
+        return result, cause
+
+    pid = Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    # Pass a valid configuration to the parser
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    if not Cgroup.exists(config, CONTROLLER, os.path.join(SLICE, SCOPE), ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = 'Failed to create systemd slice/scope'
+        return result, cause
+
+    # It's invalid to pass the same configuration file twice. The values
+    # were already read and slice/scope cgroups were created, unless
+    # something has gone wrong, this should fail.
+    try:
+        Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+    except RunError as re:
+        if 'already exists' not in re.stdout:
+            result = consts.TEST_FAILED
+            cause = 'Unexpected error  {}'.format(re.stdout)
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Creation of systemd default slice/scope erroneously succeeded'
+
+    # killing the pid, should remove the scope cgroup too.
+    Run.run(['sudo', 'kill', '-9', pid])
+
+    # Let's pause and wait for the systemd to remove the scope.
+    time.sleep(1)
+
+    if Cgroup.exists(config, CONTROLLER, os.path.join(SLICE, SCOPE), ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = 'Systemd failed to remove the scope {}'.format(SCOPE)
+
+    return result, cause
+
+
+def teardown(config):
+    # The scope is already removed, when the task was killed.
+    try:
+        Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+    except RunError as re:
+        if 'scope not loaded' not in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        result = consts.TEST_FAILED
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/061-sudo-g_flag_controller_only_systemd-v1.py
+++ b/tests/ftests/061-sudo-g_flag_controller_only_systemd-v1.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - '-b' '-g' <controller> (cgroup v1)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+
+from cgroup import Cgroup, CgroupVersion
+from systemd import Systemd
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = 'cg_in_scope'
+OTHER_CGNAME = 'cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test061.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '061cgconfig.conf')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, CONTROLLER, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/{}/'.format(SYSTEMD_CGNAME, CONTROLLER, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # create and check if the cgroup was created under the controller root
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=SYSTEMD_CGNAME)
+    if len(out.splitlines()) < 10:
+        # This cgget command gets all of the settings/values within the cgroup.
+        # We don't care about the exact data, but there should be at least 10
+        # lines of settings/values
+        result = consts.TEST_FAILED
+        cause = (
+                    'cgget failed to read at least 10 lines from '
+                    'cgroup {}: {}'.format(SYSTEMD_CGNAME, out)
+                )
+
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=OTHER_CGNAME, ignore_systemd=True)
+    if len(out.splitlines()) < 10:
+        result = consts.TEST_FAILED
+        tmp_cause = (
+                        'cgget failed to read at least 10 lines from '
+                        'cgroup {}: {}'.format(OTHER_CGNAME, out)
+                    )
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # This should fail because the wrong path should be built up
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=SYSTEMD_CGNAME, ignore_systemd=True,
+                     print_headers=False)
+    if len(out) > 0:
+        result = consts.TEST_FAILED
+        tmp_cause = (
+                        'cgget erroneously read cgroup {} at the '
+                        'wrong path: {}'.format(SYSTEMD_CGNAME, out)
+                    )
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # This should fail because the wrong path should be built up
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=OTHER_CGNAME, print_headers=False)
+    if len(out) > 0:
+        result = consts.TEST_FAILED
+        tmp_cause = (
+                        'cgget erroneously read cgroup {} at the '
+                        'wrong path: {}'.format(OTHER_CGNAME, out)
+                    )
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def teardown(config):
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        teardown(config)
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/062-sudo-g_flag_controller_only_systemd-v2.py
+++ b/tests/ftests/062-sudo-g_flag_controller_only_systemd-v2.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgget functionality test - '-b' '-g' <controller> (cgroup v2)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from systemd import Systemd
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = 'cg_in_scope'
+OTHER_CGNAME = 'cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test062.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '062cgconfig.conf')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v2 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, None, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/'.format(SYSTEMD_CGNAME, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # With cgroup v2, we can't enable controller for the child cgroup, while
+    # a task is attached to test062.scope. Attach the task from test062.scope
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
+    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
+
+    Cgroup.set(
+                config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
+                value='+cpu', ignore_systemd=True
+              )
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
+
+    # create and check if the cgroup was created under the controller root
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=SYSTEMD_CGNAME)
+    if len(out.splitlines()) < 10:
+        # This cgget command gets all of the settings/values within the cgroup.
+        # We don't care about the exact data, but there should be at least 10
+        # lines of settings/values
+        result = consts.TEST_FAILED
+        cause = (
+                    'cgget failed to read at least 10 lines from '
+                    'cgroup {}: {}'.format(SYSTEMD_CGNAME, out)
+                )
+
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=OTHER_CGNAME, ignore_systemd=True)
+    if len(out.splitlines()) < 10:
+        result = consts.TEST_FAILED
+        tmp_cause = (
+                        'cgget failed to read at least 10 lines from '
+                        'cgroup {}: {}'.format(OTHER_CGNAME, out)
+                    )
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # This should fail because the wrong path should be built up
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=SYSTEMD_CGNAME,
+                     ignore_systemd=True, print_headers=False)
+    if len(out) > 0:
+        result = consts.TEST_FAILED
+        tmp_cause = (
+                        'cgget erroneously read cgroup {} at the wrong '
+                        'path: {}'.format(SYSTEMD_CGNAME, out)
+                    )
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # This should fail because the wrong path should be built up
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=OTHER_CGNAME, print_headers=False)
+    if len(out) > 0:
+        result = consts.TEST_FAILED
+        cause = (
+                    'cgget erroneously read cgroup {} at the wrong '
+                    'path: {}'.format(OTHER_CGNAME, out)
+                )
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def teardown(config):
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        teardown(config)
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/063-sudo-systemd_cgset-v1.py
+++ b/tests/ftests/063-sudo-systemd_cgset-v1.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgset functionality test - '-b' '-g' <controller> (cgroup v1)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+
+from cgroup import Cgroup, CgroupVersion
+from systemd import Systemd
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = '063_cg_in_scope'
+OTHER_CGNAME = '063_cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test063.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '063cgconfig.conf')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, CONTROLLER, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/{}/'.format(SYSTEMD_CGNAME, CONTROLLER, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # create and check if the cgroup was created under the controller root
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.set_and_validate(config, SYSTEMD_CGNAME, 'cpu.shares', '200')
+    Cgroup.set_and_validate(config, OTHER_CGNAME, 'cpu.shares', '300', ignore_systemd=True)
+
+    try:
+        Cgroup.set(config, SYSTEMD_CGNAME, 'cpu.shares', '400', ignore_systemd=True)
+    except RunError as re:
+        if 'requested group parameter does not exist' not in re.stderr:
+            raise re
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Setting cpu.shares on {} erroneously succeeded'.format(SYSTEMD_CGNAME)
+
+    try:
+        Cgroup.set(config, OTHER_CGNAME, 'cpu.shares', '500')
+    except RunError as re:
+        if 'requested group parameter does not exist' not in re.stderr:
+            raise re
+    else:
+        result = consts.TEST_FAILED
+        tmp_cause = 'Setting cpu.shares on {} erroneously succeeded'.format(OTHER_CGNAME)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def teardown(config):
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/064-sudo-systemd_cgset-v2.py
+++ b/tests/ftests/064-sudo-systemd_cgset-v2.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgset functionality test - '-b' '-g' <controller> (cgroup v2)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+
+from cgroup import Cgroup, CgroupVersion
+from systemd import Systemd
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = '064_cg_in_scope'
+OTHER_CGNAME = '064_cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test064.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '064cgconfig.conf')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v2 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, None, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/'.format(SYSTEMD_CGNAME, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # With cgroup v2, we can't enable controller for the child cgroup, while
+    # a task is attached to test064.scope. Attach the task from test064.scope
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
+    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
+
+    Cgroup.set(
+                config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
+                value='+cpu', ignore_systemd=True
+              )
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
+
+    # create and check if the cgroup was created under the controller root
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.set_and_validate(config, SYSTEMD_CGNAME, 'cpu.weight', '200')
+    Cgroup.set_and_validate(config, OTHER_CGNAME, 'cpu.weight', '300', ignore_systemd=True)
+
+    try:
+        Cgroup.set(config, SYSTEMD_CGNAME, 'cpu.weight', '400', ignore_systemd=True)
+    except RunError as re:
+        if 'requested group parameter does not exist' not in re.stderr:
+            raise re
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Setting cpu.weight on {} erroneously succeeded'.format(SYSTEMD_CGNAME)
+
+    try:
+        Cgroup.set(config, OTHER_CGNAME, 'cpu.weight', '500')
+    except RunError as re:
+        if 'requested group parameter does not exist' not in re.stderr:
+            raise re
+    else:
+        result = consts.TEST_FAILED
+        tmp_cause = 'Setting cpu.weight on {} erroneously succeeded'.format(OTHER_CGNAME)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def teardown(config):
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/065-sudo-systemd_cgclassify-v1.py
+++ b/tests/ftests/065-sudo-systemd_cgclassify-v1.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgclassify functionality test - '-b' '-g' <controller> (cgroup v1)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from run import Run, RunError
+from systemd import Systemd
+import consts
+import ftests
+import time
+import sys
+import os
+
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = '065_cg_in_scope'
+OTHER_CGNAME = '065_cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test065.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '065cgconfig.conf')
+
+SYSTEMD_PIDS = ''
+OTHER_PIDS = ''
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, CONTROLLER, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/{}/'.format(SYSTEMD_CGNAME, CONTROLLER, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # create and check if the cgroup was created under the controller sub-tree
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def create_process_get_pid(config, CGNAME, SLICENAME='', ignore_systemd=False):
+    result = consts.TEST_PASSED
+    cause = None
+
+    config.process.create_process_in_cgroup(
+                                                config, CONTROLLER, CGNAME,
+                                                ignore_systemd=ignore_systemd
+                                            )
+
+    pids = Cgroup.get_pids_in_cgroup(config, os.path.join(SLICENAME, CGNAME), CONTROLLER)
+    if pids is None:
+        result = consts.TEST_FAILED
+        cause = 'No processes were found in cgroup {}'.format(CGNAME)
+
+    return pids, result, cause
+
+
+def terminate_process(config, pids):
+    if pids:
+        for p in pids.splitlines():
+            Run.run(['sudo', 'kill', '-9', p])
+
+
+def test(config):
+    global SYSTEMD_PIDS, OTHER_PIDS
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    # Test cgclassify, that creates a process and then uses cgclassify
+    # to migrate the task the cgroup.
+    SYSTEMD_PIDS, result, cause = create_process_get_pid(
+                                                            config, SYSTEMD_CGNAME,
+                                                            os.path.join(SLICE, SCOPE)
+                                                        )
+    if result == consts.TEST_FAILED:
+        return result, cause
+
+    OTHER_PIDS, result, tmp_cause = create_process_get_pid(
+                                                                config, OTHER_CGNAME,
+                                                                ignore_systemd=True
+                                                          )
+    if result == consts.TEST_FAILED:
+        return result, cause
+
+    # classify a task from the non-systemd scope cgroup (OTHER_CGNAME) to
+    # systemd scope cgroup (SYSTEMD_CGNAME).  Migration should fail due to
+    # the incorrect destination cgroup path that gets constructed, without
+    # the systemd slice/scope when ignore_systemd=True)
+    try:
+        Cgroup.classify(config, CONTROLLER, SYSTEMD_CGNAME, OTHER_PIDS, ignore_systemd=True)
+    except RunError as re:
+        err_str = 'Error changing group of pid {}: Cgroup does not exist'.format(OTHER_PIDS)
+        if re.stderr != err_str:
+            raise re
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Changing group of pid {} erroneously succeeded'.format(OTHER_PIDS)
+
+    # classify a task from the systemd scope cgroup (SYSTEMD_CGNAME) to
+    # non-systemd scope cgroup (OTHER_CGNAME).  Migration should fail due
+    # to the incorrect destination cgroup path that gets constructed, with
+    # the systemd slice/scope when ignore_systemd=False)
+    try:
+        Cgroup.classify(config, CONTROLLER, OTHER_CGNAME, SYSTEMD_PIDS)
+    except RunError as re:
+        err_str = 'Error changing group of pid {}: Cgroup does not exist'.format(SYSTEMD_PIDS)
+        if re.stderr != err_str:
+            raise re
+    else:
+        result = consts.TEST_FAILED
+        tmp_cause = 'Changing group of pid {} erroneously succeeded'.format(SYSTEMD_PIDS)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # classify the task from the non-systemd scope cgroup to systemd scope cgroup.
+    Cgroup.classify(config, CONTROLLER, SYSTEMD_CGNAME, OTHER_PIDS)
+
+    return result, cause
+
+
+def teardown(config):
+    global SYSTEMD_PIDS, OTHER_PIDS
+
+    terminate_process(config, SYSTEMD_PIDS)
+    terminate_process(config, OTHER_PIDS)
+
+    # We need a pause, so that cgroup.procs gets updated.
+    time.sleep(1)
+
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' not in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/066-sudo-systemd_cgclassify-v2.py
+++ b/tests/ftests/066-sudo-systemd_cgclassify-v2.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgclassify functionality test - '-b' '-g' <controller> (cgroup v2)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from systemd import Systemd
+from run import Run, RunError
+import consts
+import ftests
+import time
+import sys
+import os
+
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = '066_cg_in_scope'
+OTHER_CGNAME = '066_cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test066.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '066cgconfig.conf')
+
+SYSTEMD_PIDS = ''
+OTHER_PIDS = ''
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v2 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, None, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/'.format(SYSTEMD_CGNAME, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # With cgroup v2, we can't enable controller for the child cgroup, while
+    # a task is attached to test066.scope. Attach the task from test066.scope
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
+    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
+
+    Cgroup.set(
+                config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
+                value='+cpu', ignore_systemd=True
+              )
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
+
+    # create and check if the cgroup was created under the controller root
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def create_process_get_pid(config, CGNAME, SLICENAME='', ignore_systemd=False):
+    result = consts.TEST_PASSED
+    cause = None
+
+    config.process.create_process_in_cgroup(
+                                                config, CONTROLLER, CGNAME,
+                                                ignore_systemd=ignore_systemd
+                                            )
+
+    pids = Cgroup.get_pids_in_cgroup(config, os.path.join(SLICENAME, CGNAME), CONTROLLER)
+    if pids is None:
+        result = consts.TEST_FAILED
+        cause = 'No processes were found in cgroup {}'.format(CGNAME)
+
+    return pids, result, cause
+
+
+def terminate_process(config, pids):
+    if pids:
+        for p in pids.splitlines():
+            Run.run(['sudo', 'kill', '-9', p])
+
+
+def test(config):
+    global SYSTEMD_PIDS, OTHER_PIDS
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    # Test cgclassify, that creates a process and then uses cgclassify
+    # to migrate the task the cgroup.
+    SYSTEMD_PIDS, result, cause = create_process_get_pid(
+                                                            config, SYSTEMD_CGNAME,
+                                                            os.path.join(SLICE, SCOPE)
+                                                        )
+    if result == consts.TEST_FAILED:
+        return result, cause
+
+    OTHER_PIDS, result, tmp_cause = create_process_get_pid(
+                                                                config, OTHER_CGNAME,
+                                                                ignore_systemd=True
+                                                          )
+    if result == consts.TEST_FAILED:
+        return result, cause
+
+    # SYSTEMD_CGNAME already has the pid of the task, that scope was created
+    # with and killing it will remove the scope, be careful and pick the newly
+    # spawned task
+    SYSTEMD_PIDS = SYSTEMD_PIDS.split('\n')[1]
+
+    # classify a task from the non-systemd scope cgroup (OTHER_CGNAME) to
+    # systemd scope cgroup (SYSTEMD_CGNAME).  Migration should fail due to
+    # the incorrect destination cgroup path that gets constructed, without
+    # the systemd slice/scope when ignore_systemd=True)
+    try:
+        Cgroup.classify(config, CONTROLLER, SYSTEMD_CGNAME, OTHER_PIDS, ignore_systemd=True)
+    except RunError as re:
+        err_str = 'Error changing group of pid {}: No such file or directory'.format(OTHER_PIDS)
+        if re.stderr != err_str:
+            raise re
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Changing group of pid {} erroneously succeeded'.format(OTHER_PIDS)
+
+    # classify a task from the systemd scope cgroup (SYSTEMD_CGNAME) to
+    # non-systemd scope cgroup (OTHER_CGNAME).  Migration should fail due
+    # to the incorrect destination cgroup path that gets constructed, with
+    # the systemd slice/scope when ignore_systemd=False)
+    try:
+        Cgroup.classify(config, CONTROLLER, OTHER_CGNAME, SYSTEMD_PIDS)
+    except RunError as re:
+        err_str = 'Error changing group of pid {}: No such file or directory'.format(SYSTEMD_PIDS)
+        if re.stderr != err_str:
+            raise re
+    else:
+        result = consts.TEST_FAILED
+        tmp_cause = 'Changing group of pid {} erroneously succeeded'.format(SYSTEMD_PIDS)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # classify the task from the non-systemd scope cgroup to systemd scope cgroup.
+    Cgroup.classify(config, CONTROLLER, SYSTEMD_CGNAME, OTHER_PIDS)
+
+    return result, cause
+
+
+def teardown(config):
+    global SYSTEMD_PIDS, OTHER_PIDS
+
+    terminate_process(config, SYSTEMD_PIDS)
+    terminate_process(config, OTHER_PIDS)
+
+    # We need a pause, so that cgroup.procs gets updated.
+    time.sleep(1)
+
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' not in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/067-sudo-systemd_cgexec-v1.py
+++ b/tests/ftests/067-sudo-systemd_cgexec-v1.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgexec functionality test - '-b' '-g' <controller> (cgroup v1)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from systemd import Systemd
+from run import Run, RunError
+import consts
+import ftests
+import time
+import sys
+import os
+
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = '067_cg_in_scope'
+OTHER_CGNAME = '067_cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test067.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '067cgconfig.conf')
+
+SYSTEMD_PIDS = ''
+OTHER_PIDS = ''
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, CONTROLLER, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/{}/'.format(SYSTEMD_CGNAME, CONTROLLER, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # create and check if the cgroup was created under the controller sub-tree
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def create_process_get_pid(config, CGNAME, SLICENAME='', ignore_systemd=False):
+    result = consts.TEST_PASSED
+    cause = None
+
+    config.process.create_process_in_cgroup(
+                                                config, CONTROLLER, CGNAME, cgclassify=False,
+                                                ignore_systemd=ignore_systemd
+                                            )
+
+    # We need pause, before the cgroups.procs gets updated, post cgexec
+    time.sleep(1)
+
+    pids = Cgroup.get_pids_in_cgroup(config, os.path.join(SLICENAME, CGNAME), CONTROLLER)
+    if pids is None:
+        result = consts.TEST_FAILED
+        cause = 'No processes were found in cgroup {}'.format(CGNAME)
+
+    return pids, result, cause
+
+
+def terminate_process(config, pids):
+    if pids:
+        for p in pids.splitlines():
+            Run.run(['sudo', 'kill', '-9', p])
+
+
+def test(config):
+    global SYSTEMD_PIDS, OTHER_PIDS
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    # Test cgclassify, that creates a process and then uses cgclassify
+    # to migrate the task the cgroup.
+    SYSTEMD_PIDS, result, cause = create_process_get_pid(
+                                                            config, SYSTEMD_CGNAME,
+                                                            os.path.join(SLICE, SCOPE)
+                                                        )
+
+    OTHER_PIDS, result, tmp_cause = create_process_get_pid(
+                                                                config, OTHER_CGNAME,
+                                                                ignore_systemd=True
+                                                          )
+    cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def teardown(config):
+    global SYSTEMD_PIDS, OTHER_PIDS
+
+    terminate_process(config, SYSTEMD_PIDS)
+    terminate_process(config, OTHER_PIDS)
+
+    # We need a pause, so that cgroup.procs gets updated.
+    time.sleep(1)
+
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' not in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/068-sudo-systemd_cgexec-v2.py
+++ b/tests/ftests/068-sudo-systemd_cgexec-v2.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgexec functionality test - '-b' '-g' <controller> (cgroup v2)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from run import Run, RunError
+from systemd import Systemd
+import consts
+import ftests
+import time
+import sys
+import os
+
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = '068_cg_in_scope'
+OTHER_CGNAME = '068_cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test068.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '068cgconfig.conf')
+
+SYSTEMD_PIDS = ''
+OTHER_PIDS = ''
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v2 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, None, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/'.format(SYSTEMD_CGNAME, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # With cgroup v2, we can't enable controller for the child cgroup, while
+    # a task is attached to test068.scope. Attach the task from test068.scope
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
+    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
+
+    Cgroup.set(
+                config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
+                value='+cpu', ignore_systemd=True
+              )
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
+
+    # create and check if the cgroup was created under the controller root
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def create_process_get_pid(config, CGNAME, SLICENAME='', ignore_systemd=False):
+    result = consts.TEST_PASSED
+    cause = None
+
+    config.process.create_process_in_cgroup(
+                                                config, CONTROLLER, CGNAME, cgclassify=False,
+                                                ignore_systemd=ignore_systemd
+                                            )
+
+    # We need pause, before the cgroups.procs gets updated, post cgexec
+    time.sleep(1)
+
+    pids = Cgroup.get_pids_in_cgroup(config, os.path.join(SLICENAME, CGNAME), CONTROLLER)
+    if pids is None:
+        result = consts.TEST_FAILED
+        cause = 'No processes were found in cgroup {}'.format(CGNAME)
+
+    return pids, result, cause
+
+
+def terminate_process(config, pids):
+    if pids:
+        for p in pids.splitlines():
+            Run.run(['kill', '-9', p])
+
+
+def test(config):
+    global SYSTEMD_PIDS, OTHER_PIDS
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    # Test cgclassify, that creates a process and then uses cgclassify
+    # to migrate the task the cgroup.
+    SYSTEMD_PIDS, result, cause = create_process_get_pid(
+                                                            config, SYSTEMD_CGNAME,
+                                                            os.path.join(SLICE, SCOPE)
+                                                        )
+
+    OTHER_PIDS, result, tmp_cause = create_process_get_pid(
+                                                                config, OTHER_CGNAME,
+                                                                ignore_systemd=True
+                                                          )
+    cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # SYSTEMD_CGNAME already has the pid of the task, that scope was created
+    # with and killing it will remove the scope, be careful and pick the newly
+    # spawned task
+    SYSTEMD_PIDS = SYSTEMD_PIDS.split('\n')[1]
+
+    return result, cause
+
+
+def teardown(config):
+    global SYSTEMD_PIDS, OTHER_PIDS
+
+    terminate_process(config, SYSTEMD_PIDS)
+    terminate_process(config, OTHER_PIDS)
+
+    # We need a pause, so that cgroup.procs gets updated.
+    time.sleep(1)
+
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' not in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
+++ b/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgxget/cgxset functionality test - '-b' '-g' <controller> (cgroup v1)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from systemd import Systemd
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = '069_cg_in_scope'
+OTHER_CGNAME = '069_cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test069.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '069cgconfig.conf')
+
+CGRP_VER_V1 = CgroupVersion.CGROUP_V1
+CGRP_VER_V2 = CgroupVersion.CGROUP_V2
+
+TABLE = [
+    # writesetting, writeval, writever, readsetting, readval, readver
+    ['cpu.shares', '512', CGRP_VER_V1, 'cpu.shares', '512', CGRP_VER_V1],
+    ['cpu.shares', '512', CGRP_VER_V1, 'cpu.weight', '50',  CGRP_VER_V2],
+
+    ['cpu.weight', '200', CGRP_VER_V2, 'cpu.shares', '2048', CGRP_VER_V1],
+    ['cpu.weight', '200', CGRP_VER_V2, 'cpu.weight', '200',  CGRP_VER_V2],
+
+    ['cpu.cfs_quota_us',  '10000',       CGRP_VER_V1,
+     'cpu.cfs_quota_us',  '10000',       CGRP_VER_V1],
+    ['cpu.cfs_period_us', '100000',      CGRP_VER_V1,
+     'cpu.cfs_period_us', '100000',      CGRP_VER_V1],
+    ['cpu.cfs_period_us', '50000',       CGRP_VER_V1,
+     'cpu.max',           '10000 50000', CGRP_VER_V2],
+
+    ['cpu.cfs_quota_us',  '-1',         CGRP_VER_V1,
+     'cpu.cfs_quota_us',  '-1',         CGRP_VER_V1],
+    ['cpu.cfs_period_us', '100000',     CGRP_VER_V1,
+     'cpu.max',           'max 100000', CGRP_VER_V2],
+
+    ['cpu.max',           '5000 25000', CGRP_VER_V2,
+     'cpu.max',           '5000 25000', CGRP_VER_V2],
+    ['cpu.max',           '6000 26000', CGRP_VER_V2,
+     'cpu.cfs_quota_us',  '6000',       CGRP_VER_V1],
+    ['cpu.max',           '7000 27000', CGRP_VER_V2,
+     'cpu.cfs_period_us', '27000',      CGRP_VER_V1],
+
+    ['cpu.max',          'max 40000', CGRP_VER_V2,
+     'cpu.max',          'max 40000', CGRP_VER_V2],
+    ['cpu.max',          'max 41000', CGRP_VER_V2,
+     'cpu.cfs_quota_us', '-1',        CGRP_VER_V1],
+]
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, CONTROLLER, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/{}/'.format(SYSTEMD_CGNAME, CONTROLLER, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # create and check if the cgroup was created under the controller sub-tree
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cgrps = {SYSTEMD_CGNAME: False, OTHER_CGNAME: True}
+    for i in cgrps:
+        for entry in TABLE:
+            Cgroup.xset(config, cgname=i, setting=entry[0], value=entry[1],
+                        version=entry[2], ignore_systemd=cgrps[i])
+
+            out = Cgroup.xget(config, cgname=i, setting=entry[3],
+                              version=entry[5], values_only=True,
+                              print_headers=False, ignore_systemd=cgrps[i])
+            if out != entry[4]:
+                result = consts.TEST_FAILED
+                tmp_cause = (
+                        'After setting {}={}, expected {}={}, but received '
+                        '{}={}'.format(entry[0], entry[1], entry[3], entry[4],
+                                       entry[3], out)
+                        )
+                cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def teardown(config):
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' not in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
+++ b/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgxget/cgxset functionality test - '-b' '-g' <controller> (cgroup v2)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion
+from systemd import Systemd
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+
+CONTROLLER = 'cpu'
+SYSTEMD_CGNAME = '070_cg_in_scope'
+OTHER_CGNAME = '070_cg_not_in_scope'
+
+SLICE = 'libcgtests.slice'
+SCOPE = 'test070.scope'
+
+CONFIG_FILE_NAME = os.path.join(os.getcwd(), '070cgconfig.conf')
+
+CGRP_VER_V1 = CgroupVersion.CGROUP_V1
+CGRP_VER_V2 = CgroupVersion.CGROUP_V2
+
+TABLE = [
+    # writesetting, writeval, writever, readsetting, readval, readver
+    ['cpu.shares', '512', CGRP_VER_V1, 'cpu.shares', '512', CGRP_VER_V1],
+    ['cpu.shares', '512', CGRP_VER_V1, 'cpu.weight', '50',  CGRP_VER_V2],
+
+    ['cpu.weight', '200', CGRP_VER_V2, 'cpu.shares', '2048', CGRP_VER_V1],
+    ['cpu.weight', '200', CGRP_VER_V2, 'cpu.weight', '200',  CGRP_VER_V2],
+
+    ['cpu.cfs_quota_us',  '10000',       CGRP_VER_V1,
+     'cpu.cfs_quota_us',  '10000',       CGRP_VER_V1],
+    ['cpu.cfs_period_us', '100000',      CGRP_VER_V1,
+     'cpu.cfs_period_us', '100000',      CGRP_VER_V1],
+    ['cpu.cfs_period_us', '50000',       CGRP_VER_V1,
+     'cpu.max',           '10000 50000', CGRP_VER_V2],
+
+    ['cpu.cfs_quota_us',  '-1',         CGRP_VER_V1,
+     'cpu.cfs_quota_us',  '-1',         CGRP_VER_V1],
+    ['cpu.cfs_period_us', '100000',     CGRP_VER_V1,
+     'cpu.max',           'max 100000', CGRP_VER_V2],
+
+    ['cpu.max',           '5000 25000', CGRP_VER_V2,
+     'cpu.max',           '5000 25000', CGRP_VER_V2],
+    ['cpu.max',           '6000 26000', CGRP_VER_V2,
+     'cpu.cfs_quota_us',  '6000',       CGRP_VER_V1],
+    ['cpu.max',           '7000 27000', CGRP_VER_V2,
+     'cpu.cfs_period_us', '27000',      CGRP_VER_V1],
+
+    ['cpu.max',          'max 40000', CGRP_VER_V2,
+     'cpu.max',          'max 40000', CGRP_VER_V2],
+    ['cpu.max',          'max 41000', CGRP_VER_V2,
+     'cpu.cfs_quota_us', '-1',        CGRP_VER_V1],
+]
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v2 cpu controller'
+        return result, cause
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
+
+
+def setup(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = Systemd.write_config_with_pid(config, CONFIG_FILE_NAME, SLICE, SCOPE)
+
+    Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
+
+    # create and check if the cgroup was created under the systemd default path
+    if not Cgroup.create_and_validate(config, None, SYSTEMD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create systemd delegated cgroup {} under '
+                    '/sys/fs/cgroup/{}/{}/'.format(SYSTEMD_CGNAME, SLICE, SCOPE)
+                )
+        return result, cause
+
+    # With cgroup v2, we can't enable controller for the child cgroup, while
+    # a task is attached to test070.scope. Attach the task from test070.scope
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
+    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
+
+    Cgroup.set(
+                config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
+                value='+cpu', ignore_systemd=True
+              )
+    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
+
+    # create and check if the cgroup was created under the controller root
+    if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
+        result = consts.TEST_FAILED
+        cause = (
+                    'Failed to create cgroup {} under '
+                    '/sys/fs/cgroup/{}/'.format(OTHER_CGNAME, CONTROLLER)
+                )
+
+    return result, cause
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cgrps = {SYSTEMD_CGNAME: False, OTHER_CGNAME: True}
+    for i in cgrps:
+        for entry in TABLE:
+            Cgroup.xset(config, cgname=i, setting=entry[0], value=entry[1],
+                        version=entry[2], ignore_systemd=cgrps[i])
+
+            out = Cgroup.xget(config, cgname=i, setting=entry[3],
+                              version=entry[5], values_only=True,
+                              print_headers=False, ignore_systemd=cgrps[i])
+            if out != entry[4]:
+                result = consts.TEST_FAILED
+                tmp_cause = (
+                        'After setting {}={}, expected {}={}, but received '
+                        '{}={}'.format(entry[0], entry[1], entry[3], entry[4],
+                                       entry[3], out)
+                        )
+                cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def teardown(config):
+    Systemd.remove_scope_slice_conf(config, SLICE, SCOPE, CONTROLLER, CONFIG_FILE_NAME)
+
+    # Incase the error occurs before the creation of OTHER_CGNAME,
+    # let's ignore the exception
+    try:
+        Cgroup.delete(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True)
+    except RunError as re:
+        if 'No such file or directory' not in re.stderr:
+            raise re
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    [result, cause] = setup(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -86,6 +86,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  063-sudo-systemd_cgset-v1.py \
 			  064-sudo-systemd_cgset-v2.py \
 			  065-sudo-systemd_cgclassify-v1.py \
+			  066-sudo-systemd_cgclassify-v2.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -82,6 +82,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  059-sudo-invalid_systemd_create_scope2.py \
 			  060-sudo-cgconfigparser-systemd.py \
 			  061-sudo-g_flag_controller_only_systemd-v1.py \
+			  062-sudo-g_flag_controller_only_systemd-v2.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -90,6 +90,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  067-sudo-systemd_cgexec-v1.py \
 			  068-sudo-systemd_cgexec-v2.py \
 			  069-sudo-systemd_cgxget-cpu-settings-v1.py \
+			  070-sudo-systemd_cgxget-cpu-settings-v2.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -85,6 +85,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  062-sudo-g_flag_controller_only_systemd-v2.py \
 			  063-sudo-systemd_cgset-v1.py \
 			  064-sudo-systemd_cgset-v2.py \
+			  065-sudo-systemd_cgclassify-v1.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -88,6 +88,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  065-sudo-systemd_cgclassify-v1.py \
 			  066-sudo-systemd_cgclassify-v2.py \
 			  067-sudo-systemd_cgexec-v1.py \
+			  068-sudo-systemd_cgexec-v2.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -89,6 +89,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  066-sudo-systemd_cgclassify-v2.py \
 			  067-sudo-systemd_cgexec-v1.py \
 			  068-sudo-systemd_cgexec-v2.py \
+			  069-sudo-systemd_cgxget-cpu-settings-v1.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -87,6 +87,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  064-sudo-systemd_cgset-v2.py \
 			  065-sudo-systemd_cgclassify-v1.py \
 			  066-sudo-systemd_cgclassify-v2.py \
+			  067-sudo-systemd_cgexec-v1.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -80,6 +80,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  057-sudo-set_permissions_v1.py \
 			  058-sudo-systemd_create_scope2.py \
 			  059-sudo-invalid_systemd_create_scope2.py \
+			  060-sudo-cgconfigparser-systemd.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -84,6 +84,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  061-sudo-g_flag_controller_only_systemd-v1.py \
 			  062-sudo-g_flag_controller_only_systemd-v2.py \
 			  063-sudo-systemd_cgset-v1.py \
+			  064-sudo-systemd_cgset-v2.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -83,6 +83,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  060-sudo-cgconfigparser-systemd.py \
 			  061-sudo-g_flag_controller_only_systemd-v1.py \
 			  062-sudo-g_flag_controller_only_systemd-v2.py \
+			  063-sudo-systemd_cgset-v1.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -81,6 +81,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  058-sudo-systemd_create_scope2.py \
 			  059-sudo-invalid_systemd_create_scope2.py \
 			  060-sudo-cgconfigparser-systemd.py \
+			  061-sudo-g_flag_controller_only_systemd-v1.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/systemd.py
+++ b/tests/ftests/systemd.py
@@ -7,6 +7,8 @@
 #
 
 from run import Run, RunError
+from cgroup import Cgroup
+import os
 
 
 class Systemd(object):
@@ -27,3 +29,48 @@ class Systemd(object):
                 # until we figure out something better :(
                 return True
             raise re
+
+    # This function creates a task and writes its pid into systemd
+    # configuration file, that gets passed to the cgconfigparser tool to
+    # create systemd slice/scope.
+    @staticmethod
+    def write_config_with_pid(config, config_fname, _slice, scope, setdefault="yes"):
+        pid = config.process.create_process(config)
+        config_file = '''systemd {{
+            slice = {};
+            scope = {};
+            setdefault = {};
+            pid = {};
+        }}'''.format(_slice, scope, setdefault, pid)
+
+        f = open(config_fname, 'w')
+        f.write(config_file)
+        f.close()
+
+        return pid
+
+    # Stopping the systemd scope, will kill the default task in the scope
+    # and remove scope cgroup but will not remove the slice, that needs to
+    # removed manually.
+    @staticmethod
+    def remove_scope_slice_conf(config, _slice, scope, controller, config_fname=None):
+        if config_fname:
+            os.remove(config_fname)
+
+        try:
+            if config.args.container:
+                config.container.run(['systemctl', 'stop', '{}'.format(scope)],
+                                     shell_bool=True)
+            else:
+                Run.run(['sudo', 'systemctl', 'stop', '{}'.format(scope)], shell_bool=True)
+        except RunError as re:
+            if 'scope not loaded' in re.stderr:
+                raise re
+
+        # In case the error occurs before the creation of slice/scope and
+        # we may very well be on the teardown path, ignore the exception
+        try:
+            Cgroup.delete(config, controller, cgname=_slice, ignore_systemd=True)
+        except RunError as re:
+            if 'No such file or directory' not in re.stderr:
+                raise re


### PR DESCRIPTION
This patch series introduces systemd configurations to `cgconfig.conf`
and support to parse them. This will help the users to create `systemd slice/scope`
when system boots, and also allow them to set the resource allocations to the created
`slice/scope`.  A sample configuration would look like this:
```
systemd {
        slice = testing;
        scope = testing;
}

systemd {
        slice = testing;
        scope = testing1;
        setdefault = yes;
}

group testing.slice {
        cpu {
               cpu.weight = 10;
        }
}
```
and it also adds support to the tools to consider the default slice as the cgroup root
for all operations performed by the tool, instead of the controller mount point.  This
will help users on working on the default `slice/scope` hierarchy they created as the
new cgroup root .  The user can also ignore the default hierarchy setting by using the
new switch `-b` added to all of the tools.