### PR TITLE
workflows/ci: rename package lxd to lxd-installer

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Install container dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install lxc lxd
+        sudo apt-get install lxc lxd-installer
     - uses: actions/checkout@v2
       with:
         submodules: false
@@ -149,7 +149,7 @@ jobs:
     - name: Install container dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install lxc lxd
+        sudo apt-get install lxc lxd-installer
     - uses: actions/checkout@v2
       with:
         submodules: false
@@ -206,7 +206,7 @@ jobs:
     - name: Install container dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install lxc lxd
+        sudo apt-get install lxc lxd-installer
     - uses: actions/checkout@v2
       with:
         submodules: false


### PR DESCRIPTION
On ubuntu-latest (22.04) the `lxd` package has been renamed to `lxd-installer`,
rename it in our ` .yml`.