### PR TITLE
workflows/ci: use ubuntu 20.04 for cgroup v1 functional test [v2.0]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,7 +69,7 @@ jobs:
 
   functionaltestsv1:
     name: Cgroup v1 Functional Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Install container dependencies


### PR DESCRIPTION
Using ubuntu-latest (Ubuntu 22.04) for the cgroup v1 functional test fails, due to two reasons:
- The lxd package has been renamed to lxd-installer
- Ubuntu-latest (22.04) supports only cgroup v2 hierarchy and for branch-2.0 pass the test cases, requires forward porting a couple of patches from 3.0 branch. Let's run it on the known stable release Ubuntu-20.04 instead.