### PR TITLE
Trival: Fix warning in strncmp

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -918,7 +918,7 @@ static int config_order_namespace_table(void)
 
 		for (j = 0; cg_mount_table[j].name[0] != '\0'; j++) {
 			if (strncmp(config_namespace_table[i].name, cg_mount_table[j].name,
-				    FILENAME_MAX) == 0) {
+				    CONTROL_NAMELEN_MAX) == 0) {
 
 				flag = 1;
 


### PR DESCRIPTION
The name field of the structure is of a much smaller size CONTROL_NAMELEN_MAX and not FILENAME_MAX. Listen to the compiler and fix the issue.

Signed-off-by: Balbir singh <bsingharora@gmail.com>