### PR TITLE
[RFC] cgroup v2 - Enable controllers at the leaf/child cgroup by default

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -2706,6 +2706,12 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 		goto err;
 
 	if (controller) {
+		if (version == CGROUP_V2) {
+			error = cgroupv2_subtree_control(base, controller->name, true);
+			if (error)
+				goto err;
+		}
+
 		error = cgroup_set_values_recursive(base, controller, false);
 		if (error)
 			goto err;

--- a/src/api.c
+++ b/src/api.c
@@ -1850,7 +1850,6 @@ error:
 STATIC int cgroupv2_controller_enabled(const char * const cg_name, const char * const ctrl_name)
 {
 	char path[FILENAME_MAX] = {0};
-	char *parent = NULL, *dname;
 	enum cg_version_t version;
 	bool enabled;
 	int error;
@@ -1876,24 +1875,13 @@ STATIC int cgroupv2_controller_enabled(const char * const cg_name, const char * 
 	if (!cg_build_path(cg_name, path, ctrl_name))
 		goto err;
 
-	parent = strdup(path);
-	if (!parent) {
-		error = ECGOTHER;
-		goto err;
-	}
-
-	dname = dirname(parent);
-
-	error = cgroupv2_get_subtree_control(dname, ctrl_name, &enabled);
+	error = cgroupv2_get_subtree_control(path, ctrl_name, &enabled);
 	if (error)
 		goto err;
 
 	if (enabled)
 		error = 0;
 err:
-	if (parent)
-		free(parent);
-
 	return error;
 }
 

--- a/tests/gunit/012-cgroup_create_cgroup.cpp
+++ b/tests/gunit/012-cgroup_create_cgroup.cpp
@@ -40,6 +40,22 @@ static const int VERSIONS_CNT =
 class CgroupCreateCgroupTest : public ::testing::Test {
 	protected:
 
+	void MountCgroupV2()
+	{
+		char *mnt_dir = strdup(PARENT_DIR);
+		struct mntent ent = (struct mntent) {
+			.mnt_fsname = "cgroup2",
+			.mnt_dir = mnt_dir,
+			.mnt_type = "cgroup2",
+			.mnt_opts = "rw,relatime,seclabel",
+		};
+		int mnt_tbl_idx = 0;
+		int ret;
+
+		ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
+		ASSERT_EQ(mnt_tbl_idx, 0);
+	}
+
 	void SetUp() override
 	{
 		char tmp_path[FILENAME_MAX];
@@ -90,6 +106,7 @@ class CgroupCreateCgroupTest : public ::testing::Test {
 				ASSERT_TRUE(false);
 			}
 		}
+		MountCgroupV2();
 	}
 
 	/*
@@ -115,6 +132,32 @@ class CgroupCreateCgroupTest : public ::testing::Test {
 	}
 };
 
+static void create_subtree_contents(const char * const cg_name,
+				    const char * const ctrl)
+{
+	char tmp_path[FILENAME_MAX];
+	FILE *f;
+	int ret;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1,
+		       "%s/%s/cgroup.subtree_control",
+		       PARENT_DIR, cg_name);
+	ASSERT_GT(ret, 0);
+
+	f = fopen(tmp_path, "w");
+	ASSERT_NE(f, nullptr);
+	fclose(f);
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s",
+		       PARENT_DIR, cg_name);
+	ASSERT_GT(ret, 0);
+
+	ret = cgroupv2_subtree_control(tmp_path, ctrl, true);
+	ASSERT_EQ(ret, 0);
+}
+
 static void verify_cgroup_created(const char * const cg_name,
 				  const char * const ctrl)
 {
@@ -135,14 +178,15 @@ static void verify_cgroup_created(const char * const cg_name,
 	closedir(dir);
 }
 
-static void verify_subtree_contents(const char * const expected)
+static void verify_subtree_contents(const char * const cg_name,
+				    const char * const expected)
 {
 	char tmp_path[FILENAME_MAX], buf[4092];
 	FILE *f;
 
 	memset(tmp_path, 0, sizeof(tmp_path));
-	snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.subtree_control",
-		 PARENT_DIR);
+	snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/cgroup.subtree_control",
+		 PARENT_DIR, cg_name);
 	f = fopen(tmp_path, "r");
 	ASSERT_NE(f, nullptr);
 
@@ -182,14 +226,13 @@ TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV2)
 	cg = cgroup_new_cgroup(cg_name);
 	ASSERT_NE(cg, nullptr);
 
-	ctrl = cgroup_add_controller(cg, ctrl_name);
-	ASSERT_NE(ctrl, nullptr);
-
 	ret = cgroup_create_cgroup(cg, 0);
 	ASSERT_EQ(ret, 0);
 
+	create_subtree_contents(cg_name, ctrl_name);
+
 	verify_cgroup_created(cg_name, NULL);
-	verify_subtree_contents("+freezer");
+	verify_subtree_contents(cg_name, "+freezer");
 }
 
 TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1AndV2)
@@ -204,16 +247,22 @@ TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1AndV2)
 	cg = cgroup_new_cgroup(cg_name);
 	ASSERT_NE(cg, nullptr);
 
-	ctrl = cgroup_add_controller(cg, ctrl1_name);
-	ASSERT_NE(ctrl, nullptr);
-	ctrl = NULL;
 	ctrl = cgroup_add_controller(cg, ctrl2_name);
 	ASSERT_NE(ctrl, nullptr);
 
 	ret = cgroup_create_cgroup(cg, 1);
 	ASSERT_EQ(ret, 0);
 
+	cg = NULL;
+	cg = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cg, nullptr);
+
+	ret = cgroup_create_cgroup(cg, 1);
+	ASSERT_EQ(ret, 0);
+
+	create_subtree_contents(cg_name, ctrl1_name);
+
 	verify_cgroup_created(cg_name, NULL);
 	verify_cgroup_created(cg_name, ctrl2_name);
-	verify_subtree_contents("+memory");
+	verify_subtree_contents(cg_name, "+memory");
 }

--- a/tests/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/tests/gunit/015-cgroupv2_controller_enabled.cpp
@@ -54,6 +54,7 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 	void InitChildDir(const char dirname[])
 	{
 		char tmp_path[FILENAME_MAX] = {0};
+		FILE *f;
 		int ret;
 
 		/* create the directory */
@@ -61,6 +62,14 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 			 PARENT_DIR, dirname);
 		ret = mkdir(tmp_path, MODE);
 		ASSERT_EQ(ret, 0);
+
+		snprintf(tmp_path, FILENAME_MAX - 1,
+			 "%s/%s/cgroup.subtree_control", PARENT_DIR, dirname);
+
+		f = fopen(tmp_path, "w");
+		ASSERT_NE(f, nullptr);
+		fprintf(f, "cpu io memory pids\n");
+		fclose(f);
 	}
 
 	void InitMountTable(void)


### PR DESCRIPTION
With cgroup v2, while creating a cgroup with a controller, the whole
hierarchy tree is walked, and the controller is enabled up to the parent
cgroup of the leaf node, this guarantees that the attached controller is
available in the leaf cgroups cgroup.controllers file, but this is
incomplete because the controller is not enabled in the leaf cgroup.
    
We do not have a separate API that is called to enable the controllers
but as a workaround, one can always call the `cgroup_set_values_recursive()`
to enable the controller in the leaf node.  To maintain the idea/compatibility
with the cgroup v1, where creating a cgroup on the controller mount point
or hierarchy is equivalent to enabling the controller in the cgroup v2, let's
enable the controller in the leaf node too.

This patch series can be divided into the api changes and gunit test changes.
Where the first two patches changes the api `_cgroup_create_cgroup()` and
`cgroupv2_controller_enabled()` respectively and patches 3,4 modifies the
unit testcases to match the changes to the APIs.
