### PR TITLE
tools/cgxset: fix help/usage formatting

### DIFF
--- a/src/tools/cgxset.c
+++ b/src/tools/cgxset.c
@@ -75,12 +75,12 @@ static void usage(int status, const char *program_name)
 	info("Usage: %s [-r <name=value>] <cgroup_path> ...\n", program_name);
 	info("   or: %s --copy-from <source_cgroup_path> <cgroup_path> ...\n", program_name);
 	info("Set the parameters of given cgroup(s)\n");
-	info("  -1, --v1                      Provided parameters are in v1 format\n");
-	info("  -2, --v2                      Provided parameters are in v2 format\n");
-	info("  -i, --ignore-unmappable       Do not return an error for ");
+	info("  -1, --v1                                Provided parameters are in v1 format\n");
+	info("  -2, --v2                                Provided parameters are in v2 format\n");
+	info("  -i, --ignore-unmappable                 Do not return an error for ");
 	info("settings that cannot be converted\n");
-	info("  -r, --variable <name>			Define parameter to set\n");
-	info("  --copy-from <source_cgroup_path>	Control group whose ");
+	info("  -r, --variable <name>                   Define parameter to set\n");
+	info("  --copy-from <source_cgroup_path>        Control group whose ");
 	info("parameters will be copied\n");
 }
 #endif /* !UNIT_TEST */


### PR DESCRIPTION
The help/usage output is misaligned, which is a mix of tabs and spaces.
Fix it by using only spaces for the alignment, so that we have a visual
representation of output in the code too, instead of having unaligned
info()'s needing to calculate the tabs stops always.

```
Before:
-------
Usage: cgxset [-r <name=value>] <cgroup_path> ...
   or: cgxset --copy-from <source_cgroup_path> <cgroup_path> ...
Set the parameters of given cgroup(s)
  -1, --v1                      Provided parameters are in v1 format
  -2, --v2                      Provided parameters are in v2 format
  -i, --ignore-unmappable       Do not return an error for settings that cannot be converted
  -r, --variable <name>                 Define parameter to set
  --copy-from <source_cgroup_path>      Control group whose parameters will be copied
```
```
After:
------
Usage: cgxset [-r <name=value>] <cgroup_path> ...
   or: cgxset --copy-from <source_cgroup_path> <cgroup_path> ...
Set the parameters of given cgroup(s)
  -1, --v1                                Provided parameters are in v1 format
  -2, --v2                                Provided parameters are in v2 format
  -i, --ignore-unmappable                 Do not return an error for settings that cannot be converted
  -r, --variable <name>                   Define parameter to set
  --copy-from <source_cgroup_path>        Control group whose parameters will be copied
```
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>