### PR TITLE
[BUG] Fix cgroup_get_cgroup() on cgroup v2 systems

### DIFF
--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -651,6 +651,31 @@ int cgroup_get_controller_version(const char * const controller,
 enum cg_setup_mode_t cgroup_setup_mode(void);
 
 /**
+ * Return the number of controllers for the specified cgroup in libcgroup
+ * internal structures.
+ *
+ * @param cgroup
+ * @return Count of the controllers or -1 on error.
+ */
+int cgroup_get_controller_count(struct cgroup *cgroup);
+
+/**
+ * Return requested controller from given group
+ *
+ * @param cgroup
+ * @param index The index into the cgroup controller list
+ */
+struct cgroup_controller *cgroup_get_controller_by_index(struct cgroup *cgroup, int index);
+
+/**
+ * Given a controller pointer, get the name of the controller
+ *
+ * @param controller
+ * @return controller name string, NULL if there's an error
+ */
+char *cgroup_get_controller_name(struct cgroup_controller *controller);
+
+/**
  * @}
  * @}
  */

--- a/src/api.c
+++ b/src/api.c
@@ -2706,6 +2706,12 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 		goto err;
 
 	if (controller) {
+		if (version == CGROUP_V2) {
+			error = cgroupv2_subtree_control(base, controller->name, true);
+			if (error)
+				goto err;
+		}
+
 		error = cgroup_set_values_recursive(base, controller, false);
 		if (error)
 			goto err;

--- a/src/api.c
+++ b/src/api.c
@@ -6177,3 +6177,30 @@ out:
 	pthread_rwlock_unlock(&cg_mount_table_lock);
 	return setup_mode;
 }
+
+int cgroup_get_controller_count(struct cgroup *cgroup)
+{
+	if (!cgroup)
+		return -1;
+
+	return cgroup->index;
+}
+
+struct cgroup_controller *cgroup_get_controller_by_index(struct cgroup *cgroup, int index)
+{
+	if (!cgroup)
+		return NULL;
+
+	if (index >= cgroup->index)
+		return NULL;
+
+	return cgroup->controller[index];
+}
+
+char *cgroup_get_controller_name(struct cgroup_controller *controller)
+{
+	if (!controller)
+		return NULL;
+
+	return controller->name;
+}

--- a/src/api.c
+++ b/src/api.c
@@ -1850,7 +1850,6 @@ error:
 STATIC int cgroupv2_controller_enabled(const char * const cg_name, const char * const ctrl_name)
 {
 	char path[FILENAME_MAX] = {0};
-	char *parent = NULL, *dname;
 	enum cg_version_t version;
 	bool enabled;
 	int error;
@@ -1876,24 +1875,13 @@ STATIC int cgroupv2_controller_enabled(const char * const cg_name, const char * 
 	if (!cg_build_path(cg_name, path, ctrl_name))
 		goto err;
 
-	parent = strdup(path);
-	if (!parent) {
-		error = ECGOTHER;
-		goto err;
-	}
-
-	dname = dirname(parent);
-
-	error = cgroupv2_get_subtree_control(dname, ctrl_name, &enabled);
+	error = cgroupv2_get_subtree_control(path, ctrl_name, &enabled);
 	if (error)
 		goto err;
 
 	if (enabled)
 		error = 0;
 err:
-	if (parent)
-		free(parent);
-
 	return error;
 }
 

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -151,4 +151,7 @@ CGROUP_3.0 {
 	cgroup_setup_mode;
 	cgroup_create_scope;
 	cgroup_set_default_scope_opts;
+	cgroup_get_controller_count;
+	cgroup_get_controller_by_index;
+	cgroup_get_controller_name;
 } CGROUP_2.0;

--- a/src/python/cgroup.pxd
+++ b/src/python/cgroup.pxd
@@ -79,4 +79,14 @@ cdef extern from "libcgroup.h":
     int cgroup_create_scope(const char * const scope_name, const char * const slice_name,
                             const cgroup_systemd_scope_opts * const opts)
 
+    int cgroup_get_cgroup(cgroup *cg)
+
+    int cgroup_delete_cgroup(cgroup *cg, int ignore_migration)
+
+    int cgroup_get_controller_count(cgroup *cgroup)
+
+    cgroup_controller *cgroup_get_controller_by_index(cgroup *cgroup, int index)
+
+    char *cgroup_get_controller_name(cgroup_controller *controller)
+
 # vim: set et ts=4 sw=4:

--- a/src/python/cgroup.pxd
+++ b/src/python/cgroup.pxd
@@ -89,4 +89,7 @@ cdef extern from "libcgroup.h":
 
     char *cgroup_get_controller_name(cgroup_controller *controller)
 
+    int cgroup_attach_task(cgroup * cgroup)
+    int cgroup_attach_task_pid(cgroup * cgroup, pid_t pid)
+
 # vim: set et ts=4 sw=4:

--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -472,13 +472,22 @@ static int display_controller_data(char controller[CG_CONTROLLER_MAX][FILENAME_M
 
 			ret = cgroup_get_cgroup(group);
 			if (ret != 0) {
-				info("cannot read group '%s': %s\n", cgroup_name,
-				     cgroup_strerror(ret));
-				goto err;
+				/*
+				 * We know for sure that the cgroup exists
+				 * but just that the cgroup v2 controller
+				 * is not enabled in the cgroup.subtree_control
+				 * file.
+				 */
+				if (ret != ECGROUPNOTEXIST) {
+					info("cannot read group '%s': %s %d\n", cgroup_name,
+					     cgroup_strerror(ret), ret);
+					goto err;
+				}
 			}
 
-			display_cgroup_data(group, controller, info.full_path, prefix_len, first,
-					    program_name);
+			if (ret == 0)
+				display_cgroup_data(group, controller, info.full_path, prefix_len,
+						    first, program_name);
 			first = 0;
 			cgroup_free(&group);
 		}
@@ -495,20 +504,34 @@ err:
 static int is_ctlr_on_list(char controllers[CG_CONTROLLER_MAX][FILENAME_MAX],
 			   cont_name_t wanted_conts[CG_CONTROLLER_MAX])
 {
-	int i = 0;
-	int j = 0;
+	char tmp_controllers[CG_CONTROLLER_MAX][FILENAME_MAX];
+	int i = 0, j = 0, k = 0;
+	int ret = 0;
 
 	while (controllers[i][0] != '\0') {
 		while (wanted_conts[j][0] != '\0') {
-			if (strcmp(controllers[i], wanted_conts[j]) == 0)
-				return 1;
+			if (strcmp(controllers[i], wanted_conts[j]) == 0) {
+				strncpy(tmp_controllers[k], wanted_conts[j], FILENAME_MAX - 1);
+				(tmp_controllers[k])[FILENAME_MAX - 1] = '\0';
+				k++;
+			}
 			j++;
 		}
 		j = 0;
 		i++;
 	}
 
-	return 0;
+	(tmp_controllers[k])[0] = '\0';
+
+	/* Lets reset the controllers to intersection of controller ∩ wanted_conts */
+	for (i = 0; tmp_controllers[i][0] != '\0'; i++) {
+		strncpy(controllers[i], tmp_controllers[i], FILENAME_MAX - 1);
+		(controllers[i])[FILENAME_MAX - 1] = '\0';
+		ret = 1;
+	}
+	(controllers[i])[0] = '\0';
+
+	return ret;
 }
 
 

--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -236,12 +236,14 @@ static int display_permissions(const char *path, const char * const cg_name,
 		pw = getpwuid(sba.st_uid);
 		if (pw == NULL) {
 			err("ERROR: can't get %d user name\n", sba.st_uid);
+			fprintf(output_f, "}\n}\n");
 			return -1;
 		}
 
 		gr = getgrgid(sba.st_gid);
 		if (gr == NULL) {
 			err("ERROR: can't get %d group name\n", sba.st_gid);
+			fprintf(output_f, "}\n}\n");
 			return -1;
 		}
 
@@ -255,12 +257,14 @@ static int display_permissions(const char *path, const char * const cg_name,
 		pw = getpwuid(sbt.st_uid);
 		if (pw == NULL) {
 			err("ERROR: can't get %d user name\n", sbt.st_uid);
+			fprintf(output_f, "}\n}\n");
 			return -1;
 		}
 
 		gr = getgrgid(sbt.st_gid);
 		if (gr == NULL) {
 			err("ERROR: can't get %d group name\n", sbt.st_gid);
+			fprintf(output_f, "}\n}\n");
 			return -1;
 		}
 

--- a/tests/ftests/051-sudo-cgroup_get_cgroup.py
+++ b/tests/ftests/051-sudo-cgroup_get_cgroup.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Exercise cgroup_create_cgroup() and cgroup_get_cgroup()
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from libcgroup import Cgroup, Version
+from cgroup import CgroupVersion
+import ftests
+import consts
+import sys
+import os
+
+CGNAME = '051cgnewcg'
+
+# Which controller isn't all that important, but it is important that we
+# have a cgroup v2 controller
+CONTROLLER = 'cpu'
+
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v2'
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg.add_controller(CONTROLLER)
+    cg.create()
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg.get()
+
+    if len(cg.controllers) != 1:
+        # only one controller, cpu, should be enabled
+        result = consts.TEST_FAILED
+        cause = 'Expected one controller to be enabled, but {} were enabled'.format(
+                len(cg.controllers))
+
+    return result, cause
+
+
+def teardown(config, result):
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    try:
+        cg.delete()
+    except RuntimeError:
+        pass
+
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        result = consts.TEST_FAILED
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config, result)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/052-sudo-cgroup_attach_task.py
+++ b/tests/ftests/052-sudo-cgroup_attach_task.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Attach a task to a cgroup via cgroup_attach_task()
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli
+from libcgroup import Cgroup, Version
+from cgroup import CgroupVersion
+import ftests
+import consts
+import sys
+import os
+
+CGNAME = '052cgattachcg'
+
+# Which controller isn't all that important, but it is important that we
+# have a cgroup v2 controller
+CONTROLLER = 'cpu'
+
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v2'
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg.add_controller(CONTROLLER)
+    cg.create()
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg.get()
+    cg.attach()
+
+    found = False
+    pids = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
+    for pid in pids.splitlines():
+        if int(pid) == os.getpid():
+            # our process was successfully added to the cgroup
+            found = True
+
+    if not found:
+        result = consts.TEST_FAILED
+        cause = 'Could not find pid {} in cgroup {}'.format(os.getpid(), CGNAME)
+        return result, cause
+
+    # now let's attach this process to the root cgroup and ensure we no longer
+    # are in CGNAME
+    cg.attach(root_cgroup=True)
+
+    found = False
+    pids = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
+    for pid in pids.splitlines():
+        if int(pid) == os.getpid():
+            # our process was successfully added to the cgroup
+            found = True
+
+    if found:
+        result = consts.TEST_FAILED
+        cause = 'pid {} was erroneously found in cgroup {}'.format(os.getpid(), CGNAME)
+
+    return result, cause
+
+
+def teardown(config, result):
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    try:
+        cg.delete()
+    except RuntimeError:
+        pass
+
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        result = consts.TEST_FAILED
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config, result)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/053-sudo-cgroup_attach_task_pid.py
+++ b/tests/ftests/053-sudo-cgroup_attach_task_pid.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Attach a task to a cgroup via cgroup_attach_task_pid()
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli
+from libcgroup import Cgroup, Version
+from cgroup import CgroupVersion
+import ftests
+import consts
+import sys
+import os
+
+CGNAME = '052cgattachcg'
+
+# Which controller isn't all that important, but it is important that we
+# have a cgroup v2 controller
+CONTROLLER = 'cpu'
+
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v2'
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg.add_controller(CONTROLLER)
+    cg.create()
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    child_pid = config.process.create_process(config)
+
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg.get()
+    cg.attach(int(child_pid))
+
+    found = False
+    pids = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
+    for pid in pids.splitlines():
+        if pid == child_pid:
+            # our process was successfully added to the cgroup
+            found = True
+
+    if not found:
+        result = consts.TEST_FAILED
+        cause = 'Could not find pid {} in cgroup {}'.format(child_pid, CGNAME)
+        return result, cause
+
+    # now let's attach the child process to the root cgroup and ensure we no longer
+    # are in CGNAME
+    cg.attach(pid=int(child_pid), root_cgroup=True)
+
+    found = False
+    pids = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
+    for pid in pids.splitlines():
+        if pid == child_pid:
+            # our process was successfully added to the cgroup
+            found = True
+
+    if found:
+        result = consts.TEST_FAILED
+        cause = 'pid {} was erroneously found in cgroup {}'.format(child_pid, CGNAME)
+
+    return result, cause
+
+
+def teardown(config, result):
+    cg = Cgroup(CGNAME, Version.CGROUP_V2)
+    try:
+        cg.delete()
+    except RuntimeError:
+        pass
+
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        result = consts.TEST_FAILED
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config, result)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -70,7 +70,8 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  047-cgcreate-delete_cgrp_shared_mnt.py \
 			  048-pybindings-get_cgroup_mode.py \
 			  049-sudo-systemd_create_scope.py \
-			  050-sudo-systemd_create_scope2.py
+			  050-sudo-systemd_create_scope2.py \
+			  051-sudo-cgroup_get_cgroup.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py
 

--- a/tests/gunit/012-cgroup_create_cgroup.cpp
+++ b/tests/gunit/012-cgroup_create_cgroup.cpp
@@ -40,6 +40,22 @@ static const int VERSIONS_CNT =
 class CgroupCreateCgroupTest : public ::testing::Test {
 	protected:
 
+	void MountCgroupV2()
+	{
+		char *mnt_dir = strdup(PARENT_DIR);
+		struct mntent ent = (struct mntent) {
+			.mnt_fsname = "cgroup2",
+			.mnt_dir = mnt_dir,
+			.mnt_type = "cgroup2",
+			.mnt_opts = "rw,relatime,seclabel",
+		};
+		int mnt_tbl_idx = 0;
+		int ret;
+
+		ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
+		ASSERT_EQ(mnt_tbl_idx, 0);
+	}
+
 	void SetUp() override
 	{
 		char tmp_path[FILENAME_MAX];
@@ -90,6 +106,7 @@ class CgroupCreateCgroupTest : public ::testing::Test {
 				ASSERT_TRUE(false);
 			}
 		}
+		MountCgroupV2();
 	}
 
 	/*
@@ -115,6 +132,32 @@ class CgroupCreateCgroupTest : public ::testing::Test {
 	}
 };
 
+static void create_subtree_contents(const char * const cg_name,
+				    const char * const ctrl)
+{
+	char tmp_path[FILENAME_MAX];
+	FILE *f;
+	int ret;
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1,
+		       "%s/%s/cgroup.subtree_control",
+		       PARENT_DIR, cg_name);
+	ASSERT_GT(ret, 0);
+
+	f = fopen(tmp_path, "w");
+	ASSERT_NE(f, nullptr);
+	fclose(f);
+
+	memset(tmp_path, 0, sizeof(tmp_path));
+	ret = snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s",
+		       PARENT_DIR, cg_name);
+	ASSERT_GT(ret, 0);
+
+	ret = cgroupv2_subtree_control(tmp_path, ctrl, true);
+	ASSERT_EQ(ret, 0);
+}
+
 static void verify_cgroup_created(const char * const cg_name,
 				  const char * const ctrl)
 {
@@ -135,14 +178,15 @@ static void verify_cgroup_created(const char * const cg_name,
 	closedir(dir);
 }
 
-static void verify_subtree_contents(const char * const expected)
+static void verify_subtree_contents(const char * const cg_name,
+				    const char * const expected)
 {
 	char tmp_path[FILENAME_MAX], buf[4092];
 	FILE *f;
 
 	memset(tmp_path, 0, sizeof(tmp_path));
-	snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.subtree_control",
-		 PARENT_DIR);
+	snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/cgroup.subtree_control",
+		 PARENT_DIR, cg_name);
 	f = fopen(tmp_path, "r");
 	ASSERT_NE(f, nullptr);
 
@@ -182,14 +226,13 @@ TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV2)
 	cg = cgroup_new_cgroup(cg_name);
 	ASSERT_NE(cg, nullptr);
 
-	ctrl = cgroup_add_controller(cg, ctrl_name);
-	ASSERT_NE(ctrl, nullptr);
-
 	ret = cgroup_create_cgroup(cg, 0);
 	ASSERT_EQ(ret, 0);
 
+	create_subtree_contents(cg_name, ctrl_name);
+
 	verify_cgroup_created(cg_name, NULL);
-	verify_subtree_contents("+freezer");
+	verify_subtree_contents(cg_name, "+freezer");
 }
 
 TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1AndV2)
@@ -204,16 +247,22 @@ TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1AndV2)
 	cg = cgroup_new_cgroup(cg_name);
 	ASSERT_NE(cg, nullptr);
 
-	ctrl = cgroup_add_controller(cg, ctrl1_name);
-	ASSERT_NE(ctrl, nullptr);
-	ctrl = NULL;
 	ctrl = cgroup_add_controller(cg, ctrl2_name);
 	ASSERT_NE(ctrl, nullptr);
 
 	ret = cgroup_create_cgroup(cg, 1);
 	ASSERT_EQ(ret, 0);
 
+	cg = NULL;
+	cg = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cg, nullptr);
+
+	ret = cgroup_create_cgroup(cg, 1);
+	ASSERT_EQ(ret, 0);
+
+	create_subtree_contents(cg_name, ctrl1_name);
+
 	verify_cgroup_created(cg_name, NULL);
 	verify_cgroup_created(cg_name, ctrl2_name);
-	verify_subtree_contents("+memory");
+	verify_subtree_contents(cg_name, "+memory");
 }

--- a/tests/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/tests/gunit/015-cgroupv2_controller_enabled.cpp
@@ -54,6 +54,7 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 	void InitChildDir(const char dirname[])
 	{
 		char tmp_path[FILENAME_MAX] = {0};
+		FILE *f;
 		int ret;
 
 		/* create the directory */
@@ -61,6 +62,14 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 			 PARENT_DIR, dirname);
 		ret = mkdir(tmp_path, MODE);
 		ASSERT_EQ(ret, 0);
+
+		snprintf(tmp_path, FILENAME_MAX - 1,
+			 "%s/%s/cgroup.subtree_control", PARENT_DIR, dirname);
+
+		f = fopen(tmp_path, "w");
+		ASSERT_NE(f, nullptr);
+		fprintf(f, "cpu io memory pids\n");
+		fclose(f);
 	}
 
 	void InitMountTable(void)


### PR DESCRIPTION
Issue #272 rightfully raised a use case where `cgroup_get_cgroup()` doesn't work properly on cgroup v2.  This patchset fixes `cgroup_get_cgroup()` on v2 systems and adds a few tests around this functionality.

Note that one key change is that the requested controller(s) is(are) now enabled within the new cgroup.  Prior to this patchset the requested controller(s) was(were) only enabled in the parent cgroup's `cgroup.subtree_control` file.  The previous behavior was inconsistent with libcgroup cgroup v1 behavior.

(This needs to be evaluated for backport to the release-2.0 branch.)