### PR TITLE
ftests: fix lint warnings [v3.0+]

### DIFF
--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -995,6 +995,7 @@ class Cgroup(object):
         else:
             raise CgroupError('Unknown cgroup mode')
 
+
 class CgroupError(Exception):
     def __init__(self, message):
         super(CgroupError, self).__init__(message)

--- a/tests/ftests/ftests.py
+++ b/tests/ftests/ftests.py
@@ -274,7 +274,6 @@ def run_tests(config):
                 if config.args.num == consts.TESTS_RUN_ALL or \
                    config.args.num == filenum_int:
 
-
                     if config.args.suite == consts.TESTS_RUN_ALL_SUITES and \
                        filesuite == 'sudo':
                         # Don't run the 'sudo' tests if all tests have been specified.


### PR DESCRIPTION
This patch series fixes lint warnings in `cgroup.py` and `ftests.py`
reported by `flake8`