### PR TITLE
Fix bug in cgroup_delete_cgroup_ext() [v3.0+]

### DIFF
--- a/tests/ftests/047-cgcreate-delete_cgrp_shared_mnt.py
+++ b/tests/ftests/047-cgcreate-delete_cgrp_shared_mnt.py
@@ -59,10 +59,7 @@ def test(config):
     try:
         Cgroup.delete(config, CONTROLLER1, CGNAME)
     except RunError as re:
-        if 'No such file or directory' in re.stderr:
-            cause = 'Missing support to delete cgroup on shared mount points.'
-            result = consts.TEST_FAILED
-        else:
+        if 'No such file or directory' not in re.stderr:
             raise re
 
     return result, cause

--- a/tests/ftests/098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
+++ b/tests/ftests/098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Cgroup recursive cgdelete functionality test for shared mount point on cgroup v1
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import CgroupVersion, Cgroup
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLER = 'cpu'
+CGNAME = 'test'
+
+excepted_err = "cgdelete: cannot remove group '%s': No such file or directory" % CGNAME
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpu controller'
+        return result, cause
+
+    # cpuacct controller is only available on cgroup v1, if an exception
+    # gets raised, then no cgroup v1 controllers are mounted.
+    try:
+        CgroupVersion.get_version('cpuacct')
+    except IndexError:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the cgroup v1 cpuacct controller'
+
+    return result, cause
+
+
+def setup(config):
+    return consts.TEST_PASSED, None
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        Cgroup.delete(config, CONTROLLER, CGNAME)
+    except RunError as re:
+        if excepted_err not in re.stderr and re.ret != 82:
+            result = consts.TEST_FAILED
+            cause = 'Expected {}'.format(excepted_err)
+            return result, cause
+
+    try:
+        Cgroup.delete(config, CONTROLLER, CGNAME, recursive=True)
+    except RunError as re:
+        if excepted_err not in re.stderr and re.ret != 82:
+            result = consts.TEST_FAILED
+            cause = 'Expected {}'.format(excepted_err)
+
+    return result, cause
+
+
+def teardown(config):
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        result = consts.TEST_FAILED
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
In cgroup v1, the controllers can share mount points, and when the
cgroup is deleted on one of the controller mount points (symlink), as
the side effect is deleted for the controllers sharing the mount point.
But this might not be true always, the user might try to `call cgroup_delete_cgroup_ext()`
with  a cgroup that doesn't exist over the share mount point and still
gets the return code to be zero.
    
This patch series attempts to fix this issue by introducing `cgrp_del_shared_mnt`
flag, which gets set when deleting the cgroup on the first of the controllers
sharing the mount point and checking the flag on the second controller mount
point to ensure that cgroup existed.

It also fixes the logic the in the testcase `ftests/047` to adopt the change in the
`cgroup_delete_cgroup_ext()` and adds a new testcases, that attempts to
delete non-existent cgroup on the shared mount point