### PR TITLE
fix segfault in cgroup_set_permissions() 

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -377,6 +377,12 @@ int cg_chmod_recursive(struct cgroup *cgroup, mode_t dir_mode, int dirm_change, 
 void cgroup_set_permissions(struct cgroup *cgroup, mode_t control_dperm, mode_t control_fperm,
 			    mode_t task_fperm)
 {
+	if (!cgroup) {
+		/* ECGROUPNOTALLOWED */
+		cgroup_err("Cgroup, operation not allowed\n");
+		return;
+	}
+
 	cgroup->control_dperm = control_dperm;
 	cgroup->control_fperm = control_fperm;
 	cgroup->task_fperm = task_fperm;

--- a/tests/gunit/017-API_fuzz_test.cpp
+++ b/tests/gunit/017-API_fuzz_test.cpp
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/**
+ * libcgroup googletest for fuzz testing APIs with negative values.
+ *
+ * Copyright (c) 2023 Oracle and/or its affiliates.  All rights reserved.
+ * Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+ */
+
+#include <sys/stat.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+
+class APIArgsTest: public :: testing:: Test {
+	protected:
+
+	void SetUp() override {
+		/* Stub */
+	}
+};
+
+/**
+ * Pass NULL cgroup for setting permissions
+ * @param APIArgsTest googletest test case name
+ * @param API_cgroup_set_permissions test name
+ *
+ * This test will pass NULL cgroup to the cgroup_set_permissions()
+ * and check it handles it gracefully.
+ */
+TEST_F(APIArgsTest, API_cgroup_set_permissions)
+{
+	mode_t dir_mode, ctrl_mode, task_mode;
+	struct cgroup * cgroup = NULL;
+
+	dir_mode = (S_IRWXU | S_IXGRP | S_IXOTH);
+	ctrl_mode = (S_IRUSR | S_IWUSR | S_IRGRP);
+	task_mode = (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+
+	testing::internal::CaptureStdout();
+
+	cgroup_set_permissions(cgroup, dir_mode, ctrl_mode, task_mode);
+
+	std::string result = testing::internal::GetCapturedStdout();
+	ASSERT_EQ(result, "Error: Cgroup, operation not allowed\n");
+}

--- a/tests/gunit/Makefile.am
+++ b/tests/gunit/Makefile.am
@@ -42,7 +42,9 @@ gtest_SOURCES = gtest.cpp \
 		013-cgroup_build_tasks_procs_path.cpp \
 		014-cgroupv2_get_subtree_control.cpp \
 		015-cgroupv2_controller_enabled.cpp \
-		016-cgset_parse_r_flag.cpp
+		016-cgset_parse_r_flag.cpp \
+		017-API_fuzz_test.cpp
+
 gtest_LDFLAGS = -L$(top_srcdir)/googletest/googletest -l:libgtest.so \
 		-rpath $(abs_top_srcdir)/googletest/googletest
 


### PR DESCRIPTION
This patch set fixes a segfault in the cgroup_set_permissions() and
also adds a simple fuzzer, that exercises the unlikely code path of
APIs by passing negative/wrong values to the APIs function
arguments. To begin with the fuzzer exercises the
`cgroup_set_permissions()` and gradually will add more APIs.