### PR TITLE
Fix (Most) Github Action Warnings

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Set up Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: flake8 Lint
@@ -114,7 +114,7 @@ jobs:
         parallel: True
     - name: Archive code coverage results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Unit Test Code Coverage
         path: lcov.*
@@ -168,7 +168,7 @@ jobs:
         popd
     - name: Archive test logs
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v1 test logs
         path: ./*.log
@@ -183,7 +183,7 @@ jobs:
         parallel: True
     - name: Archive code coverage results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v1 Code Coverage
         path: lcov.*
@@ -227,7 +227,7 @@ jobs:
         cat tests/ftests/ftests-nocontainer.sh.log
     - name: Archive test logs
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v1v2 test logs
         path: tests/ftests/*.log
@@ -242,7 +242,7 @@ jobs:
         parallel: True
     - name: Archive code coverage results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v1v2 Code Coverage
         path: lcov.*
@@ -272,7 +272,7 @@ jobs:
         cat tests/ftests/ftests-nocontainer.sh.log
     - name: Archive test logs
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v2 test logs - legacy
         path: tests/ftests/*.log
@@ -287,7 +287,7 @@ jobs:
         parallel: True
     - name: Archive code coverage results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v2 Code Coverage - legacy
         path: lcov.*
@@ -317,7 +317,7 @@ jobs:
         cat tests/ftests/ftests-nocontainer.sh.log
     - name: Archive test logs
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v2 test logs - hybrid
         path: tests/ftests/*.log
@@ -332,7 +332,7 @@ jobs:
         parallel: True
     - name: Archive code coverage results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v2 Code Coverage - hybrid
         path: lcov.*
@@ -362,7 +362,7 @@ jobs:
         cat tests/ftests/ftests-nocontainer.sh.log
     - name: Archive test logs
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v2 test logs - unified
         path: tests/ftests/*.log
@@ -377,7 +377,7 @@ jobs:
         parallel: True
     - name: Archive code coverage results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Cgroup v2 Code Coverage - unified
         path: lcov.*

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - uses: github/codeql-action/init@v2
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python environment
         uses: actions/setup-python@v2
         with:
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - uses: mattnotmitt/doxygen-action@v1
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - name: Initialize the directory
@@ -128,7 +128,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install lxc lxd-installer
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - name: Initialize the directory
@@ -150,7 +150,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install lxc lxd-installer
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - name: Initialize the directory
@@ -207,7 +207,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install lxc lxd-installer
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - name: Initialize the directory
@@ -252,7 +252,7 @@ jobs:
     runs-on: cgroup-legacy
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - name: Initialize the directory
@@ -297,7 +297,7 @@ jobs:
     runs-on: cgroup-hybrid
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - name: Initialize the directory
@@ -342,7 +342,7 @@ jobs:
     runs-on: cgroup-unified
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - name: Initialize the directory


### PR DESCRIPTION
This patchset fixes most of the github action warnings.  Note that the following two warnings are not fixed because they are in the Coveralls action and must be fixed there:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16:
coverallsapp/github-action@master. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using
Environment Files. For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```