### PR TITLE
github: README: Update code quality analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Continuous Integration Workflow for libcgroup
+#
+# Copyright (c) 2020-2023 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+name: "CodeQL"
+on: ["push", "pull_request"]
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: false
+    - uses: github/codeql-action/init@v2
+      with:
+        languages: cpp, python
+    - name: Initialize the directory
+      uses: ./.github/actions/setup-libcgroup
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,22 +10,6 @@ name: Continuous Integration
 on: ["push", "pull_request"]
 
 jobs:
-  codeql:
-    name: CodeQL
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: false
-    - uses: github/codeql-action/init@v2
-      with:
-        languages: cpp, python
-    - name: Initialize the directory
-      uses: ./.github/actions/setup-libcgroup
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-
   # Doc: https://github.com/redhat-plumbers-in-action/differential-shellcheck#usage
   differential-shellcheck:
     name: Differential ShellCheck

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://github.com/libcgroup/libcgroup/workflows/Continuous%20Integration/badge.svg?branch=main)](https://github.com/libcgroup/libcgroup/actions)
 [![Coverage Status](https://coveralls.io/repos/github/libcgroup/libcgroup/badge.png)](https://coveralls.io/github/libcgroup/libcgroup)
 [![Doxygen Documentation](https://img.shields.io/badge/Documentation-Doxygen-green.svg)](https://libcgroup.github.io/libcgroup/)
-[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/libcgroup/libcgroup.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/libcgroup/libcgroup/alerts/?mode=list&lang=cpp)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/libcgroup/libcgroup.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/libcgroup/libcgroup/alerts/?mode=list&lang=python)
+[CodeQL](https://github.com/libcgroup/libcgroup/actions/workflows/codeql-analysis.yml/badge.svg?branch=main)
 
 The entire libcgroup README is available [here](README).


### PR DESCRIPTION
LGTM code quality analysis is deprecated [1] and no longer generates code quality information.  Remove the LGTM badge and replace it with a CodeQL badge.  To facilitate this, move the CodeQL workflow into its own workflow so that its status can be reported separately from the automated tests.

[1] https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>

Fixes: #288 