### PR TITLE
 wrapper: fix segfault in cgroup_new_cgroup()

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -42,8 +42,12 @@ void init_cgroup_table(struct cgroup *cgroups, size_t count)
 
 struct cgroup *cgroup_new_cgroup(const char *name)
 {
-	struct cgroup *cgroup = calloc(1, sizeof(struct cgroup));
+	struct cgroup *cgroup;
 
+	if (!name)
+		return NULL;
+
+	cgroup = calloc(1, sizeof(struct cgroup));
 	if (!cgroup)
 		return NULL;
 

--- a/tests/gunit/017-API_fuzz_test.cpp
+++ b/tests/gunit/017-API_fuzz_test.cpp
@@ -44,3 +44,20 @@ TEST_F(APIArgsTest, API_cgroup_set_permissions)
 	std::string result = testing::internal::GetCapturedStdout();
 	ASSERT_EQ(result, "Error: Cgroup, operation not allowed\n");
 }
+
+/**
+ * Pass NULL cgroup name for creating a cgroup
+ * @param APIArgsTest googletest test case name
+ * @param API_cgroup_new_cgroup test name
+ *
+ * This test will pass NULL cgroup name to the cgroup_new_cgroup()
+ * and check it handles it gracefully.
+ */
+TEST_F(APIArgsTest, API_cgroup_new_cgroup)
+{
+	struct cgroup *cgroup = NULL;
+	char *name = NULL;
+
+	cgroup = cgroup_new_cgroup(name);
+	ASSERT_EQ(cgroup, nullptr);
+}


### PR DESCRIPTION
This patch series fixes a segfault in `cgroup_new_cgroup()` API,
when NULL is passed to the `cgroup name`.  It also adds a test
case to the `gunit` fuzzer.