### PR TITLE
pybindings: Fix a build warning on Fedora

### DIFF
--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -9,7 +9,7 @@
 
 PY_DISTUTILS = \
 	VERSION_RELEASE="@PACKAGE_VERSION@" \
-	CPPFLAGS="-I\${top_srcdir}/include ${AM_CPPFLAGS} ${CPPFLAGS}" \
+	CPPFLAGS="-I\${top_srcdir}/include ${AM_CPPFLAGS} ${CPPLAGS} -O2" \
 	CFLAGS="$(CODE_COVERAGE_CFLAGS) ${AM_CFLAGS} ${CFLAGS}" \
 	LDFLAGS="$(CODE_COVERAGE_LIBS) ${AM_LDFLAGS} ${LDFLAGS}" \
 	${PYTHON} ${srcdir}/setup.py


### PR DESCRIPTION
While building python bindings on `Fedora 34`,`gcc 11.3.1` triggers a build warning:
```
[1/1] Cythonizing libcgroup.pyx
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/limits.h:26,
                 from /usr/lib/gcc/x86_64-redhat-linux/11/include/limits.h:203,
                 from /usr/lib/gcc/x86_64-redhat-linux/11/include/syslimits.h:7,
                 from /usr/lib/gcc/x86_64-redhat-linux/11/include/limits.h:34,
                 from /usr/include/python3.9/Python.h:11,
                 from libcgroup.c:25:
/usr/include/features.h:397:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  397 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
```
the reason being the default compiler flags for c/c++ includes `-Wp,-D_FORTIFY_SOURCE=2` and `-D_FORTIFY_SOURCE=2`. Whereas Ubuntu compilers include `-D_FORTIFY_SOURCE=2` option only.  This can be fixed by adding `-O2` to the CPP Flags in the pybinding Makefile and there is no side effect in both Fedora and Ubuntu because by default `-D_FORTIFY_SOURCE=2` is included. The Ubuntu automatically auto includes `-D_FORTIFY_SOURCE=2` when `-O2` is passed but here it's been already explicitly passed.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>