### PR TITLE
tools - man pages update

### DIFF
--- a/doc/man/cgclassify.1
+++ b/doc/man/cgclassify.1
@@ -6,7 +6,7 @@
 cgclassify \- move running task(s) to given cgroups
 
 .SH SYNOPSIS
-\fBcgclassify\fR [\fB-g\fR <\fIcontrollers>:<path\fR>] [--sticky | --cancel-sticky] <\fIpidlist\fR>
+\fBcgclassify\fR [\fB-b\fR] [\fB-g\fR <\fIcontrollers>:<path\fR>] [--sticky | --cancel-sticky] <\fIpidlist\fR>
 
 .SH DESCRIPTION
 this command moves processes defined by the list
@@ -15,6 +15,12 @@ of processes
 to the given control groups.
 
 The pids in the pidlist are separated by spaces
+
+.TP
+.B -b
+ignores the default systemd delegated hierarchy path and
+constructs the path of the control groups relative to the
+cgroup root hierarchy.
 
 .TP
 .B -g <controllers>:<path>

--- a/doc/man/cgcreate.1
+++ b/doc/man/cgcreate.1
@@ -5,7 +5,7 @@
 cgcreate \- create new cgroup(s)
 
 .SH SYNOPSIS
-\fBcgcreate\fR [\fB-h\fR] [\fB-t\fR <\fItuid>:<tgid\fR>]
+\fBcgcreate\fR [\fB-h\fR] [\fB-b\fR] [\fB-t\fR <\fItuid>:<tgid\fR>]
 [\fB-a\fR <\fIagid>:<auid\fR>] [\fB-f\fR mode] [\fB-d\fR mode]
 [\fB-s\fR mode] \fB-g\fR <\fIcontrollers>:<path\fR> [\fB-g\fR ...]
 
@@ -19,6 +19,12 @@ defines the name of the user and the group which own the
 rest of the defined control group’s files. These users are
 allowed to set subsystem parameters and create subgroups.
 The default value is the same as has the parent cgroup.
+
+.TP
+.B -b
+ignores the default systemd delegated hierarchy path and
+constructs the path of the control groups relative to the
+cgroup root hierarchy.
 
 .TP
 .B -d, --dperm=mode

--- a/doc/man/cgdelete.1
+++ b/doc/man/cgdelete.1
@@ -7,12 +7,18 @@
 cgdelete \- remove control group(s)
 
 .SH SYNOPSIS
-\fBcgdelete\fR [\fB-h\fR] [\fB-r\fR] [[\fB-g\fR]
+\fBcgdelete\fR [\fB-h\fR] [\fB-r\fR] [\fB-b\fR] [[\fB-g\fR]
 <\fIcontrollers\fR>:\fI<path\fR>] ...
 
 .SH DESCRIPTION
 The \fBcgdelete\fR
 program removes all specified control groups.
+
+.TP
+.B -b
+ignores the default systemd delegated hierarchy path and
+constructs the path of the control groups relative to the
+cgroup root hierarchy.
 
 .TP
 .B [-g] <controllers>:<path>

--- a/doc/man/cgexec.1
+++ b/doc/man/cgexec.1
@@ -7,12 +7,18 @@
 cgexec \- run the task in given control groups
 
 .SH SYNOPSIS
-\fBcgexec\fR [\fB-h\fR] [\fB-g\fR <\fIcontrollers>:<path\fR>] [--sticky] \fBcommand\fR [\fIarguments\fR]
+\fBcgexec\fR [\fB-h\fR] [\fB-b\fR] [\fB-g\fR <\fIcontrollers>:<path\fR>] [--sticky] \fBcommand\fR [\fIarguments\fR]
 
 .SH DESCRIPTION
 The \fBcgexec\fR
 program executes the task \fBcommand\fR
 with arguments \fBarguments\fR in the given control groups.
+
+.TP
+.B -b
+ignores the default systemd delegated hierarchy path and
+constructs the path of the control groups relative to the
+cgroup root hierarchy.
 
 .TP
 .B -g <controllers>:<path>

--- a/doc/man/cgget.1
+++ b/doc/man/cgget.1
@@ -7,10 +7,10 @@
 cgget \- print parameter(s) of given group(s)
 
 .SH SYNOPSIS
-\fBcgget\fR [\fB-n\fR] [\fB-v\fR] [\fB-r\fR <\fIname\fR>]
+\fBcgget\fR [\fB-n\fR] [\fB-v\fR] [\fB-m\fR] [\fB-r\fR <\fIname\fR>]
 [\fB-g\fR <\fIcontroller\fR>] [\fB-a\fR] <\fBpath\fR> ...
 .br
-\fBcgget\fR [\fB-n\fR] [\fB-v\fR] [\fB-r\fR <\fIname\fR>]
+\fBcgget\fR [\fB-n\fR] [\fB-v\fR] [\fB-m\fR] [\fB-r\fR <\fIname\fR>]
 \fB-g\fR <\fIcontroller\fR>:<\fBpath\fR> ...
 
 .SH DESCRIPTION
@@ -40,6 +40,11 @@ This option can be used multiple times.
 .TP
 .B -h, --help
 display help and exit
+
+.TP
+.B -m
+displays the current control groups setup mode. The control groups can be set up in one of three modes,
+legacy (cgroup v1 only), unified (cgroup v2 only) or hybrid (cgroup v1/v2).
 
 .TP
 .B -n
@@ -82,6 +87,9 @@ $ cgget -n -g cpu /
 cpu.rt_period_us=1000000
 cpu.rt_runtime_us=950000
 cpu.shares=1024
+
+$ cgget -m
+Unified Mode (Cgroup v2 only).
 
 .fi
 

--- a/doc/man/cgget.1
+++ b/doc/man/cgget.1
@@ -7,10 +7,10 @@
 cgget \- print parameter(s) of given group(s)
 
 .SH SYNOPSIS
-\fBcgget\fR [\fB-n\fR] [\fB-v\fR] [\fB-m\fR] [\fB-r\fR <\fIname\fR>]
+\fBcgget\fR [\fB-n\fR] [\fB-v\fR] [\fB-m\fR] [\fB-b\fR] [\fB-r\fR <\fIname\fR>]
 [\fB-g\fR <\fIcontroller\fR>] [\fB-a\fR] <\fBpath\fR> ...
 .br
-\fBcgget\fR [\fB-n\fR] [\fB-v\fR] [\fB-m\fR] [\fB-r\fR <\fIname\fR>]
+\fBcgget\fR [\fB-n\fR] [\fB-v\fR] [\fB-m\fR] [\fB-b\fR] [\fB-r\fR <\fIname\fR>]
 \fB-g\fR <\fIcontroller\fR>:<\fBpath\fR> ...
 
 .SH DESCRIPTION
@@ -26,6 +26,12 @@ This parameter can be used multiple times.
 .TP
 .B -a, --all
 print the variables for all controllers which consist in the  given cgroup
+
+.TP
+.B -b
+ignores the default systemd delegated hierarchy path and
+constructs the path of the control groups relative to the
+cgroup root hierarchy.
 
 .TP
 .B -g <controller>

--- a/doc/man/cgset.1
+++ b/doc/man/cgset.1
@@ -7,9 +7,9 @@
 cgset \- set the parameters of given cgroup(s)
 
 .SH SYNOPSIS
-\fBcgset\fR [\fB-r\fR <\fIname=value\fR>] <\fBcgroup_path\fR> ...
+\fBcgset\fR [\fB-b\fR] [\fB-r\fR <\fIname=value\fR>] <\fBcgroup_path\fR> ...
 .br
-\fBcgset\fR \fB--copy-from\fR <\fIsource_cgroup_path\fR> <\fBcgroup_path\fR> ...
+\fBcgset\fR [\fB-b\fR] \fB--copy-from\fR <\fIsource_cgroup_path\fR> <\fBcgroup_path\fR> ...
 
 .SH DESCRIPTION
 Set the parameters of input cgroups.
@@ -18,6 +18,12 @@ Set the parameters of input cgroups.
 .B <path>
 is the name of the cgroup which should be changed.
 This parameter can be used multiple times.
+
+.TP
+.B -b
+ignores the default systemd delegated hierarchy path and
+constructs the path of the control groups relative to the
+cgroup root hierarchy.
 
 .TP
 .B -r <name=value>

--- a/doc/man/cgxget.1
+++ b/doc/man/cgxget.1
@@ -4,10 +4,10 @@
 cgxget \- print parameter(s) of given group(s)
 
 .SH SYNOPSIS
-\fBcgxget\fR [\fB-1\fR] [\fB-2\fR] [\fB-i\fR] [\fB-n\fR] [\fB-v\fR] [\fB-r\fR <\fIname\fR>]
+\fBcgxget\fR [\fB-1\fR] [\fB-2\fR] [\fB-i\fR] [\fB-n\fR] [\fB-v\fR] [\fB-b\fR] [\fB-r\fR <\fIname\fR>]
 [\fB-g\fR <\fIcontroller\fR>] [\fB-a\fR] <\fBpath\fR> ...
 .br
-\fBcgxget\fR [\fB-1\fR] [\fB-2\fR] [\fB-i\fR] [\fB-n\fR] [\fB-v\fR] [\fB-r\fR <\fIname\fR>]
+\fBcgxget\fR [\fB-1\fR] [\fB-2\fR] [\fB-i\fR] [\fB-n\fR] [\fB-v\fR] [\fB-b\fR] [\fB-r\fR <\fIname\fR>]
 \fB-g\fR <\fIcontroller\fR>:<\fBpath\fR> ...
 
 .SH DESCRIPTION
@@ -42,6 +42,11 @@ If the system is running in cgroup v1 mode, libcgroup will convert the data as n
 .TP
 .B -a, --all
 print the variables for all controllers which consist in the  given cgroup
+
+.TP
+.B -b
+ignores the default systemd delegated hierarchy path and constructs the path of the control groups
+relative to the cgroup root hierarchy.
 
 .TP
 .B -g <controller>

--- a/doc/man/cgxset.1
+++ b/doc/man/cgxset.1
@@ -4,9 +4,9 @@
 cgxset \- set the parameters of given cgroup(s)
 
 .SH SYNOPSIS
-\fBcgxset\fR [\fB-1\fR] [\fB-2\fR] [\fB-i\fR] [\fB-r\fR <\fIname=value\fR>] <\fBcgroup_path\fR> ...
+\fBcgxset\fR [\fB-1\fR] [\fB-2\fR] [\fB-i\fR] [\fB-b\fR] [\fB-r\fR <\fIname=value\fR>] <\fBcgroup_path\fR> ...
 .br
-\fBcgxset\fR \fB--copy-from\fR <\fIsource_cgroup_path\fR> <\fBcgroup_path\fR> ...
+\fBcgxset\fR [\fB-b\fR] \fB--copy-from\fR <\fIsource_cgroup_path\fR> <\fBcgroup_path\fR> ...
 
 .SH DESCRIPTION
 Set the parameters of input cgroups.
@@ -35,6 +35,11 @@ If the system is running in cgroup v2 mode, libcgroup will convert the data as n
 data in/out of \fBcgxset\fR is in cgroup v2 format.
 In this mode, the user will provide values in cgroup v2 format and receive values in v2 format.
 If the system is running in cgroup v1 mode, libcgroup will convert the data as necessary
+
+.TP
+.B -b
+ignores the default systemd delegated hierarchy path and constructs the path of the control groups
+relative to the cgroup root hierarchy.
 
 .TP
 .B -i, --ignore-unmappable


### PR DESCRIPTION
This patch series updates the man pages of the libcgroup tools
with `-b` option, which ignores the default systemd delegated hierarchy
path and constructs the path of the control groups relative to the
cgroup root hierarchy and also updates `cgget` tools ` -m` option,
which prints the current cgroup setup mode.