### PR TITLE
Add support for reading cgroup.* files

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -3554,6 +3554,7 @@ int cgroup_get_cgroup(struct cgroup *cgroup)
 	int initial_controller_cnt;
 	char *control_path = NULL;
 	char path[FILENAME_MAX];
+	int ctrl_cnt = 0;
 	DIR *dir = NULL;
 	int error;
 	int i, j;
@@ -3644,8 +3645,10 @@ int cgroup_get_cgroup(struct cgroup *cgroup)
 				 * and we've made it this far, then they are explicitly
 				 * interested in this controller and we should not remove it.
 				 */
-				if (initial_controller_cnt == 0)
+				if (initial_controller_cnt == 0) {
+					ctrl_cnt++;
 					continue;
+				}
 			} else if (error) {
 				goto unlock_error;
 			}
@@ -3666,6 +3669,8 @@ int cgroup_get_cgroup(struct cgroup *cgroup)
 			error = ECGOTHER;
 			goto unlock_error;
 		}
+
+		ctrl_cnt++;
 
 		while ((ctrl_dir = readdir(dir)) != NULL) {
 			/* Skip over non regular files */
@@ -3707,8 +3712,14 @@ int cgroup_get_cgroup(struct cgroup *cgroup)
 		}
 	}
 
-	/* Check if the group really exists or not */
-	if (!cgroup->index) {
+	/*
+	 * Check if the group really exists or not.  The cgroup->index controller count can't
+	 * be used in this case because cgroup v2 allows controllers to be enabled/disabled in
+	 * the subtree_control file.  Rather, cgroup_get_cgroup() tracks the number of possible
+	 * controllers in the ctrl_cnt variable and uses that to determine if the cgroup exists
+	 * or not.
+	 */
+	if (!ctrl_cnt) {
 		error = ECGROUPNOTEXIST;
 		goto unlock_error;
 	}

--- a/tests/ftests/072-pybindings-cgroup_get_cgroup.py
+++ b/tests/ftests/072-pybindings-cgroup_get_cgroup.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgroup_get_cgroup() test using the python bindings
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli, Mode
+from libcgroup import Cgroup, Version
+import consts
+import ftests
+import sys
+import os
+
+CGNAME = '072cggetcg'
+CONTROLLERS = ['cpu', 'memory', 'io', 'pids']
+
+CGNAME2 = '072cggetcg2/childcg'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if Cgroup.cgroup_mode() != Mode.CGROUP_MODE_UNIFIED:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the unified cgroup v2 hierarchy'
+        return result, cause
+
+    return result, cause
+
+
+def setup(config):
+    CgroupCli.create(config, CONTROLLERS, CGNAME)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    #
+    # Test 1 - Ensure all enabled controllers get populated
+    #
+    cgall = Cgroup(CGNAME, Version.CGROUP_V2)
+    cgall.get()
+
+    if len(cgall.controllers) != len(CONTROLLERS):
+        result = consts.TEST_FAILED
+        tmp_cause = 'Expected {} controllers in cgall but received {}'.format(
+                    len(CONTROLLERS), len(cgall.controllers))
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    #
+    # Test 2 - Ensure the user can read the "cgroup" pseudo-controller
+    #
+    cgcg = Cgroup(CGNAME, Version.CGROUP_V2)
+    cgcg.add_controller('cgroup')
+    cgcg.get()
+
+    if len(cgcg.controllers) != 1 or 'cgroup' not in cgcg.controllers.keys():
+        result = consts.TEST_FAILED
+        tmp_cause = 'Expected 1 controller in cgcg but received {}'.format(len(cgcg.controllers))
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    #
+    # Test 3 - Ensure the user can read a disabled controller
+    #
+    cgcpuset = Cgroup(CGNAME, Version.CGROUP_V2)
+    cgcpuset.add_controller('cpuset')
+    cgcpuset.get()
+
+    if len(cgcpuset.controllers) != 1 or 'cpuset' not in cgcpuset.controllers.keys():
+        result = consts.TEST_FAILED
+        tmp_cause = 'Expected 1 controller in cgcpuset but received {}'.format(
+                    len(cgcpuset.controllers))
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    #
+    # Test 4 - Ensure the user can read a cgroup with a mix of enabled and hidden controllers
+    #
+    cgmix = Cgroup(CGNAME, Version.CGROUP_V2)
+    cgmix.add_controller('cpuset')
+    cgmix.add_controller('cgroup')
+    cgmix.add_controller('memory')
+    cgmix.get()
+
+    if len(cgmix.controllers) != 3 or 'cpuset' not in cgmix.controllers.keys() or \
+       'cgroup' not in cgmix.controllers.keys() or 'memory' not in cgmix.controllers.keys():
+        result = consts.TEST_FAILED
+        tmp_cause = 'Expected 3 controller in cgmix but received {}'.format(
+                    len(cgcpuset.controllers))
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    #
+    # Test 5 - Create a parent/child cgroup with no controllers enabled.  Ensure the user can get
+    # the cgroup with no errors.  .get() should populate zero cgroups
+    #
+    CgroupCli.create(config, None, CGNAME2)
+    cgempty = Cgroup(CGNAME2, Version.CGROUP_V2)
+    cgempty.get()
+
+    if len(cgempty.controllers) != 0:
+        result = consts.TEST_FAILED
+        tmp_cause = 'Expected 0 controller in cgempty but received {}'.format(
+                    len(cgcpuset.controllers))
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def teardown(config):
+    CgroupCli.delete(config, CONTROLLERS, CGNAME)
+    CgroupCli.delete(config, CONTROLLERS, CGNAME2, recursive=True)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -91,6 +91,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  068-sudo-systemd_cgexec-v2.py \
 			  069-sudo-systemd_cgxget-cpu-settings-v1.py \
 			  070-sudo-systemd_cgxget-cpu-settings-v2.py \
+			  072-pybindings-cgroup_get_cgroup.py \
 			  098-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/gunit/008-cgroup_process_v2_mount.cpp
+++ b/tests/gunit/008-cgroup_process_v2_mount.cpp
@@ -106,13 +106,14 @@ TEST_F(CgroupProcessV2MntTest, AddV2Mount)
 	ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
 
 	ASSERT_EQ(ret, 0);
-	ASSERT_EQ(mnt_tbl_idx, 6);
+	ASSERT_EQ(mnt_tbl_idx, 7);
 	ASSERT_STREQ(cg_mount_table[0].name, "cpuset");
 	ASSERT_STREQ(cg_mount_table[1].name, "cpu");
 	ASSERT_STREQ(cg_mount_table[2].name, "io");
 	ASSERT_STREQ(cg_mount_table[3].name, "memory");
 	ASSERT_STREQ(cg_mount_table[4].name, "pids");
 	ASSERT_STREQ(cg_mount_table[5].name, "rdma");
+	ASSERT_STREQ(cg_mount_table[6].name, "cgroup");
 
 	ASSERT_STREQ(cg_mount_table[0].mount.path, ent.mnt_dir);
 	ASSERT_STREQ(cg_mount_table[1].mount.path, ent.mnt_dir);
@@ -120,6 +121,7 @@ TEST_F(CgroupProcessV2MntTest, AddV2Mount)
 	ASSERT_STREQ(cg_mount_table[3].mount.path, ent.mnt_dir);
 	ASSERT_STREQ(cg_mount_table[4].mount.path, ent.mnt_dir);
 	ASSERT_STREQ(cg_mount_table[5].mount.path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[6].mount.path, ent.mnt_dir);
 }
 
 TEST_F(CgroupProcessV2MntTest, AddV2Mount_Duplicate)
@@ -136,13 +138,14 @@ TEST_F(CgroupProcessV2MntTest, AddV2Mount_Duplicate)
 	ret = cgroup_process_v2_mnt(&ent, &mnt_tbl_idx);
 
 	ASSERT_EQ(ret, 0);
-	ASSERT_EQ(mnt_tbl_idx, 6);
+	ASSERT_EQ(mnt_tbl_idx, 7);
 	ASSERT_STREQ(cg_mount_table[0].name, "cpuset");
 	ASSERT_STREQ(cg_mount_table[1].name, "cpu");
 	ASSERT_STREQ(cg_mount_table[2].name, "io");
 	ASSERT_STREQ(cg_mount_table[3].name, "memory");
 	ASSERT_STREQ(cg_mount_table[4].name, "pids");
 	ASSERT_STREQ(cg_mount_table[5].name, "rdma");
+	ASSERT_STREQ(cg_mount_table[6].name, "cgroup");
 
 	ASSERT_STREQ(cg_mount_table[0].mount.next->path, ent.mnt_dir);
 	ASSERT_STREQ(cg_mount_table[1].mount.next->path, ent.mnt_dir);
@@ -150,6 +153,7 @@ TEST_F(CgroupProcessV2MntTest, AddV2Mount_Duplicate)
 	ASSERT_STREQ(cg_mount_table[3].mount.next->path, ent.mnt_dir);
 	ASSERT_STREQ(cg_mount_table[4].mount.next->path, ent.mnt_dir);
 	ASSERT_STREQ(cg_mount_table[5].mount.next->path, ent.mnt_dir);
+	ASSERT_STREQ(cg_mount_table[6].mount.next->path, ent.mnt_dir);
 }
 
 /*


### PR DESCRIPTION
Add support to `cgroup_get_cgroup()` to read disabled controllers and psuedo-controllers like cgroup.*.  Note that this change was only added to cgroup v2 and cgroup v1 remains the same.

Example usage:
```
#!/usr/bin/env python3
from libcgroup import Cgroup, Version

# Read all _enabled_ controllers.  The "cgroup" controller will not be read in this case
cg = Cgroup('user.slice', Version.CGROUP_V2)
cg.get()
print(cg)

# Read the cpuset controller.  This will work whether it's enabled or disabled
cg = Cgroup('user.slice', Version.CGROUP_V2)
cg.add_controller('cpuset')
cg.get()
print(cg)

# Read the "cgroup" controller
cg = Cgroup('user.slice', Version.CGROUP_V2)
cg.add_controller('cgroup')
cg.get()
print(cg)

# And of course, it's legal to combine controllers as you see fit
cg = Cgroup('user.slice', Version.CGROUP_V2)
cg.add_controller('cpuset')
cg.add_controller('cgroup')
cg.add_controller('memory')
cg.get()
print(cg)
```

Closes: #297 