### PR TITLE
[RFC] tests/ftests: synchronize between github runners

### DIFF
--- a/.github/actions/setup-libcgroup/action.yml
+++ b/.github/actions/setup-libcgroup/action.yml
@@ -11,9 +11,13 @@ description: "Install dependencies, git clone, bootstrap, configure, and make li
 runs:
   using: "composite"
   steps:
-  - run: sudo apt-get update
+  - run: |
+      while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do sleep 3; done
+      sudo apt-get update
     shell: bash
-  - run: sudo apt-get install libpam-dev lcov python3-pip python3-dev cmake bison flex byacc g++ autoconf automake libtool libsystemd-dev -y
+  - run: |
+      while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do sleep 3; done
+      sudo apt-get install libpam-dev lcov python3-pip python3-dev cmake bison flex byacc g++ autoconf automake libtool libsystemd-dev -y
     shell: bash
   - run: sudo pip install cython
     shell: bash

--- a/tests/ftests/ftests-nocontainer.sh
+++ b/tests/ftests/ftests-nocontainer.sh
@@ -6,6 +6,22 @@ AUTOMAKE_HARD_ERROR=99
 
 START_DIR=$PWD
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+RUNNER_LOCK_FILE="/var/run/libcgroup/github-runner.lock"
+
+# the lock file is removed after executing no-container
+# test cases, whereas the lock is taken by the ftests.sh
+function cleanup()
+{
+	sudo rm -f "$RUNNER_LOCK_FILE"
+	exit "$1"
+}
+
+# ftests.sh should have taken the lock, if not
+# something is out of order, let's abort
+if [ ! -f "$RUNNER_LOCK_FILE" ]; then
+	echo "Lock file $RUNNER_LOCK_FILE missing, aborting"
+	exit 1
+fi
 
 if [ "$START_DIR" != "$SCRIPT_DIR" ]; then
 	cp "$SCRIPT_DIR"/*.py "$START_DIR"
@@ -21,10 +37,10 @@ fi
 	-n Libcg"$RANDOM"
 RET1=$?
 
-pushd ../../src || exit $AUTOMAKE_HARD_ERROR
+pushd ../../src || cleanup $AUTOMAKE_HARD_ERROR
 PATH="$PATH:$(pwd)"
 export PATH
-popd || exit $AUTOMAKE_HARD_ERROR
+popd || cleanp $AUTOMAKE_HARD_ERROR
 
 sudo PATH=$PATH PYTHONPATH=$PYTHONPATH ./ftests.py -l 10 -s "sudo" \
 	-L "$START_DIR/ftests-nocontainer.py.sudo.log" --no-container -n Libcg"$RANDOM"
@@ -40,20 +56,20 @@ fi
 
 if [[ $RET1 -ne $AUTOMAKE_SKIPPED ]] && [[ $RET1 -ne 0 ]]; then
 	# always return errors from the first test run
-	exit $RET1
+	cleanup $RET1
 fi
 if [[ $RET2 -ne $AUTOMAKE_SKIPPED ]] && [[ $RET2 -ne 0 ]]; then
 	# return errors from the second test run
-	exit $RET2
+	cleanup $RET2
 fi
 
 if [[ $RET1 -eq 0 ]] || [[ $RET2 -eq 0 ]]; then
-	exit 0
+	cleanup 0
 fi
 
 if [[ $RET1 -eq $AUTOMAKE_SKIPPED ]] || [[ $RET2 -eq $AUTOMAKE_SKIPPED ]]; then
-	exit $AUTOMAKE_SKIPPED
+	cleanup $AUTOMAKE_SKIPPED
 fi
 
 # I don't think we should ever get here, but better safe than sorry
-exit $AUTOMAKE_HARD_ERROR
+cleanup $AUTOMAKE_HARD_ERROR

--- a/tests/ftests/ftests.sh
+++ b/tests/ftests/ftests.sh
@@ -4,6 +4,14 @@
 START_DIR=$PWD
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+# synchronize between different github runners running on
+# same VM's, this will stop runners from stomping over
+# each other's run.
+LIBCGROUP_RUN_DIR="/var/run/libcgroup/"
+RUNNER_LOCK_FILE="/var/run/libcgroup/github-runner.lock"
+RUNNER_SLEEP_SECS=300		# sleep for 5 minutes
+RUNNER_MAX_TRIES=10		# Abort after 50 minutes, if we don't chance to run
+
 if [ "$START_DIR" != "$SCRIPT_DIR" ]; then
 	cp "$SCRIPT_DIR"/*.py "$START_DIR"
 fi
@@ -13,6 +21,27 @@ if [ -d ../../src/python/build/lib.* ]; then
 	export PYTHONPATH="$PYTHONPATH:$(pwd)"
 	popd
 fi
+
+# If other runners are running then the file exists
+# let's wait for 5 minutes
+time_waited=0
+pretty_time=0
+while [ -f "$RUNNER_LOCK_FILE" ]; do
+	if [ "$RUNNER_MAX_TRIES" -le 0 ]; then
+		echo "Unable to get lock to run the ftests, aborting"
+		exit 1
+	fi
+
+	RUNNER_MAX_TRIES=$(( RUNNER_MAX_TRIES - 1 ))
+	sleep "$RUNNER_SLEEP_SECS"
+
+	time_waited=$(( time_waited + RUNNER_SLEEP_SECS ))
+	pretty_time=$(echo $time_waited | awk '{printf "%d:%02d:%02d", $1/3600, ($1/60)%60, $1%60}')
+	echo "[$pretty_time] Waiting on other runners to complete, $RUNNER_MAX_TRIES retries left"
+done
+# take the lock and start executing
+sudo mkdir -p "$LIBCGROUP_RUN_DIR"
+sudo touch "$RUNNER_LOCK_FILE"
 
 ./ftests.py -l 10 -L "$START_DIR/ftests.py.log" -n Libcg"$RANDOM"
 RET=$?


### PR DESCRIPTION
If a VM is shared between multiple github runners, there are chances of
each other stomping over other's run, if executed parallelly.  To avoid the
race between the runners, introduce lock file, that gets acquired (created)
when `ftest.sh` starts and gets removed by `ftest-nocontainer.sh`, this
ensures that both test cases are executed before other runners, that's
waiting for their chance to run.  A runner would wait for 10 minutes before
re-trying to run.  At the max, a runner would wait for 50 minutes (5 retries)
before giving up.