### PR TITLE
wrapper: fix segfault in cgroup_{set,get}_value_string() 

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -437,7 +437,7 @@ int cgroup_get_value_string(struct cgroup_controller *controller, const char *na
 {
 	int i;
 
-	if (!controller)
+	if (!controller || !name || !value)
 		return ECGINVAL;
 
 	for (i = 0; i < controller->index; i++) {

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -462,7 +462,7 @@ int cgroup_set_value_string(struct cgroup_controller *controller, const char *na
 {
 	int i;
 
-	if (!controller)
+	if (!controller || !name || !value)
 		return ECGINVAL;
 
 	for (i = 0; i < controller->index; i++) {

--- a/tests/gunit/017-API_fuzz_test.cpp
+++ b/tests/gunit/017-API_fuzz_test.cpp
@@ -117,3 +117,56 @@ TEST_F(APIArgsTest, API_cgroup_set_value_string)
 
 	free(value);
 }
+
+/**
+ * Test arguments passed to get a controller's setting
+ * @param APIArgsTest googletest test case name
+ * @param API_cgroup_get_value_string test name
+ *
+ * This test will pass a combination of valid and NULL as
+ * arguments to cgroup_get_value_string() and check if it
+ * handles it gracefully.
+ */
+TEST_F(APIArgsTest, API_cgroup_get_value_string)
+{
+	const char * const cg_name = "FuzzerCgroup";
+	struct cgroup_controller * cgc = NULL;
+	const char * const cg_ctrl = "cpu";
+	char *name = NULL, *value = NULL;
+	struct cgroup *cgroup = NULL;
+	int ret;
+
+	// case 1
+	// cgc = NULL, name = NULL, value = NULL
+	ret = cgroup_get_value_string(cgc, name, NULL);
+	ASSERT_EQ(ret, 50011);
+
+	cgroup = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cgroup, nullptr);
+
+	cgc = cgroup_add_controller(cgroup, cg_ctrl);
+	ASSERT_NE(cgroup, nullptr);
+
+	// case 2
+	// cgc = valid, name = NULL, value = NULL
+	ret = cgroup_get_value_string(cgc, name, NULL);
+	ASSERT_EQ(ret, 50011);
+
+	name = strdup("cgroup.shares");
+	ASSERT_NE(name, nullptr);
+
+	// case 3
+	// cgc = valid, name = valid, value = NULL
+	ret = cgroup_get_value_string(cgc, name, NULL);
+	ASSERT_EQ(ret, 50011);
+
+	free(name);
+	name = NULL;
+
+	// case 4
+	// cgc = valid, name = valid, value = NULL
+	ret = cgroup_get_value_string(cgc, name, &value);
+	ASSERT_EQ(ret, 50011);
+
+	free(value);
+}

--- a/tests/gunit/017-API_fuzz_test.cpp
+++ b/tests/gunit/017-API_fuzz_test.cpp
@@ -61,3 +61,59 @@ TEST_F(APIArgsTest, API_cgroup_new_cgroup)
 	cgroup = cgroup_new_cgroup(name);
 	ASSERT_EQ(cgroup, nullptr);
 }
+
+/**
+ * Test arguments passed to set a controller's setting
+ * @param APIArgsTest googletest test case name
+ * @param API_cgroup_set_value_string test name
+ *
+ * This test will pass a combination of valid and NULL as
+ * arguments to cgroup_set_value_string() and check if it
+ * handles it gracefully.
+ */
+TEST_F(APIArgsTest, API_cgroup_set_value_string)
+{
+	const char * const cg_name = "FuzzerCgroup";
+	struct cgroup_controller * cgc = NULL;
+	const char * const cg_ctrl = "cpu";
+	char * name = NULL, *value = NULL;
+	struct cgroup *cgroup = NULL;
+	int ret;
+
+	// case 1
+	// cgc = NULL, name = NULL, value = NULL
+	ret = cgroup_set_value_string(cgc, name, value);
+	ASSERT_EQ(ret, 50011);
+
+	cgroup = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cgroup, nullptr);
+
+	cgc = cgroup_add_controller(cgroup, cg_ctrl);
+	ASSERT_NE(cgroup, nullptr);
+
+	// case 2
+	// cgc = valid, name = NULL, value = NULL
+	ret = cgroup_set_value_string(cgc, name, value);
+	ASSERT_EQ(ret, 50011);
+
+	name = strdup("cgroup.shares");
+	ASSERT_NE(name, nullptr);
+
+	// case 3
+	// cgc = valid, name = valid, value = NULL
+	ret = cgroup_set_value_string(cgc, name, value);
+	ASSERT_EQ(ret, 50011);
+
+	free(name);
+	name = NULL;
+
+	value = strdup("1024");
+	ASSERT_NE(value, nullptr);
+
+	// case 4
+	// cgc = valid, name = NULL, value = valid
+	ret = cgroup_set_value_string(cgc, name, value);
+	ASSERT_EQ(ret, 50011);
+
+	free(value);
+}


### PR DESCRIPTION
This patch series fixes a segfault in `cgroup_set_value_string()` and
`cgroup_get_value_string()` APIs.  when `NULL` is passed in place of
the controller setting name or value or both. It also adds test cases
to the gunit fuzzer.