### PR TITLE
tests/ftest: use string filter() to concatenation cause

### DIFF
--- a/tests/ftests/054-sudo-set_uid_gid_v2.py
+++ b/tests/ftests/054-sudo-set_uid_gid_v2.py
@@ -59,10 +59,7 @@ def test(config):
     if gid != CTRL_GID:
         result = consts.TEST_FAILED
         tmp_cause = 'Expected cgroup.procs group to be {} but it\'s {}'.format(CTRL_GID, gid)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     return result, cause
 

--- a/tests/ftests/055-sudo-set_uid_gid_v1.py
+++ b/tests/ftests/055-sudo-set_uid_gid_v1.py
@@ -59,10 +59,7 @@ def test(config):
     if tasks_gid != TASKS_GID:
         result = consts.TEST_FAILED
         tmp_cause = 'Expected tasks group to be {} but it\'s {}'.format(TASKS_GID, tasks_gid)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     ctrl_path = os.path.join(CgroupCli.get_controller_mount_point(CONTROLLER), CGNAME,
                              'cgroup.procs')
@@ -71,10 +68,7 @@ def test(config):
     if ctrl_uid != CTRL_UID:
         result = consts.TEST_FAILED
         tmp_cause = 'Expected cgroup.procs owner to be {} but it\'s {}'.format(CTRL_UID, ctrl_uid)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     ctrl_gid = utils.get_file_owner_gid(config, ctrl_path)
     if ctrl_gid != CTRL_GID:

--- a/tests/ftests/056-sudo-set_permissions_v2.py
+++ b/tests/ftests/056-sudo-set_permissions_v2.py
@@ -66,10 +66,7 @@ def test(config):
         result = consts.TEST_FAILED
         tmp_cause = 'Expected cgroup.procs mode to be {} but it\'s {}'.format(
                     format(CTRL_MODE, '03o'), ctrl_mode)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     return result, cause
 

--- a/tests/ftests/057-sudo-set_permissions_v1.py
+++ b/tests/ftests/057-sudo-set_permissions_v1.py
@@ -66,10 +66,7 @@ def test(config):
         result = consts.TEST_FAILED
         tmp_cause = 'Expected cgroup.procs mode to be {} but it\'s {}'.format(
                     format(CTRL_MODE, '03o'), ctrl_mode)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     task_path = os.path.join(CgroupCli.get_controller_mount_point(CONTROLLER), CGNAME,
                              'tasks')
@@ -79,10 +76,7 @@ def test(config):
         result = consts.TEST_FAILED
         tmp_cause = 'Expected tasks mode to be {} but it\'s {}'.format(
                     format(TASK_MODE, '03o'), task_mode)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     return result, cause
 

--- a/tests/ftests/058-sudo-systemd_create_scope2.py
+++ b/tests/ftests/058-sudo-systemd_create_scope2.py
@@ -83,10 +83,7 @@ def test(config):
     if not CgroupCli.is_controller_enabled(config, CGNAME, CONTROLLER):
         result = consts.TEST_FAILED
         tmp_cause = 'Controller {} is not enabled in the parent cgroup'.format(CONTROLLER)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     dir_path = os.path.join(CgroupCli.get_controller_mount_point(CONTROLLER), CGNAME)
 
@@ -95,10 +92,7 @@ def test(config):
         result = consts.TEST_FAILED
         tmp_cause = 'Expected directory mode to be {} but it\'s {}'.format(
                     format(DIR_MODE, '03o'), dir_mode)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     ctrl_path = os.path.join(CgroupCli.get_controller_mount_point(CONTROLLER), CGNAME,
                              'cgroup.procs')
@@ -108,28 +102,19 @@ def test(config):
         result = consts.TEST_FAILED
         tmp_cause = 'Expected cgroup.procs mode to be {} but it\'s {}'.format(
                     format(CTRL_MODE, '03o'), ctrl_mode)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     uid = utils.get_file_owner_uid(config, ctrl_path)
     if uid != CTRL_UID:
         result = consts.TEST_FAILED
         tmp_cause = 'Expected cgroup.procs owner to be {} but it\'s {}'.format(CTRL_UID, uid)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     gid = utils.get_file_owner_gid(config, ctrl_path)
     if gid != CTRL_GID:
         result = consts.TEST_FAILED
         tmp_cause = 'Expected cgroup.procs group to be {} but it\'s {}'.format(CTRL_GID, gid)
-        if not cause:
-            cause = tmp_cause
-        else:
-            cause = '{}\n{}'.format(cause, tmp_cause)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     return result, cause
 


### PR DESCRIPTION
if, then, else construction is used to concatenate the 'cause' string, that 
appends the reason for the test failures.  The reason to use the checks
to `TypeError` that occurs while concatenating `None` and `str` type.
Replace them with a one-liner `string.filter()`, across the test sources.