### PR TITLE
api: cgroup_set_value_string: allocate correct value size to copy value provided 

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -469,7 +469,7 @@ int cgroup_set_value_string(struct cgroup_controller *controller, const char *na
 		struct control_value *val = controller->values[i];
 
 		if (!strcmp(val->name, name)) {
-			strncpy(val->value, value, CG_VALUE_MAX);
+			strncpy(val->value, value, CG_CONTROL_VALUE_MAX);
 			val->value[sizeof(val->value)-1] = '\0';
 			val->dirty = true;
 			return 0;


### PR DESCRIPTION
Replaces libcgroup/libcgroup#305

`cgroup_set_value_string` is using CG_VALUE_MAX to copy the value into the `control_value.value`, where I think it should actually be using `CG_CONTROL_VALUE_MAX`. 

On machines containing a large number of cpu ids, it is possible to end up with `cpuset.cpus` configurations that exceed 100 characters. This leads to a truncation of the value and assigning either less than expected, or a syntax error, depending on the truncation.

An example would be a host containing 64 cpu ids. If one wanted to assign every other cpu id, they would generate a `cpuset.cpus` value size of 181 bytes. In my own experience I have worked with hosts with 128 and 256 cpus and hit this issue many times, where the value wants to be well over 512 bytes.
