### PR TITLE
ftests: Cleanup pid logic in functional tests

### DIFF
--- a/tests/ftests/034-cgexec-basic_cgexec.py
+++ b/tests/ftests/034-cgexec-basic_cgexec.py
@@ -7,8 +7,8 @@
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
+from process import Process
 from cgroup import Cgroup
-from run import Run
 import consts
 import ftests
 import sys
@@ -55,12 +55,7 @@ def test(config):
 
 def teardown(config):
     pids = Cgroup.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
-    if pids:
-        for p in pids.splitlines():
-            if config.args.container:
-                config.container.run(['kill', '-9', p])
-            else:
-                Run.run(['sudo', 'kill', '-9', p])
+    Process.kill(config, pids)
 
     Cgroup.delete(config, CONTROLLER, CGNAME)
 

--- a/tests/ftests/036-cgset-multi_thread.py
+++ b/tests/ftests/036-cgset-multi_thread.py
@@ -8,7 +8,7 @@
 #
 
 from cgroup import Cgroup, CgroupVersion
-from run import Run
+from process import Process
 import consts
 import ftests
 import sys
@@ -69,9 +69,7 @@ def test(config):
 def teardown(config):
     # destroy the child processes
     pids = Cgroup.get_pids_in_cgroup(config, PARENT_CGNAME, CONTROLLER)
-    if pids:
-        for p in pids.splitlines():
-            Run.run(['sudo', 'kill', '-9', p])
+    Process.kill(config, pids)
 
     Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
 

--- a/tests/ftests/046-cgexec-empty_controller.py
+++ b/tests/ftests/046-cgexec-empty_controller.py
@@ -7,7 +7,7 @@
 #
 
 from cgroup import Cgroup, CgroupVersion
-from run import Run
+from process import Process
 import consts
 import ftests
 import sys
@@ -52,12 +52,7 @@ def test(config):
 
 def teardown(config):
     pids = Cgroup.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
-    if pids:
-        for p in pids.splitlines():
-            if config.args.container:
-                config.container.run(['kill', '-9', p])
-            else:
-                Run.run(['sudo', 'kill', '-9', p])
+    Process.kill(config, pids)
 
     Cgroup.delete(config, None, CGNAME)
 

--- a/tests/ftests/049-sudo-systemd_create_scope.py
+++ b/tests/ftests/049-sudo-systemd_create_scope.py
@@ -9,9 +9,10 @@
 
 from cgroup import Cgroup as CgroupCli
 from cgroup import CgroupVersion
-from run import Run, RunError
 from libcgroup import Cgroup
 from systemd import Systemd
+from process import Process
+from run import RunError
 import ftests
 import consts
 import sys
@@ -62,8 +63,7 @@ def test(config):
 def teardown(config, result):
     pid = CgroupCli.get(config, cgname=os.path.join(SLICE, SCOPE), setting='cgroup.procs',
                         print_headers=False, values_only=True)
-    if pid is not None:
-        Run.run(['kill', '-9', str(pid)], shell_bool=True)
+    Process.kill(config, pid)
 
     if result != consts.TEST_PASSED:
         # Something went wrong.  Let's force the removal of the cgroups just to be safe.

--- a/tests/ftests/050-sudo-systemd_create_scope_w_pid.py
+++ b/tests/ftests/050-sudo-systemd_create_scope_w_pid.py
@@ -12,6 +12,7 @@ from cgroup import CgroupVersion
 from run import Run, RunError
 from libcgroup import Cgroup
 from systemd import Systemd
+from process import Process
 import ftests
 import consts
 import sys
@@ -66,8 +67,7 @@ def test(config):
 def teardown(config, result):
     global pid
 
-    if pid is not None:
-        Run.run(['kill', '-9', str(pid)], shell_bool=True)
+    Process.kill(config, pid)
 
     if result != consts.TEST_PASSED:
         # Something went wrong.  Let's force the removal of the cgroups just to be safe.

--- a/tests/ftests/052-sudo-cgroup_attach_task.py
+++ b/tests/ftests/052-sudo-cgroup_attach_task.py
@@ -55,8 +55,8 @@ def test(config):
 
     found = False
     pids = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
-    for pid in pids.splitlines():
-        if int(pid) == os.getpid():
+    for pid in pids:
+        if pid == os.getpid():
             # our process was successfully added to the cgroup
             found = True
 
@@ -71,8 +71,8 @@ def test(config):
 
     found = False
     pids = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
-    for pid in pids.splitlines():
-        if int(pid) == os.getpid():
+    for pid in pids:
+        if pid == os.getpid():
             # our process was successfully added to the cgroup
             found = True
 

--- a/tests/ftests/053-sudo-cgroup_attach_task_pid.py
+++ b/tests/ftests/053-sudo-cgroup_attach_task_pid.py
@@ -53,11 +53,11 @@ def test(config):
 
     cg = Cgroup(CGNAME, Version.CGROUP_V2)
     cg.get()
-    cg.attach(int(child_pid))
+    cg.attach(child_pid)
 
     found = False
     pids = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
-    for pid in pids.splitlines():
+    for pid in pids:
         if pid == child_pid:
             # our process was successfully added to the cgroup
             found = True
@@ -69,11 +69,11 @@ def test(config):
 
     # now let's attach the child process to the root cgroup and ensure we no longer
     # are in CGNAME
-    cg.attach(pid=int(child_pid), root_cgroup=True)
+    cg.attach(pid=child_pid, root_cgroup=True)
 
     found = False
     pids = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
-    for pid in pids.splitlines():
+    for pid in pids:
         if pid == child_pid:
             # our process was successfully added to the cgroup
             found = True

--- a/tests/ftests/058-sudo-systemd_create_scope2.py
+++ b/tests/ftests/058-sudo-systemd_create_scope2.py
@@ -10,8 +10,9 @@
 from cgroup import CgroupVersion as CgroupCliVersion
 from cgroup import Cgroup as CgroupCli
 from libcgroup import Cgroup, Version
-from run import Run, RunError
 from systemd import Systemd
+from process import Process
+from run import RunError
 import ftests
 import consts
 import utils
@@ -66,7 +67,7 @@ def test(config):
     result = consts.TEST_PASSED
     cause = None
 
-    pid = int(config.process.create_process(config))
+    pid = config.process.create_process(config)
 
     cg = Cgroup(CGNAME, Version.CGROUP_V2)
 
@@ -122,8 +123,7 @@ def test(config):
 def teardown(config, result):
     global pid
 
-    if pid is not None:
-        Run.run(['kill', '-9', str(pid)], shell_bool=True)
+    Process.kill(config, pid)
 
     if result != consts.TEST_PASSED:
         # Something went wrong.  Let's force the removal of the cgroups just to be safe.

--- a/tests/ftests/060-sudo-cgconfigparser-systemd.py
+++ b/tests/ftests/060-sudo-cgconfigparser-systemd.py
@@ -6,9 +6,10 @@
 # Copyright (c) 2023 Oracle and/or its affiliates.
 # Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
 
-from run import Run, RunError
 from systemd import Systemd
+from process import Process
 from cgroup import Cgroup
+from run import RunError
 import consts
 import ftests
 import time
@@ -147,8 +148,8 @@ def test(config):
         result = consts.TEST_FAILED
         cause = 'Creation of systemd default slice/scope erroneously succeeded'
 
-    # killing the pid, should remove the scope cgroup too.
-    Run.run(['sudo', 'kill', '-9', pid])
+    # killing the pid should remove the scope cgroup too.
+    Process.kill(config, pid)
 
     # Let's pause and wait for the systemd to remove the scope.
     time.sleep(1)

--- a/tests/ftests/065-sudo-systemd_cgclassify-v1.py
+++ b/tests/ftests/065-sudo-systemd_cgclassify-v1.py
@@ -8,8 +8,9 @@
 #
 
 from cgroup import Cgroup, CgroupVersion
-from run import Run, RunError
 from systemd import Systemd
+from process import Process
+from run import RunError
 import consts
 import ftests
 import time
@@ -91,12 +92,6 @@ def create_process_get_pid(config, CGNAME, SLICENAME='', ignore_systemd=False):
     return pids, result, cause
 
 
-def terminate_process(config, pids):
-    if pids:
-        for p in pids.splitlines():
-            Run.run(['sudo', 'kill', '-9', p])
-
-
 def test(config):
     global SYSTEMD_PIDS, OTHER_PIDS
 
@@ -126,12 +121,12 @@ def test(config):
     try:
         Cgroup.classify(config, CONTROLLER, SYSTEMD_CGNAME, OTHER_PIDS, ignore_systemd=True)
     except RunError as re:
-        err_str = 'Error changing group of pid {}: Cgroup does not exist'.format(OTHER_PIDS)
+        err_str = 'Error changing group of pid {}: Cgroup does not exist'.format(OTHER_PIDS[0])
         if re.stderr != err_str:
             raise re
     else:
         result = consts.TEST_FAILED
-        cause = 'Changing group of pid {} erroneously succeeded'.format(OTHER_PIDS)
+        cause = 'Changing group of pid {} erroneously succeeded'.format(OTHER_PIDS[0])
 
     # classify a task from the systemd scope cgroup (SYSTEMD_CGNAME) to
     # non-systemd scope cgroup (OTHER_CGNAME).  Migration should fail due
@@ -140,12 +135,12 @@ def test(config):
     try:
         Cgroup.classify(config, CONTROLLER, OTHER_CGNAME, SYSTEMD_PIDS)
     except RunError as re:
-        err_str = 'Error changing group of pid {}: Cgroup does not exist'.format(SYSTEMD_PIDS)
+        err_str = 'Error changing group of pid {}: Cgroup does not exist'.format(SYSTEMD_PIDS[0])
         if re.stderr != err_str:
             raise re
     else:
         result = consts.TEST_FAILED
-        tmp_cause = 'Changing group of pid {} erroneously succeeded'.format(SYSTEMD_PIDS)
+        tmp_cause = 'Changing group of pid {} erroneously succeeded'.format(SYSTEMD_PIDS[0])
         cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     # classify the task from the non-systemd scope cgroup to systemd scope cgroup.
@@ -157,8 +152,8 @@ def test(config):
 def teardown(config):
     global SYSTEMD_PIDS, OTHER_PIDS
 
-    terminate_process(config, SYSTEMD_PIDS)
-    terminate_process(config, OTHER_PIDS)
+    Process.kill(config, SYSTEMD_PIDS)
+    Process.kill(config, OTHER_PIDS)
 
     # We need a pause, so that cgroup.procs gets updated.
     time.sleep(1)

--- a/tests/ftests/067-sudo-systemd_cgexec-v1.py
+++ b/tests/ftests/067-sudo-systemd_cgexec-v1.py
@@ -9,7 +9,8 @@
 
 from cgroup import Cgroup, CgroupVersion
 from systemd import Systemd
-from run import Run, RunError
+from process import Process
+from run import RunError
 import consts
 import ftests
 import time
@@ -94,12 +95,6 @@ def create_process_get_pid(config, CGNAME, SLICENAME='', ignore_systemd=False):
     return pids, result, cause
 
 
-def terminate_process(config, pids):
-    if pids:
-        for p in pids.splitlines():
-            Run.run(['sudo', 'kill', '-9', p])
-
-
 def test(config):
     global SYSTEMD_PIDS, OTHER_PIDS
 
@@ -125,8 +120,8 @@ def test(config):
 def teardown(config):
     global SYSTEMD_PIDS, OTHER_PIDS
 
-    terminate_process(config, SYSTEMD_PIDS)
-    terminate_process(config, OTHER_PIDS)
+    Process.kill(config, SYSTEMD_PIDS)
+    Process.kill(config, OTHER_PIDS)
 
     # We need a pause, so that cgroup.procs gets updated.
     time.sleep(1)

--- a/tests/ftests/068-sudo-systemd_cgexec-v2.py
+++ b/tests/ftests/068-sudo-systemd_cgexec-v2.py
@@ -8,8 +8,9 @@
 #
 
 from cgroup import Cgroup, CgroupVersion
-from run import Run, RunError
 from systemd import Systemd
+from process import Process
+from run import RunError
 import consts
 import ftests
 import time
@@ -26,8 +27,8 @@ SCOPE = 'test068.scope'
 
 CONFIG_FILE_NAME = os.path.join(os.getcwd(), '068cgconfig.conf')
 
-SYSTEMD_PIDS = ''
-OTHER_PIDS = ''
+SYSTEMD_PIDS = None
+OTHER_PIDS = None
 
 
 def prereqs(config):
@@ -106,12 +107,6 @@ def create_process_get_pid(config, CGNAME, SLICENAME='', ignore_systemd=False):
     return pids, result, cause
 
 
-def terminate_process(config, pids):
-    if pids:
-        for p in pids.splitlines():
-            Run.run(['kill', '-9', p])
-
-
 def test(config):
     global SYSTEMD_PIDS, OTHER_PIDS
 
@@ -134,7 +129,7 @@ def test(config):
     # SYSTEMD_CGNAME already has the pid of the task, that scope was created
     # with and killing it will remove the scope, be careful and pick the newly
     # spawned task
-    SYSTEMD_PIDS = SYSTEMD_PIDS.split('\n')[1]
+    SYSTEMD_PIDS = SYSTEMD_PIDS[1]
 
     return result, cause
 
@@ -142,8 +137,8 @@ def test(config):
 def teardown(config):
     global SYSTEMD_PIDS, OTHER_PIDS
 
-    terminate_process(config, SYSTEMD_PIDS)
-    terminate_process(config, OTHER_PIDS)
+    Process.kill(config, SYSTEMD_PIDS)
+    Process.kill(config, OTHER_PIDS)
 
     # We need a pause, so that cgroup.procs gets updated.
     time.sleep(1)

--- a/tests/ftests/process.py
+++ b/tests/ftests/process.py
@@ -77,7 +77,7 @@ class Process(object):
             pid = Run.run(cmd, shell_bool=True)
 
             for _pid in pid.splitlines():
-                self.children_pids.append(_pid)
+                self.children_pids.append(int(_pid))
 
             if pid.find('\n') >= 0:
                 # The second pid in the list contains the actual perl process
@@ -90,7 +90,7 @@ class Process(object):
                                 ''.format(pid)
                             )
 
-        return pid
+        return int(pid)
 
     def create_process(self, config):
         # To allow for multiple processes to be created, each new process
@@ -253,5 +253,21 @@ class Process(object):
             return Process.__get_cgroup_v2(config, pid, controller)
 
         raise ValueError("get_cgroup() shouldn't reach this point")
+
+    @staticmethod
+    def kill(config, pids):
+        if not pids:
+            return
+
+        if type(pids) == str:
+            pids = [int(pid) for pid in pids.splitlines()]
+        elif type(pids) == int:
+            pids = [pids]
+
+        for pid in pids:
+            if config.args.container:
+                config.container.run(['kill', '-9', str(pid)])
+            else:
+                Run.run(['kill', '-9', str(pid)])
 
 # vim: set et ts=4 sw=4:


### PR DESCRIPTION
PIDs were inconsistently being managed in the functional tests.  Some functions treated them as `int` and in others they were `str`.  Modify all functions that deal with PIDs to treat them as `int` or a list of `int`s.