### PR TITLE
tools/cg{get,set}: check for delimiter in name_value_string

### DIFF
--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -78,8 +78,15 @@ static void usage(int status, const char *program_name)
 STATIC int parse_r_flag(const char * const program_name, const char * const name_value_str,
 			struct control_value * const name_value)
 {
-	char *copy, *buf;
+	char *copy = NULL, *buf = NULL;
 	int ret = 0;
+
+	buf = strchr(name_value_str, '=');
+	if (buf == NULL) {
+		err("%s: wrong parameter of option -r: %s\n", program_name, optarg);
+		ret = EXIT_BADARGS;
+		goto err;
+	}
 
 	copy = strdup(name_value_str);
 	if (copy == NULL) {

--- a/src/tools/cgxset.c
+++ b/src/tools/cgxset.c
@@ -92,8 +92,15 @@ static void usage(int status, const char *program_name)
 STATIC int parse_r_flag(const char * const program_name, const char * const name_value_str,
 			struct control_value * const name_value)
 {
-	char *copy, *buf;
+	char *copy = NULL, *buf = NULL;
 	int ret = 0;
+
+	buf = strchr(name_value_str, '=');
+	if (buf == NULL) {
+		err("%s: wrong parameter of option -r: %s\n", program_name, optarg);
+		ret = EXIT_BADARGS;
+		goto err;
+	}
 
 	copy = strdup(name_value_str);
 	if (copy == NULL) {


### PR DESCRIPTION
check for delimiter in name_value string

While parsing `-r` option for name, and value pairs, we rely on `strtok()`
to return NULL, when there is no delimiter and lhf/rhf can't be mapped
into the name, and value tokens. This assumption is not true, `strtok()`
returns the whole string when it doesn't find the delimiter. Operating
under this assumption also segfaults later in the code.  Fix it, by
checking for the presence of a delimiter in the passed `name_value_str`
in `parse_r_flag()`.  This also initializes the pointer to `NULL`, to
avoid reading them before assignment in the error path.
