### PR TITLE
wrapper: fix segfault in cgroup_set_bool()

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -604,7 +604,7 @@ int cgroup_set_value_bool(struct cgroup_controller *controller, const char *name
 	int ret;
 	int i;
 
-	if (!controller)
+	if (!controller || !name)
 		return ECGINVAL;
 
 	for (i = 0; i < controller->index; i++) {

--- a/tests/gunit/017-API_fuzz_test.cpp
+++ b/tests/gunit/017-API_fuzz_test.cpp
@@ -537,3 +537,58 @@ TEST_F(APIArgsTest, API_cgroup_get_value_uint64)
 	ret = cgroup_get_value_uint64(cgc, name, &value);
 	ASSERT_EQ(ret, 50011);
 }
+
+/**
+ * Test arguments passed to set a controller's setting
+ * @param APIArgsTest googletest test case name
+ * @param API_cgroup_set_value_bool test name
+ *
+ * This test will pass a combination of valid and NULL as
+ * arguments to cgroup_set_value_bool() and check if it
+ * handles it gracefully.
+ */
+TEST_F(APIArgsTest, API_cgroup_set_value_bool)
+{
+	const char * const cg_name = "FuzzerCgroup";
+	struct cgroup_controller * cgc = NULL;
+	const char * const cg_ctrl = "cpuset";
+	struct cgroup *cgroup = NULL;
+	char * name = NULL;
+	bool value = 1;
+	int ret;
+
+	// case 1
+	// cgc = NULL, name = NULL, value = valid
+	ret = cgroup_set_value_bool(cgc, name, value);
+	ASSERT_EQ(ret, 50011);
+
+	// case 2
+	// cgc = valid, name = NULL, value = valid
+	cgroup = cgroup_new_cgroup(cg_name);
+	ASSERT_NE(cgroup, nullptr);
+
+	cgc = cgroup_add_controller(cgroup, cg_ctrl);
+	ASSERT_NE(cgroup, nullptr);
+
+	// set cpuset.cpu_exclusive, so that cgc->index > 0
+	ret = cgroup_set_value_bool(cgc, "cpuset.cpu_exclusive", 0);
+	ASSERT_EQ(ret, 0);
+
+	ret = cgroup_set_value_bool(cgc, name, value);
+	ASSERT_EQ(ret, 50011);
+
+	// case 3
+	// cgc = valid, name = valid, value = valid
+	name = strdup("cpuset.cpu_exclusive");
+	ASSERT_NE(name, nullptr);
+
+	ret = cgroup_set_value_bool(cgc, name, value);
+	ASSERT_EQ(ret, 0);
+
+	// check if the value was set right
+	ret = cgroup_get_value_bool(cgc, name, &value);
+	ASSERT_EQ(ret, 0);
+	ASSERT_EQ(value, 1);
+
+	free(name);
+}


### PR DESCRIPTION
This patch series fixes a segfault in the `cgroup_set_bool()` API,
that triggers when `NULL` is passed in place of the arguments that
expect pointers. It also adds test cases to the gunit fuzzer.
