### PR TITLE
cleanup cgroup_set_values_recursive() to write dirty values only

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -2630,8 +2630,11 @@ int cgroup_copy_controller_values(struct cgroup_controller * const dst,
 		} else {
 			dst_val->prev_name = NULL;
 		}
-
-		dst_val->dirty = src_val->dirty;
+		/*
+		 * set dirty flag unconditionally, as we overwrite
+		 * destination controller values.
+		 */
+		dst_val->dirty = true;
 	}
 
 	return ret;

--- a/tests/gunit/009-cgroup_set_values_recursive.cpp
+++ b/tests/gunit/009-cgroup_set_values_recursive.cpp
@@ -103,7 +103,7 @@ TEST_F(SetValuesRecursiveTest, SuccessfulSetValues)
 		ctrlr.index++;
 	}
 
-	ret = cgroup_set_values_recursive(PARENT_DIR, &ctrlr, true);
+	ret = cgroup_set_values_recursive(PARENT_DIR, &ctrlr, false);
 	ASSERT_EQ(ret, 0);
 
 	for (i = 0; i < NAMES_CNT; i++) {


### PR DESCRIPTION
`cgroup_set_values_recursive()` is called by `cgroup_modify_cgroup()` to
modify controller values, where all the settings modified or not are
written to the disk.  This breaks when writing a new value of a setting
that is linked to another setting of the controller, followed by writing
an unmodified value to the linked setting. This effectively undoes the
modification. For example, consider two linked settings of the cpu
controller: `cpu.weight` and `cpu.weight.nice`, where writing the new value
of `cpu.weight` is followed by unmodified `cpu.weight.nice` value. Writing
of the latter will undo the new value of the former.

This three-patch, series cleans up the `cgroup_set_values_recursive()` by
renaming the third argument `ignore_non_dirty_failure` to
`ignore_non_dirty_values`.  This renames also changes the purpose of the
flag, where the calling functions, set it to ignore the writing of the
controller setting, which is not modified/dirty and introduces extensive
checks for writing the controller setting.  It also, sets the dirty flag unconditionally,
for destination controller values in cgroup_copy_controller_values() and
propagate the changes to the gunit test case.