### PR TITLE
ftests: fix flake8 warnings

### DIFF
--- a/tests/ftests/050-sudo-systemd_create_scope_w_pid.py
+++ b/tests/ftests/050-sudo-systemd_create_scope_w_pid.py
@@ -9,10 +9,10 @@
 
 from cgroup import Cgroup as CgroupCli
 from cgroup import CgroupVersion
-from run import Run, RunError
 from libcgroup import Cgroup
 from systemd import Systemd
 from process import Process
+from run import RunError
 import ftests
 import consts
 import sys

--- a/tests/ftests/059-sudo-invalid_systemd_create_scope2.py
+++ b/tests/ftests/059-sudo-invalid_systemd_create_scope2.py
@@ -11,7 +11,6 @@ from cgroup import CgroupVersion as CgroupCliVersion
 from libcgroup import Cgroup, Version
 import ftests
 import consts
-import utils
 import sys
 import os
 
@@ -56,7 +55,6 @@ def test(config):
     else:
         result = consts.TEST_FAILED
         cause = 'An invalid cgroup name unexpectedly passed: {}'.format(cg1.name)
-
 
     cg2 = Cgroup("Invalid/TooMany/Slashes", Version.CGROUP_V2)
     cg2.add_controller(CONTROLLER)

--- a/tests/ftests/072-pybindings-cgroup_get_cgroup.py
+++ b/tests/ftests/072-pybindings-cgroup_get_cgroup.py
@@ -20,6 +20,7 @@ CONTROLLERS = ['cpu', 'memory', 'io', 'pids']
 
 CGNAME2 = '{}/grandchildcg'.format(CGNAME)
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None


### PR DESCRIPTION
This patch series fixes `flake8` warnings reported in a few test cases,
the warnings reported were of three types:
```
- F401 - imported but unused
- E302 - expected 2 blank lines, found 1
- E303 - too many blank lines (2)
```