### PR TITLE
ftests: cleanup return statements

### DIFF
--- a/tests/ftests/002-cgdelete-recursive_delete.py
+++ b/tests/ftests/002-cgdelete-recursive_delete.py
@@ -21,7 +21,7 @@ GRANDCHILD = 'grandchildcg'
 
 def prereqs(config):
     # This test should run on both cgroup v1 and v2
-    return consts.TEST_PASSED, None
+    pass
 
 
 def setup(config):
@@ -53,10 +53,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/004-cgsnapshot-basic_snapshot_v1.py
+++ b/tests/ftests/004-cgsnapshot-basic_snapshot_v1.py
@@ -60,7 +60,6 @@ def prereqs(config):
     if not config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test must be run within a container'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/006-cgrules-basic_cgrules_v1.py
+++ b/tests/ftests/006-cgrules-basic_cgrules_v1.py
@@ -40,7 +40,6 @@ def prereqs(config):
     if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v1 cpu controller'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/007-cgrules-basic_cgrules_v2.py
+++ b/tests/ftests/007-cgrules-basic_cgrules_v2.py
@@ -36,7 +36,6 @@ def prereqs(config):
     if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v2 cpuset controller'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/008-cgget-multiple_r_flags.py
+++ b/tests/ftests/008-cgget-multiple_r_flags.py
@@ -26,10 +26,7 @@ VALUE2 = '1024000'
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -90,10 +87,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/009-cgget-g_flag_controller_only.py
+++ b/tests/ftests/009-cgget-g_flag_controller_only.py
@@ -123,10 +123,7 @@ EXPECTED_OUT_V2 = [
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -177,10 +174,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -116,10 +116,7 @@ EXPECTED_OUT_V2 = [
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -180,10 +177,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/011-cgget-r_flag_two_cgroups.py
+++ b/tests/ftests/011-cgget-r_flag_two_cgroups.py
@@ -37,10 +37,7 @@ memory.max: 2048000
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -92,10 +89,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/012-cgget-multiple_r_flags2.py
+++ b/tests/ftests/012-cgget-multiple_r_flags2.py
@@ -36,10 +36,7 @@ EXPECTED_OUT = '''{}:
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -93,10 +90,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/013-cgget-multiple_g_flags.py
+++ b/tests/ftests/013-cgget-multiple_g_flags.py
@@ -145,10 +145,7 @@ EXPECTED_OUT_V2 = [
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -211,10 +208,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/014-cgget-a_flag.py
+++ b/tests/ftests/014-cgget-a_flag.py
@@ -19,10 +19,7 @@ CGNAME = '014cgget'
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -65,7 +62,6 @@ def test(config):
     if 'cpuset.cpus' not in out:
         result = consts.TEST_FAILED
         cause = 'Failed to find cpuset settings in output\n{}'.format(out)
-        return result, cause
 
     return result, cause
 
@@ -85,10 +81,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/015-cgget-multiline_r_flag.py
+++ b/tests/ftests/015-cgget-multiline_r_flag.py
@@ -21,10 +21,7 @@ VALUE = '512'
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -53,7 +50,6 @@ def test(config):
     if '\tunevictable' not in out:
         result = consts.TEST_FAILED
         cause = 'Unexpected output\n{}'.format(out)
-        return result, cause
 
     return result, cause
 
@@ -63,10 +59,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/016-cgget-invalid_options.py
+++ b/tests/ftests/016-cgget-invalid_options.py
@@ -27,7 +27,6 @@ def prereqs(config):
     if not config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test must be run within a container'
-        return result, cause
 
     return result, cause
 
@@ -189,7 +188,6 @@ def test(config):
     if 'Print parameter(s)' not in ret:
         result = consts.TEST_FAILED
         cause = '#7 Failed to print help text'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/017-cgconfig-load_file.py
+++ b/tests/ftests/017-cgconfig-load_file.py
@@ -38,7 +38,6 @@ def prereqs(config):
     if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v1 cpu controller'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/018-cgconfig-load_dir.py
+++ b/tests/ftests/018-cgconfig-load_dir.py
@@ -53,7 +53,6 @@ def prereqs(config):
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v1 memory controller'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/019-cgconfig-uidgid_dperm_fperm.py
+++ b/tests/ftests/019-cgconfig-uidgid_dperm_fperm.py
@@ -34,10 +34,7 @@ CONFIG_FILE_NAME = os.path.join(os.getcwd(), '019cgconfig.conf')
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -98,7 +95,6 @@ def test(config):
                     'Directory permissions failed.  Expected {}, received {}\n'
                     ''.format(DPERM, dperm)
                 )
-        return result, cause
 
     return result, cause
 
@@ -120,9 +116,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
+    prereqs(config)
 
     try:
         setup(config)

--- a/tests/ftests/020-cgconfig-tasks_perms_owner.py
+++ b/tests/ftests/020-cgconfig-tasks_perms_owner.py
@@ -39,7 +39,6 @@ def prereqs(config):
     if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v1 cpuset controller'
-        return result, cause
 
     return result, cause
 
@@ -93,7 +92,6 @@ def test(config):
                     'File permissions failed.  Expected {}, received {}\n'
                     ''.format(TPERM, tperm)
                 )
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/021-cgconfig-invalid_options.py
+++ b/tests/ftests/021-cgconfig-invalid_options.py
@@ -30,10 +30,7 @@ CONFIG_FILE_NAME = os.path.join(os.getcwd(), '021cgconfig.conf')
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -67,7 +64,6 @@ def test(config):
     else:
         result = consts.TEST_FAILED
         cause = 'Test case erroneously passed'
-        return result, cause
 
     return result, cause
 
@@ -77,9 +73,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
+    prereqs(config)
 
     try:
         setup(config)

--- a/tests/ftests/022-cgset-multiple_r_flag.py
+++ b/tests/ftests/022-cgset-multiple_r_flag.py
@@ -29,7 +29,6 @@ def prereqs(config):
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v1 memory controller'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/023-cgset-copy_from.py
+++ b/tests/ftests/023-cgset-copy_from.py
@@ -30,7 +30,6 @@ def prereqs(config):
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v1 memory controller'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/025-cgset-multiple_cgroups.py
+++ b/tests/ftests/025-cgset-multiple_cgroups.py
@@ -28,7 +28,6 @@ def prereqs(config):
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v1 memory controller'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/026-cgset-multiple_r_multiple_cgroup.py
+++ b/tests/ftests/026-cgset-multiple_r_multiple_cgroup.py
@@ -30,7 +30,6 @@ def prereqs(config):
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v1 memory controller'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/027-cgset-invalid_options.py
+++ b/tests/ftests/027-cgset-invalid_options.py
@@ -20,10 +20,7 @@ CGNAME2 = '027cgset2'
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -146,7 +143,6 @@ def test(config):
     if 'Usage:' not in ret:
         result = consts.TEST_FAILED
         cause = '#6 Failed to print help text'
-        return result, cause
 
     return result, cause
 
@@ -157,10 +153,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/029-lssubsys-basic_lssubsys.py
+++ b/tests/ftests/029-lssubsys-basic_lssubsys.py
@@ -15,10 +15,7 @@ import os
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -69,9 +66,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
+    prereqs(config)
 
     try:
         setup(config)

--- a/tests/ftests/030-lssubsys-lssubsys_all.py
+++ b/tests/ftests/030-lssubsys-lssubsys_all.py
@@ -15,10 +15,7 @@ import os
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -66,7 +63,6 @@ def test(config):
     if 'Usage:' not in ret:
         result = consts.TEST_FAILED
         cause = 'Failed to print help text'
-        return result, cause
 
     return result, cause
 
@@ -76,9 +72,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
+    prereqs(config)
 
     try:
         setup(config)

--- a/tests/ftests/031-lscgroup-g_flag.py
+++ b/tests/ftests/031-lscgroup-g_flag.py
@@ -52,7 +52,6 @@ def prereqs(config):
         # Skip this test because of this
         result = consts.TEST_SKIPPED
         cause = 'See Github Issue #50 - lscgroup lists controllers...'
-        return result, cause
 
     return result, cause
 
@@ -81,7 +80,6 @@ def test(config):
                     "".format(utils.indent(EXPECTED_OUT1, 4),
                               utils.indent(out, 4))
                 )
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/032-lscgroup-multiple_g_flags.py
+++ b/tests/ftests/032-lscgroup-multiple_g_flags.py
@@ -57,7 +57,6 @@ def prereqs(config):
         # Skip this test because of this
         result = consts.TEST_SKIPPED
         cause = 'See Github Issue #50 - lscgroup lists controllers...'
-        return result, cause
 
     return result, cause
 
@@ -95,7 +94,6 @@ def test(config):
     if 'Usage:' not in ret:
         result = consts.TEST_FAILED
         cause = 'Failed to print help text'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/033-cgget-no_flags.py
+++ b/tests/ftests/033-cgget-no_flags.py
@@ -18,10 +18,7 @@ CGNAME = '033cgget'
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -57,10 +54,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/034-cgexec-basic_cgexec.py
+++ b/tests/ftests/034-cgexec-basic_cgexec.py
@@ -20,12 +20,13 @@ CGNAME = '034cgexec'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
     if not config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test must be run within a container'
-        return result, cause
 
-    return consts.TEST_PASSED, None
+    return result, cause
 
 
 def setup(config):
@@ -33,6 +34,9 @@ def setup(config):
 
 
 def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     config.process.create_process_in_cgroup(config, CONTROLLER, CGNAME,
                                             cgclassify=False)
 
@@ -48,9 +52,8 @@ def test(config):
     if 'Run the task in given control group(s)' not in ret:
         result = consts.TEST_FAILED
         cause = 'Failed to print cgexec help text: {}'.format(ret)
-        return result, cause
 
-    return consts.TEST_PASSED, None
+    return result, cause
 
 
 def teardown(config):

--- a/tests/ftests/035-cgset-set_cgroup_type.py
+++ b/tests/ftests/035-cgset-set_cgroup_type.py
@@ -43,8 +43,6 @@ def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
     Cgroup.get_and_validate(config, CGNAME, SETTING, BEFORE)
 
-    return consts.TEST_PASSED, None
-
 
 def test(config):
     Cgroup.set_and_validate(config, CGNAME, SETTING, AFTER)
@@ -62,9 +60,6 @@ def main(config):
         return [result, cause]
 
     setup(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
     [result, cause] = test(config)
     teardown(config)
 

--- a/tests/ftests/036-cgset-multi_thread.py
+++ b/tests/ftests/036-cgset-multi_thread.py
@@ -35,7 +35,6 @@ def prereqs(config):
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the cgroup v2'
-        return result, cause
 
     return result, cause
 
@@ -45,8 +44,6 @@ def setup(config):
     Cgroup.create(config, CONTROLLER, CHILD_CGPATH)
 
     Cgroup.set_and_validate(config, CHILD_CGPATH, SETTING, AFTER)
-
-    return consts.TEST_PASSED, None
 
 
 def test(config):

--- a/tests/ftests/037-cgxget-cpu_settings.py
+++ b/tests/ftests/037-cgxget-cpu_settings.py
@@ -54,10 +54,7 @@ TABLE = [
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -92,10 +89,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/038-cgxget-cpuset_settings.py
+++ b/tests/ftests/038-cgxget-cpuset_settings.py
@@ -80,7 +80,6 @@ def prereqs(config):
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/039-pybindings-cgxget.py
+++ b/tests/ftests/039-pybindings-cgxget.py
@@ -26,13 +26,12 @@ VALUE2 = '400'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 
@@ -113,7 +112,6 @@ def test(config):
                     ''.format(SETTING2, VALUE2,
                               cg2.controllers[CONTROLLER].settings[SETTING2])
                 )
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/040-pybindings-cgxset.py
+++ b/tests/ftests/040-pybindings-cgxset.py
@@ -27,13 +27,12 @@ VALUE2 = '50'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 
@@ -89,7 +88,6 @@ def test(config):
     if value_v2 != VALUE2:
         result = consts.TEST_FAILED
         cause = 'Expected {}, but received {}'.format(VALUE2, value_v2)
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/041-pybindings-library_version.py
+++ b/tests/ftests/041-pybindings-library_version.py
@@ -15,11 +15,11 @@ import os
 
 
 def prereqs(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def setup(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def test(config):
@@ -41,7 +41,6 @@ def test(config):
     if not isinstance(release, int):
         result = consts.TEST_FAILED
         cause = 'Release version failed. Received {}'.format(release)
-        return result, cause
 
     return result, cause
 
@@ -51,10 +50,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/042-cgxget-unmappable.py
+++ b/tests/ftests/042-cgxget-unmappable.py
@@ -19,10 +19,7 @@ SETTING = 'cpu.stat'
 
 
 def prereqs(config):
-    result = consts.TEST_PASSED
-    cause = None
-
-    return result, cause
+    pass
 
 
 def setup(config):
@@ -56,10 +53,7 @@ def teardown(config):
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/043-cgcreate-empty_controller.py
+++ b/tests/ftests/043-cgcreate-empty_controller.py
@@ -31,7 +31,7 @@ def prereqs(config):
 
 
 def setup(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def test(config):
@@ -60,9 +60,6 @@ def main(config):
         return [result, cause]
 
     setup(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
     [result, cause] = test(config)
     teardown(config)
 

--- a/tests/ftests/045-pybindings-list_mount_points.py
+++ b/tests/ftests/045-pybindings-list_mount_points.py
@@ -17,19 +17,18 @@ CGNAME = '045bindings'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 
 
 def setup(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def test(config):
@@ -46,7 +45,7 @@ def test(config):
 
 
 def teardown(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def main(config):

--- a/tests/ftests/047-cgcreate-delete_cgrp_shared_mnt.py
+++ b/tests/ftests/047-cgcreate-delete_cgrp_shared_mnt.py
@@ -66,7 +66,7 @@ def test(config):
 
 
 def teardown(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def main(config):

--- a/tests/ftests/048-pybindings-get_cgroup_mode.py
+++ b/tests/ftests/048-pybindings-get_cgroup_mode.py
@@ -16,11 +16,11 @@ import os
 
 
 def prereqs(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def setup(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def test(config):
@@ -38,14 +38,11 @@ def test(config):
 
 
 def teardown(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def main(config):
-    [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
+    prereqs(config)
     setup(config)
     [result, cause] = test(config)
     teardown(config)

--- a/tests/ftests/049-sudo-systemd_create_scope.py
+++ b/tests/ftests/049-sudo-systemd_create_scope.py
@@ -27,6 +27,9 @@ CONTROLLER = 'cpu'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
@@ -35,10 +38,6 @@ def prereqs(config):
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 

--- a/tests/ftests/050-sudo-systemd_create_scope_w_pid.py
+++ b/tests/ftests/050-sudo-systemd_create_scope_w_pid.py
@@ -28,6 +28,9 @@ CONTROLLER = 'cpu'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
@@ -36,10 +39,6 @@ def prereqs(config):
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 

--- a/tests/ftests/051-sudo-cgroup_get_cgroup.py
+++ b/tests/ftests/051-sudo-cgroup_get_cgroup.py
@@ -22,6 +22,9 @@ CONTROLLER = 'cpu'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
@@ -30,10 +33,6 @@ def prereqs(config):
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 
@@ -66,8 +65,6 @@ def teardown(config, result):
         cg.delete()
     except RuntimeError:
         pass
-
-    return consts.TEST_PASSED, None
 
 
 def main(config):

--- a/tests/ftests/052-sudo-cgroup_attach_task.py
+++ b/tests/ftests/052-sudo-cgroup_attach_task.py
@@ -23,6 +23,9 @@ CONTROLLER = 'cpu'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
@@ -31,10 +34,6 @@ def prereqs(config):
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 
@@ -89,8 +88,6 @@ def teardown(config, result):
         cg.delete()
     except RuntimeError:
         pass
-
-    return consts.TEST_PASSED, None
 
 
 def main(config):

--- a/tests/ftests/053-sudo-cgroup_attach_task_pid.py
+++ b/tests/ftests/053-sudo-cgroup_attach_task_pid.py
@@ -23,6 +23,9 @@ CONTROLLER = 'cpu'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
@@ -31,10 +34,6 @@ def prereqs(config):
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 
@@ -91,8 +90,6 @@ def teardown(config, result):
         cg.delete()
     except RuntimeError:
         pass
-
-    return consts.TEST_PASSED, None
 
 
 def main(config):

--- a/tests/ftests/054-sudo-set_uid_gid_v2.py
+++ b/tests/ftests/054-sudo-set_uid_gid_v2.py
@@ -35,7 +35,7 @@ def prereqs(config):
 
 
 def setup(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def test(config):
@@ -66,8 +66,6 @@ def test(config):
 
 def teardown(config):
     CgroupCli.delete(config, None, CGNAME)
-
-    return consts.TEST_PASSED, None
 
 
 def main(config):

--- a/tests/ftests/055-sudo-set_uid_gid_v1.py
+++ b/tests/ftests/055-sudo-set_uid_gid_v1.py
@@ -35,7 +35,7 @@ def prereqs(config):
 
 
 def setup(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def test(config):
@@ -84,8 +84,6 @@ def test(config):
 
 def teardown(config):
     CgroupCli.delete(config, CONTROLLER, CGNAME)
-
-    return consts.TEST_PASSED, None
 
 
 def main(config):

--- a/tests/ftests/056-sudo-set_permissions_v2.py
+++ b/tests/ftests/056-sudo-set_permissions_v2.py
@@ -38,7 +38,7 @@ def prereqs(config):
 
 
 def setup(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def test(config):
@@ -73,8 +73,6 @@ def test(config):
 
 def teardown(config):
     CgroupCli.delete(config, None, CGNAME)
-
-    return consts.TEST_PASSED, None
 
 
 def main(config):

--- a/tests/ftests/057-sudo-set_permissions_v1.py
+++ b/tests/ftests/057-sudo-set_permissions_v1.py
@@ -38,7 +38,7 @@ def prereqs(config):
 
 
 def setup(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def test(config):
@@ -83,8 +83,6 @@ def test(config):
 
 def teardown(config):
     CgroupCli.delete(config, CONTROLLER, CGNAME)
-
-    return consts.TEST_PASSED, None
 
 
 def main(config):

--- a/tests/ftests/058-sudo-systemd_create_scope2.py
+++ b/tests/ftests/058-sudo-systemd_create_scope2.py
@@ -41,6 +41,9 @@ CTRL_GID = 5791
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
@@ -49,10 +52,6 @@ def prereqs(config):
     if CgroupCliVersion.get_version(CONTROLLER) != CgroupCliVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 

--- a/tests/ftests/059-sudo-invalid_systemd_create_scope2.py
+++ b/tests/ftests/059-sudo-invalid_systemd_create_scope2.py
@@ -20,6 +20,9 @@ CONTROLLER = 'cpu'
 
 
 def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
@@ -28,10 +31,6 @@ def prereqs(config):
     if CgroupCliVersion.get_version(CONTROLLER) != CgroupCliVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
-        return result, cause
-
-    result = consts.TEST_PASSED
-    cause = None
 
     return result, cause
 

--- a/tests/ftests/060-sudo-cgconfigparser-systemd.py
+++ b/tests/ftests/060-sudo-cgconfigparser-systemd.py
@@ -78,7 +78,7 @@ def prereqs(config):
 
 
 def setup(config):
-    return consts.TEST_PASSED, None
+    pass
 
 
 def write_conf_file(config, configurations):

--- a/tests/ftests/072-pybindings-cgroup_get_cgroup.py
+++ b/tests/ftests/072-pybindings-cgroup_get_cgroup.py
@@ -33,7 +33,6 @@ def prereqs(config):
     if Cgroup.cgroup_mode() != Mode.CGROUP_MODE_UNIFIED:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the unified cgroup v2 hierarchy'
-        return result, cause
 
     return result, cause
 

--- a/tests/ftests/999-stress-cgroup_init.py
+++ b/tests/ftests/999-stress-cgroup_init.py
@@ -83,9 +83,6 @@ def teardown(config):
 
 def main(config):
     [result, cause] = prereqs(config)
-    if result != consts.TEST_PASSED:
-        return [result, cause]
-
     setup(config)
     [result, cause] = test(config)
     teardown(config)


### PR DESCRIPTION
This patch cleans up a few oddities around return statements:
1. Removes redundant return statements across the `ftests/*`, mostly 
    in the function prereqs and a few other places too.
2. Follows the same function template for prereqs, across the `ftests/*.`,
    and removes the checks for success on return from prereqs function,
    those will be true always.
3. Also, replace `consts.TEST_PASSED, None` with `pass` for functions,
    that serves as stub and removes the return value checks for stubs.