### PR TITLE
Revert enabling controller on cgroup v2 leaf cgroups

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1924,6 +1924,7 @@ error:
 STATIC int cgroupv2_controller_enabled(const char * const cg_name, const char * const ctrl_name)
 {
 	char path[FILENAME_MAX] = {0};
+	char *parent = NULL, *dname;
 	enum cg_version_t version;
 	bool enabled;
 	int error;
@@ -1949,13 +1950,24 @@ STATIC int cgroupv2_controller_enabled(const char * const cg_name, const char * 
 	if (!cg_build_path(cg_name, path, ctrl_name))
 		goto err;
 
-	error = cgroupv2_get_subtree_control(path, ctrl_name, &enabled);
+	parent = strdup(path);
+	if (!parent) {
+		error = ECGOTHER;
+		goto err;
+	}
+
+	dname = dirname(parent);
+
+	error = cgroupv2_get_subtree_control(dname, ctrl_name, &enabled);
 	if (error)
 		goto err;
 
 	if (enabled)
 		error = 0;
 err:
+	if (parent)
+		free(parent);
+
 	return error;
 }
 

--- a/src/api.c
+++ b/src/api.c
@@ -2847,12 +2847,6 @@ static int _cgroup_create_cgroup(const struct cgroup * const cgroup,
 		goto err;
 
 	if (controller) {
-		if (version == CGROUP_V2) {
-			error = cgroupv2_subtree_control(base, controller->name, true);
-			if (error)
-				goto err;
-		}
-
 		error = cgroup_set_values_recursive(base, controller, false);
 		if (error)
 			goto err;

--- a/tests/ftests/062-sudo-g_flag_controller_only_systemd-v2.py
+++ b/tests/ftests/062-sudo-g_flag_controller_only_systemd-v2.py
@@ -60,15 +60,14 @@ def setup(config):
 
     # With cgroup v2, we can't enable controller for the child cgroup, while
     # a task is attached to test062.scope. Attach the task from test062.scope
-    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
-    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent,
+    # so that the cgroup.get() works
     Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
 
     Cgroup.set(
                 config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
                 value='+cpu', ignore_systemd=True
               )
-    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
 
     # create and check if the cgroup was created under the controller root
     if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):

--- a/tests/ftests/064-sudo-systemd_cgset-v2.py
+++ b/tests/ftests/064-sudo-systemd_cgset-v2.py
@@ -60,15 +60,14 @@ def setup(config):
 
     # With cgroup v2, we can't enable controller for the child cgroup, while
     # a task is attached to test064.scope. Attach the task from test064.scope
-    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
-    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent,
+    # so that the cgroup.get() works
     Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
 
     Cgroup.set(
                 config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
                 value='+cpu', ignore_systemd=True
               )
-    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
 
     # create and check if the cgroup was created under the controller root
     if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):

--- a/tests/ftests/066-sudo-systemd_cgclassify-v2.py
+++ b/tests/ftests/066-sudo-systemd_cgclassify-v2.py
@@ -66,15 +66,14 @@ def setup(config):
 
     # With cgroup v2, we can't enable controller for the child cgroup, while
     # a task is attached to test066.scope. Attach the task from test066.scope
-    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
-    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent,
+    # so that the cgroup.get() works
     Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
 
     Cgroup.set(
                 config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
                 value='+cpu', ignore_systemd=True
               )
-    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
 
     # create and check if the cgroup was created under the controller root
     if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):
@@ -133,7 +132,7 @@ def test(config):
     try:
         Cgroup.classify(config, CONTROLLER, SYSTEMD_CGNAME, OTHER_PIDS, ignore_systemd=True)
     except RunError as re:
-        err_str = 'Error changing group of pid {}: No such file or directory'.format(OTHER_PIDS[0])
+        err_str = 'Error changing group of pid {}: Cgroup does not exist'.format(OTHER_PIDS[0])
         if re.stderr != err_str:
             raise re
     else:
@@ -147,7 +146,7 @@ def test(config):
     try:
         Cgroup.classify(config, CONTROLLER, OTHER_CGNAME, SYSTEMD_PIDS[1])
     except RunError as re:
-        err_str = 'Error changing group of pid {}: No such file or directory'.format(
+        err_str = 'Error changing group of pid {}: Cgroup does not exist'.format(
                   SYSTEMD_PIDS[1])
         if re.stderr != err_str:
             raise re

--- a/tests/ftests/068-sudo-systemd_cgexec-v2.py
+++ b/tests/ftests/068-sudo-systemd_cgexec-v2.py
@@ -66,15 +66,14 @@ def setup(config):
 
     # With cgroup v2, we can't enable controller for the child cgroup, while
     # a task is attached to test068.scope. Attach the task from test068.scope
-    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
-    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent,
+    # so that the cgroup.get() works
     Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
 
     Cgroup.set(
                 config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
                 value='+cpu', ignore_systemd=True
               )
-    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
 
     # create and check if the cgroup was created under the controller root
     if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):

--- a/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
+++ b/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
@@ -97,15 +97,14 @@ def setup(config):
 
     # With cgroup v2, we can't enable controller for the child cgroup, while
     # a task is attached to test070.scope. Attach the task from test070.scope
-    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent
-    # and then in the SYSTEMD_CGNAME cgroup, so that the cgroup.get() works
+    # to child cgroup SYSTEMD_CGNAME and then enable cpu controller in the parent,
+    # so that the cgroup.get() works
     Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.procs', value=pid)
 
     Cgroup.set(
                 config, cgname=(os.path.join(SLICE, SCOPE)), setting='cgroup.subtree_control',
                 value='+cpu', ignore_systemd=True
               )
-    Cgroup.set(config, cgname=SYSTEMD_CGNAME, setting='cgroup.subtree_control', value='+cpu')
 
     # create and check if the cgroup was created under the controller root
     if not Cgroup.create_and_validate(config, CONTROLLER, OTHER_CGNAME, ignore_systemd=True):

--- a/tests/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/tests/gunit/015-cgroupv2_controller_enabled.cpp
@@ -54,7 +54,6 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 	void InitChildDir(const char dirname[])
 	{
 		char tmp_path[FILENAME_MAX] = {0};
-		FILE *f;
 		int ret;
 
 		/* create the directory */
@@ -62,14 +61,6 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 			 PARENT_DIR, dirname);
 		ret = mkdir(tmp_path, MODE);
 		ASSERT_EQ(ret, 0);
-
-		snprintf(tmp_path, FILENAME_MAX - 1,
-			 "%s/%s/cgroup.subtree_control", PARENT_DIR, dirname);
-
-		f = fopen(tmp_path, "w");
-		ASSERT_NE(f, nullptr);
-		fprintf(f, "cpu io memory pids\n");
-		fclose(f);
 	}
 
 	void InitMountTable(void)


### PR DESCRIPTION
cgroup v2, has no internal process constraint, where the process runs
only on the leaf node of the cgroup hierarchy and no controllers should
be enabled on the leaf cgroup node too so that they don't compete with
the parent's internal process. This patch broke this rule by enabling
the controller on the leaf node by default. This patch series reverts to
the original approach of not enabling the controller on the leaf cgroup
node and also reverts the logic in the test cases too.