### PR TITLE
tools/cgxget: fix segfault in free path

### DIFF
--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -823,7 +823,7 @@ out:
 		 * Free the old list.
 		 */
 		for (i = 0; i < cg_list_len; i++)
-			cgroup_free(cg_list[i]);
+			cgroup_free(&(*cg_list)[i]);
 
 		*cg_list = cg_converted_list;
 	}


### PR DESCRIPTION
`cgxget` tool crashes, when passing basic operations such as multiple
cgroups as arguments or invalid parameters, it turns out the address
of `struct cgroup` passed for `cgroup_free()` has been invalid.
```
$ sudo ./src/tools/cgxget -1 -r cpu.shares a b
Segmentation fault (core dumped)

$ sudo ./src/tools/cgxget -1 cpu.shares a b
Segmentation fault (core dumped)
```
this patch fixes it by passing the right address of the `struct cgroup[]` to `cgroup_free()`.