### PR TITLE
 [RFC] tools/cgget: add '-c' option

### DIFF
--- a/doc/man/cgget.1
+++ b/doc/man/cgget.1
@@ -34,6 +34,11 @@ constructs the path of the control groups relative to the
 cgroup root hierarchy.
 
 .TP
+.B -c
+displays the controllers and their versions.
+This option can be used along with -m option.
+
+.TP
 .B -g <controller>
 defines controllers whose values should be displayed.
 This option can be used multiple times.


### PR DESCRIPTION
This patch series adds the `-c` option to `cgget` and updates the man
page for the option.  The added `-c` option,  prints the controllers and
their versions, this is useful for the user, who wants to list the available
controllers and/or their versions too.

```
 $ cgget -c
 #Controller     Version
 cpu             2
 memory          2
 cpuset          1
 misc            1
 hugetlb         1
 blkio           1
 net_cls         1
 net_prio        1
 freezer         1
 devices         1
 pids            1
 perf_event      1
 rdma            1
```

this option works with legacy, unified, and hybrid cgroup setup modes.
