### PR TITLE
add cgroup v2 support to cgroup_get_current_controller_path()

### DIFF
--- a/src/python/cgroup.pxd
+++ b/src/python/cgroup.pxd
@@ -115,4 +115,6 @@ cdef extern from "libcgroup.h":
 
     bool is_cgroup_mode_unified()
 
+    int cgroup_get_current_controller_path(pid_t pid, const char *controller,
+                                           char **current_path)
 # vim: set et ts=4 sw=4:

--- a/tests/ftests/081-pybindings-cgrp_get_curr_ctrl_path-v1.py
+++ b/tests/ftests/081-pybindings-cgrp_get_curr_ctrl_path-v1.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgroup_get_current_controller_path() test using the python bindings (cgroup v1)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli, Mode
+from libcgroup import Cgroup, Version
+from process import Process
+import consts
+import ftests
+import sys
+import os
+
+
+CGNAME = '081getctrlpathv1'
+CONTROLLER = 'cpu'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if Cgroup.cgroup_mode() == Mode.CGROUP_MODE_UNIFIED:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the legacy cgroup v1 hierarchy'
+
+    return result, cause
+
+
+def setup(config):
+    CgroupCli.create(config, CONTROLLER, CGNAME)
+
+    config.process.create_process_in_cgroup(config, CONTROLLER, CGNAME, ignore_systemd=True)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    expected_path = "/" + CGNAME
+    pid = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)[0]
+
+    cgrp = Cgroup(CGNAME, Version.CGROUP_V2)
+    #
+    # Test 1 - get the relative path of cgroup, for the pid's cpu controller.
+    #          It's expected to pass because we had created cgroup on cpu
+    #          hierarchy and moved the task to that group.
+    #
+    cgrp_path = cgrp.get_current_controller_path(pid, CONTROLLER)
+    if cgrp_path != expected_path:
+        result = consts.TEST_FAILED
+        cause = 'Expected cgroup path {} got {}'.format(expected_path, cgrp_path)
+
+    #
+    # Test 2 - get the relative path of cgroup, for the pid's memory controller.
+    #          It's expected to fail because we not had created cgroup.
+    #
+    cgrp_path = cgrp.get_current_controller_path(pid, "memory")
+    if cgrp_path == expected_path:
+        result = consts.TEST_FAILED
+        tmp_cause = 'cgroup path unexpectedly formed {}'.format(cgrp_path)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    #
+    # Test 3 - get the relative path of cgroup, for the pid's invalid controller.
+    #          It's expected to fail because such controller doesn't exists.
+    #
+    try:
+        cgrp_path = cgrp.get_current_controller_path(pid, "invalid")
+    except RuntimeError as re:
+        if '50011' not in str(re):
+            raise re
+
+    #
+    # Test 4 - get the relative path of cgroup, for the pid's pass NULL as
+    #          controller. It's expected to fail because it's not supported
+    #          cgroup v1.
+    #
+    try:
+        cgrp_path = cgrp.get_current_controller_path(pid, None)
+    except RuntimeError as re:
+        if '50016' not in str(re):
+            raise re
+
+    #
+    # Test 5 - get the relative path of cgroup, for the pid's pass int as
+    #          controller. It's expected to fail because string is expected
+    #          for the controller name.
+    #
+    try:
+        cgrp_path = cgrp.get_current_controller_path(pid, 1234)
+    except TypeError as re:
+        if 'expected controller type string, but passed' not in str(re):
+            raise re
+
+    return result, cause
+
+
+def teardown(config):
+    pid = CgroupCli.get_pids_in_cgroup(config, CGNAME, CONTROLLER)[0]
+    Process.kill(config, pid)
+
+    CgroupCli.delete(config, CONTROLLER, CGNAME)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/082-pybindings-cgrp_get_curr_ctrl_path-v2.py
+++ b/tests/ftests/082-pybindings-cgrp_get_curr_ctrl_path-v2.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgroup_get_current_controller_path() test using the python bindings (cgroup v2)
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli, Mode
+from libcgroup import Cgroup, Version
+from process import Process
+import consts
+import ftests
+import sys
+import os
+
+
+CGNAME = '082getctrlpathv2'
+CHILDCG = '082getctrlpathv2/childcg'
+CONTROLLER = 'cpu'
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if Cgroup.cgroup_mode() != Mode.CGROUP_MODE_UNIFIED:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the unified cgroup v2 hierarchy'
+
+    return result, cause
+
+
+def setup(config):
+    CgroupCli.create(config, CONTROLLER, CGNAME)
+    CgroupCli.create(config, CONTROLLER, CHILDCG)
+
+    config.process.create_process_in_cgroup(config, CONTROLLER, CHILDCG, ignore_systemd=True)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    expected_path = "/" + CHILDCG
+    pid = CgroupCli.get_pids_in_cgroup(config, CHILDCG, CONTROLLER)[0]
+    cgrp = Cgroup(CGNAME, Version.CGROUP_V2)
+
+    #
+    # Test 1 - get the relative path of cgroup, for the pid's cpu controller.
+    #          It's expected to pass because we had created cgroup on cpu
+    #          hierarchy and moved the task to that group.
+    #
+    cgrp_path = cgrp.get_current_controller_path(pid, CONTROLLER)
+    if cgrp_path != expected_path:
+        result = consts.TEST_FAILED
+        cause = 'Expected cgroup path {} got {}'.format(expected_path, cgrp_path)
+
+    #
+    # Test 2 - get the relative path of cgroup, for the pid's memory controller.
+    #          It's expected to fail because we not had created cgroup.
+    #
+    try:
+        cgrp_path = cgrp.get_current_controller_path(pid, "memory")
+    except RuntimeError as re:
+        if '50001' not in str(re):
+            raise re
+
+    #
+    # Test 3 - get the relative path of cgroup, for the pid's invalid controller.
+    #          It's expected to fail because such controller doesn't exists.
+    #
+    try:
+        cgrp_path = cgrp.get_current_controller_path(pid, "invalid")
+    except RuntimeError as re:
+        if '50011' not in str(re):
+            raise re
+
+    #
+    # Test 4 - get the relative path of cgroup, for the pid's pass NULL as
+    #          controller. It's expected to return the path with children.
+    #
+    cgrp_path = cgrp.get_current_controller_path(pid)
+    if cgrp_path != expected_path:
+        result = consts.TEST_FAILED
+        tmp_cause = 'Expected cgroup path {} got {}'.format(expected_path, cgrp_path)
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    #
+    # Test 5 - get the relative path of cgroup, for the pid's pass int as
+    #          controller. It's expected to fail because string is expected
+    #          for the controller name.
+    #
+    try:
+        cgrp_path = cgrp.get_current_controller_path(pid, 1234)
+    except TypeError as re:
+        if 'expected controller type string, but passed' not in str(re):
+            raise re
+
+    return result, cause
+
+
+def teardown(config):
+    pid = CgroupCli.get_pids_in_cgroup(config, CHILDCG, CONTROLLER)[0]
+    Process.kill(config, pid)
+
+    CgroupCli.delete(config, CONTROLLER, CGNAME, recursive=True)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -102,6 +102,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  079-sudo-cgcreate_default_systemd_scope.py \
 			  080-kernel-domain_invalid.py \
 			  081-pybindings-cgrp_get_curr_ctrl_path-v1.py \
+			  082-pybindings-cgrp_get_curr_ctrl_path-v2.py \
 			  083-pybindings-helpers_cgroup_mode.py \
 			  998-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -101,6 +101,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  078-sudo-cgcreate_systemd_scope.py \
 			  079-sudo-cgcreate_default_systemd_scope.py \
 			  080-kernel-domain_invalid.py \
+			  081-pybindings-cgrp_get_curr_ctrl_path-v1.py \
 			  083-pybindings-helpers_cgroup_mode.py \
 			  998-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist


### PR DESCRIPTION
Add support to read/parse cgroup v2 format `/proc/<pid>/cgroup` to
`cgroup_get_current_controller_path()`. The format of `/proc/<pid>/cgroup`
remains the same:
`hierarchy-ID:controller-list:cgroup-path`

the difference is that in cgroup v2 mode:
- `hierarchy-ID` is always 0 (one hierarchy allowed)
- `controller-list` is empty
    
there can also be a mix of both legacy and unified controllers for a
given task if the cgroup mode is hybrid mode.  This patch, add support
for the mixed cgroup setup mode too.

Closes #335 