### PR TITLE
wrapper: cgroup_add_all_controllers(): fix variable typo

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -170,7 +170,7 @@ int cgroup_add_all_controllers(struct cgroup *cgroup)
 			cgc = cgroup_add_controller(cgroup, controller);
 			if (!cgc) {
 				ret = ECGINVAL;
-				fprintf(stderr, "controller %s can't be added\n", info.name);
+				fprintf(stderr, "controller %s can't be added\n", controller);
 				goto end;
 			}
 		} while ((controller = strtok_r(NULL, " ", &stok_buff)));


### PR DESCRIPTION
Coverity reported uninitialized value:
```
CID 313909 (#1 of 1): Uninitialized scalar variable (UNINIT)8. uninit_use_in_call:
Using uninitialized value *info.name as argument to %s when calling fprintf.
```
In `cgroup_add_all_controllers()`, fix the wrong variable name in the error message,
while parsing the controller name.