### PR TITLE
Add cgroup_setup_mode() helpers

### DIFF
--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -676,6 +676,24 @@ struct cgroup_controller *cgroup_get_controller_by_index(struct cgroup *cgroup, 
 char *cgroup_get_controller_name(struct cgroup_controller *controller);
 
 /**
+ * Return true if cgroup setup mode is cgroup v1 (legacy), else
+ * returns false.
+ */
+bool is_cgroup_mode_legacy(void);
+
+/**
+ * Return true if cgroup setup mode is cgroup v1/v2 (hybrid), else
+ * returns false.
+ */
+bool is_cgroup_mode_hybrid(void);
+
+/**
+ * Return true if cgroup setup mode is cgroup v2 (unified), else
+ * returns false.
+ */
+bool is_cgroup_mode_unified(void);
+
+/**
  * @}
  * @}
  */

--- a/samples/c/Makefile.am
+++ b/samples/c/Makefile.am
@@ -6,7 +6,8 @@ if WITH_SAMPLES
 noinst_PROGRAMS = setuid walk_test read_stats walk_task get_controller	\
 		  get_mount_point proctest get_all_controller		\
 		  get_variable_names test_named_hierarchy		\
-		  get_procs wrapper_test logger empty_cgroup_v2
+		  get_procs wrapper_test logger empty_cgroup_v2		\
+		  get_setup_mode
 
 setuid_SOURCES=setuid.c
 walk_test_SOURCES=walk_test.c
@@ -22,5 +23,6 @@ get_procs_SOURCES=get_procs.c
 wrapper_test_SOURCES=wrapper_test.c
 logger_SOURCES=logger.c
 empty_cgroup_v2_SOURCES=empty_cgroup_v2.c
+get_setup_mode=get_setup_mode.c
 
 endif

--- a/samples/c/get_setup_mode.c
+++ b/samples/c/get_setup_mode.c
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: LGPL-2.1-only
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates
+ *
+ * Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+ *
+ * Description: This file contains the sample code to demonstrate usage of
+ * 		cgroup_setup_mode() API.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <libcgroup.h>
+
+int main(void)
+{
+	enum cg_setup_mode_t setup_mode;
+	int ret;
+
+	ret = cgroup_init();
+	if (ret) {
+		printf("cgroup_init failed with %s\n", cgroup_strerror(ret));
+		exit(1);
+	}
+
+	setup_mode = cgroup_setup_mode();
+	switch(setup_mode) {
+	case CGROUP_MODE_LEGACY:
+		printf("cgroup mode: Legacy\n");
+		break;
+	case CGROUP_MODE_HYBRID:
+		printf("cgroup mode: Hybrid\n");
+		break;
+	case CGROUP_MODE_UNIFIED:
+		printf("cgroup mode: Unified\n");
+		break;
+	default:
+		printf("cgroup mode: Unknown\n");
+		break;
+	}
+
+	return 0;
+}

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -158,4 +158,7 @@ CGROUP_3.0 {
 	cgroup_set_default_systemd_cgroup;
 	cgroup_write_systemd_default_cgroup;
 	cgroup_setup_mode;
+	is_cgroup_mode_legacy;
+	is_cgroup_mode_hybrid;
+	is_cgroup_mode_unified;
 } CGROUP_2.0;

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -157,4 +157,5 @@ CGROUP_3.0 {
 	cgroup_create_scope2;
 	cgroup_set_default_systemd_cgroup;
 	cgroup_write_systemd_default_cgroup;
+	cgroup_setup_mode;
 } CGROUP_2.0;

--- a/src/python/cgroup.pxd
+++ b/src/python/cgroup.pxd
@@ -9,6 +9,7 @@
 # cython: language_level = 3str
 
 from posix.types cimport pid_t, uid_t, gid_t, mode_t
+from libcpp cimport bool
 
 cdef extern from "libcgroup.h":
     cdef struct cgroup:
@@ -107,4 +108,11 @@ cdef extern from "libcgroup.h":
     int cgroup_compare_cgroup(cgroup *cgroup_a, cgroup *cgroup_b)
 
     int cgroup_get_procs(char *name, char *controller, pid_t **pids, int *size)
+
+    bool is_cgroup_mode_legacy()
+
+    bool is_cgroup_mode_hybrid()
+
+    bool is_cgroup_mode_unified()
+
 # vim: set et ts=4 sw=4:

--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -627,6 +627,33 @@ cdef class Cgroup:
 
         return pid_list
 
+    @staticmethod
+    def is_cgroup_mode_legacy():
+        """Check if the current setup mode is legacy (v1)
+
+        Return:
+        True is the mode is legacy, else false
+        """
+        return cgroup.is_cgroup_mode_legacy()
+
+    @staticmethod
+    def is_cgroup_mode_hybrid():
+        """Check if the current setup mode is hybrid (v1/v2)
+
+        Return:
+        True is the mode is hybrid, else false
+        """
+        return cgroup.is_cgroup_mode_hybrid()
+
+    @staticmethod
+    def is_cgroup_mode_unified():
+        """Check if the current setup mode is unified (v2)
+
+        Return:
+        True is the mode is unified, else false
+        """
+        return cgroup.is_cgroup_mode_unified()
+
     def __dealloc__(self):
         cgroup.cgroup_free(&self._cgp);
 

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -793,3 +793,40 @@ char *cgroup_get_cgroup_name(struct cgroup *cgroup)
 
 	return cgroup->name;
 }
+
+
+/*
+ * Return true if cgroup setup mode is cgroup v1 (legacy), else
+ * returns false.
+ */
+bool is_cgroup_mode_legacy(void)
+{
+       enum cg_setup_mode_t setup_mode;
+
+       setup_mode = cgroup_setup_mode();
+       return (setup_mode == CGROUP_MODE_LEGACY);
+}
+
+/*
+ * Return true if cgroup setup mode is cgroup v1/v2 (hybrid), else
+ * returns false.
+ */
+bool is_cgroup_mode_hybrid(void)
+{
+       enum cg_setup_mode_t setup_mode;
+
+       setup_mode = cgroup_setup_mode();
+       return (setup_mode == CGROUP_MODE_HYBRID);
+}
+
+/*
+ * Return true if cgroup setup mode is cgroup v2 (unified), else
+ * returns false.
+ */
+bool is_cgroup_mode_unified(void)
+{
+       enum cg_setup_mode_t setup_mode;
+
+       setup_mode = cgroup_setup_mode();
+       return (setup_mode == CGROUP_MODE_UNIFIED);
+}

--- a/tests/ftests/083-pybindings-helpers_cgroup_mode.py
+++ b/tests/ftests/083-pybindings-helpers_cgroup_mode.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Test to excerise cgroup_setup_mode() helpers
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli
+from libcgroup import Cgroup, Mode
+import consts
+import ftests
+import sys
+import os
+
+
+def prereqs(config):
+    pass
+
+
+def setup(config):
+    pass
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    mode1 = Cgroup.cgroup_mode()
+    mode2 = CgroupCli.get_cgroup_mode(config)
+
+    if mode1 != mode2:
+        result = consts.TEST_FAILED
+        cause = 'mode mismatch: libcgroup mode: {}, tests mode: {}'.format(mode1, mode2)
+        return result, cause
+
+    if mode1 == Mode.CGROUP_MODE_LEGACY:
+        ret = Cgroup.is_cgroup_mode_legacy()
+        if ret is False:
+            result = consts.TEST_FAILED
+            cause = 'mode mismatch: libcgroup mode: legacy (v1) check, returned false'
+    elif mode1 == Mode.CGROUP_MODE_HYBRID:
+        ret = Cgroup.is_cgroup_mode_hybrid()
+        if ret is False:
+            result = consts.TEST_FAILED
+            cause = 'mode mismatch: libcgroup mode: hybrid (v1/v2) check, returned false'
+    elif mode1 == Mode.CGROUP_MODE_UNIFIED:
+        ret = Cgroup.is_cgroup_mode_unified()
+        if ret is False:
+            result = consts.TEST_FAILED
+            cause = 'mode mismatch: libcgroup mode: unified (v2) check, returned false'
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Unknown libcgroup mode: {}'.format(mode1)
+
+    return result, cause
+
+
+def teardown(config):
+    pass
+
+
+def main(config):
+    prereqs(config)
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -101,6 +101,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  078-sudo-cgcreate_systemd_scope.py \
 			  079-sudo-cgcreate_default_systemd_scope.py \
 			  080-kernel-domain_invalid.py \
+			  083-pybindings-helpers_cgroup_mode.py \
 			  998-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py


### PR DESCRIPTION
This patch set exports `cgroup_setup_mode()` and adds following
helpers to check for a cgroup mode, the user might be interested in:
- `is_cgroup_mode_legacy()`
- `is_cgroup_mode_hybrid()`
- `is_cgroup_mode_unified()`

also adds python bindings for the helper functions, along with
test cases to exercise the python bindings.  It also adds a sample
program to demonstrate the usage of `cgroup_setup_mode()`
to the `samples/c/`.