### PR TITLE
cgcreate: add -p <pid> support for systemd scope 

### DIFF
--- a/doc/man/cgcreate.1
+++ b/doc/man/cgcreate.1
@@ -33,7 +33,8 @@ creates a new systemd scope. The cgroup name provided after the
 \fB-g\fR flag must be of the form
 \fB<slice-name>.slice/<scope-name>.scope\fR. If the slice
 does not exist, systemd will create it. Libcgroup will place an
-idle process in the scope's cgroup.procs file.
+idle process in the scope's cgroup.procs file unless the \fB-p\fR
+flag is provided.
 
 .TP
 .B -d, --dperm=mode
@@ -62,6 +63,12 @@ multiple times.
 .TP
 .B -h, --help
 display this help and exit
+
+.TP
+.B -p, --pid=pid
+moves the provided \fBpid\fR into the
+\fB<slice-name>.slice/<scope-name>.scope\fR.  Must be used in
+conjunction with \fB-c\fR.
 
 .TP
 .B -s, --tperm=mode

--- a/tests/ftests/084-sudo-cgcreate_systemd_scope_pid.py
+++ b/tests/ftests/084-sudo-cgcreate_systemd_scope_pid.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Test to create a systemd scope with pid using cgcreate
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup
+from process import Process
+from libcgroup import Mode
+from run import RunError
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLERS = ['cpu', 'pids']
+SLICE = 'libcgroup.slice'
+CGNAME1 = os.path.join(SLICE, '084cgcreate1.scope')
+CGNAME2 = os.path.join(SLICE, '084cgcreate2.scope')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if Cgroup.get_cgroup_mode(config) != Mode.CGROUP_MODE_UNIFIED:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the unified cgroup hierarchy'
+
+    return result, cause
+
+
+def setup(config):
+    pass
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    #
+    # Test 1: Pass invalid task pid as scope_pid and systemd scope creation
+    #         should fail
+    #
+    try:
+        Cgroup.create_and_validate(config, CONTROLLERS, CGNAME1, create_scope=True,
+                                   scope_pid=1000000)
+    except RunError as re:
+        if 'Process with ID 1000000 does not exist' not in str(re):
+            raise re
+
+    #
+    # Test 2: Pass a valid task pid as scope_pid and systemd scope creation
+    #         will succeed. Read the scope cgroup.procs to find if the task
+    #         passed by us was used as scope task.
+    #
+    scope_pid = config.process.create_process(config)
+    Cgroup.create_and_validate(config, CONTROLLERS, CGNAME1, create_scope=True, scope_pid=scope_pid)
+
+    try:
+        pid = Cgroup.get_pids_in_cgroup(config, CGNAME1, CONTROLLERS[0])[0]
+        if scope_pid != pid:
+            result = consts.TEST_FAILED
+            cause = 'scope created with other pid {}, expected pid {}'.format(pid, scope_pid)
+            return result, cause
+    except RunError:
+        result = consts.TEST_FAILED
+        cause = 'Failed to read pid in {}\'s cgroup.procs'.format(CGNAME1)
+        return result, cause
+
+    #
+    # Test 3: Pass the already created task pid as scope_pid for a new systemd
+    #         scope.  This would mean the CGNAME1 should be killed and the pid
+    #         should be the default scope task of CGNAME2
+    Cgroup.create_and_validate(config, CONTROLLERS, CGNAME2, create_scope=True, scope_pid=scope_pid)
+
+    # CGNAME1 should be deleted by the systemd.
+    try:
+        pid = Cgroup.get_pids_in_cgroup(config, CGNAME1, CONTROLLERS[0])[0]
+    except RunError as re:
+        if 'No such file or directory' not in re.stderr:
+            raise re
+    else:
+        result = consts.TEST_FAILED
+        cause = 'Erroneously succeeded reading cgroup.procs in {}'.format(CGNAME1)
+        return result, cause
+
+    try:
+        pid = Cgroup.get_pids_in_cgroup(config, CGNAME2, CONTROLLERS[0])[0]
+        if scope_pid != pid:
+            result = consts.TEST_FAILED
+            cause = 'scope created with other pid {}, expected pid {}'.format(pid, scope_pid)
+            return result, cause
+    except RunError:
+        result = consts.TEST_FAILED
+        cause = 'Failed to read pid in {}\'s cgroup.procs'.format(CGNAME2)
+
+    return result, cause
+
+
+def teardown(config):
+    pid = int(Cgroup.get(config, None, CGNAME2, setting='cgroup.procs',
+                         print_headers=False, values_only=True, ignore_systemd=True))
+    Process.kill(config, pid)
+
+    # systemd will automatically remove the cgroup once there are no more pids in
+    # the cgroup, so we don't need to delete CGNAME2.  But let's try to remove the
+    # slice
+    try:
+        Cgroup.delete(config, CONTROLLERS, SLICE)
+    except RunError:
+        pass
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/Makefile.am
+++ b/tests/ftests/Makefile.am
@@ -104,6 +104,7 @@ EXTRA_DIST_PYTHON_TESTS = \
 			  081-pybindings-cgrp_get_curr_ctrl_path-v1.py \
 			  082-pybindings-cgrp_get_curr_ctrl_path-v2.py \
 			  083-pybindings-helpers_cgroup_mode.py \
+			  084-sudo-cgcreate_systemd_scope_pid.py \
 			  998-cgdelete-non-existing-shared-mnt-cgroup-v1.py
 # Intentionally omit the stress test from the extra dist
 # 999-stress-cgroup_init.py

--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -127,7 +127,8 @@ class Cgroup(object):
     def create(config, controller_list, cgname, user_name=None,
                group_name=None, dperm=None, fperm=None, tperm=None,
                tasks_user_name=None, tasks_group_name=None, cghelp=False,
-               ignore_systemd=False, create_scope=False, set_default_scope=False):
+               ignore_systemd=False, create_scope=False, set_default_scope=False,
+               scope_pid=-1):
         if isinstance(controller_list, str):
             controller_list = [controller_list]
 
@@ -174,6 +175,12 @@ class Cgroup(object):
         if set_default_scope:
             cmd.append('-S')
 
+        # -p requires -c to be provided, but this is too checked in libcgroup itself
+
+        if scope_pid > 1:
+            cmd.append('-p')
+            cmd.append('{}'.format(scope_pid))
+
         if controller_list:
             controllers_and_path = '{}:{}'.format(
                 ','.join(controller_list), cgname)
@@ -200,9 +207,10 @@ class Cgroup(object):
     # True if the cgroup exists, False otherwise
     @staticmethod
     def create_and_validate(config, ctrl_name, cgroup_name, ignore_systemd=False,
-                            create_scope=False, set_default_scope=False):
+                            create_scope=False, set_default_scope=False, scope_pid=-1):
         Cgroup.create(config, ctrl_name, cgroup_name, ignore_systemd=ignore_systemd,
-                      create_scope=create_scope, set_default_scope=set_default_scope)
+                      create_scope=create_scope, set_default_scope=set_default_scope,
+                      scope_pid=scope_pid)
         return Cgroup.exists(config, ctrl_name, cgroup_name, ignore_systemd=ignore_systemd)
 
     @staticmethod


### PR DESCRIPTION
Currently, an idle_thread is created for the transient systemd scope by
default, it works fine, when the slice/scope creation is treated in par
to create of traditional cgroup, but the user may wish to create a
slice/scope, with a process of their choice, instead of a default idle
thread.  This patchset adds support to pass task pid via `-p`  option,
while creating a systemd slice/scope.  Also, adds support for ftest
cgroup to accept pid during scope creation and the ftest test case
to exercise it.