### PR TITLE
api: cgroup_get_current_controller_path: fix a segfault

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -4816,6 +4816,9 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller, char *
 		return ECGROUPNOTINITIALIZED;
 	}
 
+	if (!current_path)
+		return ECGOTHER;
+
 	mode = cgroup_setup_mode();
 	if (mode == CGROUP_MODE_LEGACY && !controller)
 		return ECGOTHER;


### PR DESCRIPTION
`cgroup_get_current_controller_path(pid, controller, current_path)`, the third
argument isn't currently validated and will cause segfault if the user passes
`NULL`, in place of expected `char **`.  Introduce a check to validate
`current_path` argument too.
```
Reproducer:
___________
 #include <stdio.h>
 #include <stdlib.h>
 #include <libcgroup.h>

 int main(int argc, char **argv)
 {
 	pid_t pid;
 	int ret;

 	ret = cgroup_init();
 	if (ret) {
 		printf("cgroup initialization failed:%s\n", cgroup_strerror(ret));
 		return ret;
 	}

	ret = cgroup_get_current_controller_path(atoi(argv[1]), NULL, NULL);
	/* should not reach here */
	return 0;
 }

 # gcc -o rep rep.c
 # ./rep <valid pid>
 Segmentation fault (core dumped)
```