### PR TITLE
fix: include paths for out-of-source builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,7 @@ AM_YFLAGS = -d
 
 CLEANFILES = lex.c parse.c parse.h
 
-AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
 
 VERSION_NUMBER = $(LIBRARY_VERSION_MAJOR):$(LIBRARY_VERSION_MINOR):$(LIBRARY_VERSION_RELEASE)
 TESTING_MAP_FILE = $(top_srcdir)/tests/gunit/libcgroup_unittest.map

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -1,6 +1,6 @@
 @CODE_COVERAGE_RULES@
 
-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include -I$(top_builddir)/include
 
 if WITH_DAEMON
 

--- a/src/pam/Makefile.am
+++ b/src/pam/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I $(top_srcdir)/include
+AM_CPPFLAGS = -I $(top_srcdir)/include -I$(top_builddir)/include
 
 if WITH_PAM
 

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -9,7 +9,7 @@
 
 PY_DISTUTILS = \
 	VERSION_RELEASE="@PACKAGE_VERSION@" \
-	CPPFLAGS="-I\${top_srcdir}/include ${AM_CPPFLAGS} ${CPPLAGS} -O2" \
+	CPPFLAGS="-I\${top_srcdir}/include -I\${top_builddir}/include ${AM_CPPFLAGS} ${CPPLAGS} -O2" \
 	CFLAGS="$(CODE_COVERAGE_CFLAGS) ${AM_CFLAGS} ${CFLAGS}" \
 	LDFLAGS="$(CODE_COVERAGE_LIBS) ${AM_LDFLAGS} ${LDFLAGS}" \
 	${PYTHON} ${srcdir}/setup.py

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -1,6 +1,6 @@
 @CODE_COVERAGE_RULES@
 
-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include -I$(top_builddir)/include
 LDADD = $(top_builddir)/src/libcgroup.la -lpthread
 
 if WITH_TOOLS


### PR DESCRIPTION
This is so the generated libcgroup/init.h is found when not building in the source tree.