### PR TITLE
fix: repaid build for --disable-systemd

### DIFF
--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -96,7 +96,7 @@ err:
 }
 #else
 static int create_systemd_scope(struct cgroup * const cg, const char * const prog_name,
-				int set_default)
+				int set_default, pid_t pid)
 {
 	return ECGINVAL;
 }


### PR DESCRIPTION
Ensure that the prototypes of `create_systemd_scope` match for both `WITH_SYSTEMD` and `!WITH_SYSTEMD`.