### PR TITLE
samples/Makefile: introduce systemd dependency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -124,8 +124,8 @@ jobs:
       run: |
         cat libcgroup-*/_build/sub/tests/ftests/ftests-wrapper.sh.log
 
-  withoutsystemd:
-    name: Systemd Support Disabled
+  buildtests:
+    name: Build tests
     runs-on: ubuntu-20.04
 
     steps:
@@ -141,22 +141,12 @@ jobs:
       run: CFLAGS="$CFLAGS -Werror" ./configure --sysconfdir=/etc --localstatedir=/var --enable-code-coverage --enable-opaque-hierarchy="name=systemd" --enable-python --enable-systemd=no
     - name: Build the library
       run: make
-
-  buildsamples:
-    name: Build Samples
-    runs-on: ubuntu-20.04
-
-    steps:
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-    - uses: actions/checkout@v3
-      with:
-        submodules: false
-    - name: Initialize the directory
-      uses: ./.github/actions/setup-libcgroup
     - name: Reconfigure libcgroup with samples enabled
       run: CFLAGS="$CFLAGS -Werror" ./configure --sysconfdir=/etc --localstatedir=/var --enable-code-coverage --enable-opaque-hierarchy="name=systemd" --enable-python --enable-samples
+    - name: Build the library
+      run: make
+    - name: Reconfigure libcgroup with systemd disabled and samples enabled
+      run: CFLAGS="$CFLAGS -Werror" ./configure --sysconfdir=/etc --localstatedir=/var --enable-code-coverage --enable-opaque-hierarchy="name=systemd" --enable-python --enable-systemd=no --enable-samples
     - name: Build the library
       run: make
 

--- a/samples/c/Makefile.am
+++ b/samples/c/Makefile.am
@@ -7,7 +7,11 @@ noinst_PROGRAMS = setuid walk_test read_stats walk_task get_controller	\
 		  get_mount_point proctest get_all_controller		\
 		  get_variable_names test_named_hierarchy		\
 		  get_procs wrapper_test logger empty_cgroup_v2		\
-		  get_setup_mode create_systemd_scope
+		  get_setup_mode
+
+if WITH_SYSTEMD
+noinst_PROGRAMS += create_systemd_scope
+endif
 
 setuid_SOURCES=setuid.c
 walk_test_SOURCES=walk_test.c


### PR DESCRIPTION
Some of the `samples` programs depend on `systemd` to be
enabled during configuration.  Add this dependency to the
`Makefile` so that the samples are built according to the current
configuration options.  This patch also, folds different CI workflow
build tests into single step and adds `systemd=no, samples=yes`
case too.