### PR TITLE
config.c: fix memory leak in convert_controller_versions()

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -852,7 +852,8 @@ next_controller:
 		cgroup_free_controller(cgc);
 		cgrp_cpy->index = 0;
 	}
-	return 0;
+
+	ret = 0;
 err:
 	cgroup_free(&convert_cgrp);
 	cgroup_free(&cgrp_cpy);


### PR DESCRIPTION
Fix memory leak warning in convert_controller_versions(), reported by Coverity tool:

CID 313911 (#1 of 1): Resource leak (RESOURCE_LEAK)9. leaked_storage:
Variable cgrp_cpy going out of scope leaks the storage it points to.

struct cgroup cgrp_cpy was not freed in the success path, fix it.