### PR TITLE
ftests-999: fix random dir name generation logic

### DIFF
--- a/tests/ftests/999-stress-cgroup_init.py
+++ b/tests/ftests/999-stress-cgroup_init.py
@@ -17,9 +17,9 @@ import sys
 import os
 
 MNT_COUNT = 101
-MNT_POINT = '/tmp/999stress/'
+MNT_POINT = '/tmp/'
 DIR_PREFIX = 'name'
-RANDOM_DIR = ''.join(random.choices(string.ascii_letters, k=5))
+RANDOM_DIR = ''.join(random.choices(string.ascii_letters, k=5)) + '-999stress'
 
 
 def cgroup_path(count):
@@ -33,7 +33,6 @@ def prereqs(config):
 def setup(config):
     cmd = ['sudo', 'mkdir']
 
-    cmd.append(MNT_POINT)
     cmd.append(MNT_POINT + RANDOM_DIR)
 
     for count in range(MNT_COUNT):
@@ -78,7 +77,6 @@ def teardown(config):
         cmd.append(cgroup_path(count))
 
     cmd.append(MNT_POINT + RANDOM_DIR)
-    cmd.append(MNT_POINT)
 
     # execute rmdir top-level top-level/sub-directory* at once.
     Run.run(cmd)


### PR DESCRIPTION
The current logic of creating a random directory under the `/tmp/`
the directory is incorrect because the random directory is generated
under `/tmp/999stress`, making it a common parent directory, and
attempting to create/delete it will fail the test instance, that overlaps.
Fix this by generating `/tmp/<random-999stress>` making it unique
per run.

```
----------------------------------------------------------------- 
Test Results:
        Run Date:                          Jun 12 11:39:41
        Passed:                                  1 test(s)
        Skipped:                                 0 test(s)
        Failed:                                  0 test(s)
-----------------------------------------------------------------
Timing Results:
        Test                          Time (sec)
        ----------------------------------------
        setup                               0.00
        999-stress-cgroup_init.py           1.55
        teardown                            0.00
        ----------------------------------------
        Total Run Time                      1.55
```
Fixes: b81915a1fbe7 ("tests-999: add a random directory to mount path")