### PR TITLE
wrapper: fix missing unlock() in cgroup_add_all_controllers()

### DIFF
--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -136,6 +136,7 @@ int cgroup_add_all_controllers(struct cgroup *cgroup)
 
 		pthread_rwlock_rdlock(&cg_mount_table_lock);
 		if (strlen(cg_cgroup_v2_mount_path) == 0) {
+			pthread_rwlock_unlock(&cg_mount_table_lock);
 			ret = ECGOTHER;
 			goto out;
 		}


### PR DESCRIPTION
Fix missing unlock(), reported by the Coverity tool:

CID 313906 (#1 of 1): Missing unlock (LOCK)6. missing_unlock: Returning 
without unlocking cg_mount_table_lock

add the missing `pthread_rwlock_unlock()` in the error path of the
`cgroup_add_all_controllers()`

Fixes: 4124f4d6853a ("wrapper: Add cgroup v2 support to cgroup_add_all_controllers()")