### PR TITLE
tools/cgexec: fix memory leak in find_scope_pid()

### DIFF
--- a/src/tools/cgexec.c
+++ b/src/tools/cgexec.c
@@ -335,6 +335,8 @@ static pid_t find_scope_pid(pid_t pid)
 		 * have libcgroup_systemd_idle_thread
 		 */
 		_scope_pid = search_systemd_idle_thread_task(pids, size);
+		free(pids);
+
 		if (_scope_pid == -1)
 			continue;
 


### PR DESCRIPTION
Fix a memory leak, reported by the Coverity tool.

CID 321265 (#1-2 of 2): Resource leak (RESOURCE_LEAK)37.
leaked_storage: Variable pids going out of scope leaks the storage it points to.

`find_scope_pid ()`, calls `cgroup_get_procs()` to get the pids of the tasks under
cgroup name, and it's up to the caller to free the allocated pids. Fix it by calling
`free(pids)` after every call to `cgroup_get_procs()`.