### PR TITLE
tools/cgexec: fix uninitialized variable in find_scope_pid()

### DIFF
--- a/src/tools/cgexec.c
+++ b/src/tools/cgexec.c
@@ -284,6 +284,8 @@ static pid_t find_scope_pid(pid_t pid)
 	}
 
 	while (fgets(buffer, FILENAME_MAX, pid_proc_fp)) {
+		memset(ctrl_name, '\0', sizeof(CONTROL_NAMELEN_MAX));
+
 		/* read according to the cgroup mode */
 		if (strstr(buffer, "::"))
 			ret = sscanf(buffer, "%d::%4096s\n", &idx, cgroup_name);


### PR DESCRIPTION
Fix uninitialized variable, reported by the Coverity tool:

CID 321266: Uninitialized scalar variable (UNINIT)

`memset()`, `ctrl_name` with every iteration, to avoid using the
stale value or uninitialized values.