### PR TITLE
cgcreate: fix null pointer dereference in create_systemd_scope()

### DIFF
--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -71,6 +71,12 @@ static int create_systemd_scope(struct cgroup * const cg, const char * const pro
 	ret = cgroup_create_scope2(cg, 0, &opts);
 	if (!ret && set_default) {
 		scope = strstr(cg->name, "/");
+		if (!scope) {
+			err("%s: Invalid scope name %s, expected <slice>/<scope>\n",
+			    prog_name, cg->name);
+			ret = ECGINVAL;
+			goto err;
+		}
 		len = strlen(cg->name) - strlen(scope);
 		strncpy(slice, cg->name, len);
 		slice[len] = '\0';


### PR DESCRIPTION
Fix a possible NULL pointer dereference, reported by the Coverity tool:

CID 321267 (#1 of 1): Dereference null return value (NULL_RETURNS)6.
dereference: Dereferencing a pointer that might be NULL scope when
calling strlen.

check for the return value from `strstr()`, before dereferencing it.