### PR TITLE
api: add ret value check in cgroup_get_current_controller_path()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -4914,8 +4914,9 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller, char *
 				 * line, skip this line.
 				 */
 				if (unified) {
-					fscanf(pid_cgroup_fd, "%*[^\n]\n");
-					continue;
+					ret = fscanf(pid_cgroup_fd, "%*[^\n]\n");
+					if (ret == 0)
+						continue;
 				}
 
 				cgroup_warn("read failed for pid_cgroup_fd ret %d\n", ret);


### PR DESCRIPTION
Fix unchecked return value, reported by the Coverity tool:

CID 320874 (#1 of 1): Unchecked return value from library
(CHECKED_RETURN)13. check_return: Calling fscanf(pid_cgroup_fd,
"%*[^\n]\n") without checking return value. This library function may
fail and return an error code.

add the missing return value check from `fscanf()` in 
`cgroup_get_current_controller_path()`