### PR TITLE
api: fix build warning

### DIFF
--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -78,7 +78,7 @@ static int create_systemd_scope(struct cgroup * const cg, const char * const pro
 			goto err;
 		}
 		len = strlen(cg->name) - strlen(scope);
-		strncpy(slice, cg->name, len);
+		strncpy(slice, cg->name, FILENAME_MAX - 1);
 		slice[len] = '\0';
 		scope++;
 


### PR DESCRIPTION
Fix a build warning:
```
cgcreate.c: In function ‘create_systemd_scope’:
cgcreate.c:81:17: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-truncation]
   81 |                 strncpy(slice, cg->name, len);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cgcreate.c:80:23: note: length computed here
   80 |                 len = strlen(cg->name) - strlen(scope);

```
fix it by using, length of destination in the strncpy().