### PR TITLE
cgcreate: cgget: Fix help spacing

### DIFF
--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -45,7 +45,7 @@ static void usage(int status, const char *program_name)
 	info("  -b				Ignore default systemd");
 	info("delegate hierarchy\n");
 	info("  -c, --scope			Create a delegated systemd scope\n");
-	info("  -p, --pid=pid                   Task pid to use to create systemd ");
+	info("  -p, --pid=pid			Task pid to use to create systemd ");
 	info("scope\n");
 	info("  -S, --setdefault		Set this scope as the default scope ");
 	info("delegate hierarchy\n");

--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -50,7 +50,7 @@ static void usage(int status, const char *program_name)
 #ifdef WITH_SYSTEMD
 	info("  -b				Ignore default systemd delegate hierarchy\n");
 #endif
-	info("  -c                              Display controller version\n");
+	info("  -c				Display controller version\n");
 }
 
 static int get_controller_from_name(const char * const name, char **controller)


### PR DESCRIPTION
Fix spacing in cgcreate and cgget help where spaces were used instead of tabs.