### PR TITLE
python: remove unused var in Cgroup::add_setting()

### DIFF
--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -196,7 +196,6 @@ cdef class Cgroup:
         Does not modify the cgroup sysfs
         """
         cdef cgroup.cgroup_controller *cgcp
-        cdef char * value
 
         ctrl_name = setting_name.split('.')[0]
 


### PR DESCRIPTION
In Cgroup::add_setting(), remove unused variable 'value'