### PR TITLE
tools/cgclassify: fix controller overflow array range

### DIFF
--- a/src/tools/cgclassify.c
+++ b/src/tools/cgclassify.c
@@ -41,7 +41,7 @@ static int rollback_pid_cgroups(pid_t pid);
 struct cgroup_info {
 	char ctrl_name[CONTROL_NAMELEN_MAX];
 	char cgrp_path[FILENAME_MAX];
-}info[MAX_MNT_ELEMENTS];
+}info[MAX_MNT_ELEMENTS + 1];
 
 static void usage(int status, const char *program_name)
 {


### PR DESCRIPTION
Fix out-of-bounds write issue, reported by Coverity tool:

CID 321270 (#1 of 1): Out-of-bounds write (OVERRUN)47. overrun-local:
Overrunning array info of 16 4128-byte elements at element index 16
(byte offset 70175) using index i (which evaluates to 16).

MAX_MNT_ELEMENTS is an array that's allocated for array parsing and
populating the mount points, as per Linux Kernel, this can't be above
16 and it works fine while checking for index < MAX_MNT_ELEMENTS, but
in this case, we rely on the mount point name to be empty ('\0'), since the
allowed maximum mount points are 16, increase the allocation index to
17 for the info structure, to accommodate 16 controllers, but that is unlikely.