### PR TITLE
api: fix missing goto in cgroup_get_current_controller_path()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -4936,6 +4936,7 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller, char *
 			if (!*current_path) {
 				last_errno = errno;
 				ret = ECGOTHER;
+				goto done;
 			}
 			ret = 0;
 			goto done;


### PR DESCRIPTION
Fix missing goto on error in `cgroup_get_current_controller_path()`,
it was reported by Coverity tool as unused value:

CID 320875 (#1 of 1): Unused value (UNUSED_VALUE)assigned_value:
Assigning value ECGOTHER to ret here, but that stored value is overwritten
before it can be used.

It turns out that, it is more than an over-written value, the `strdup()` was
missing goto error path statement on failure, add it.