### PR TITLE
tools/cgxget: fix unused value in main

### DIFF
--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -861,13 +861,13 @@ int main(int argc, char *argv[])
 		cgroup_set_default_systemd_cgroup();
 
 	ret = convert_cgroups(&cg_list, cg_list_len, version, CGROUP_DISK);
-	if (ret == ECGNOVERSIONCONVERT && ignore_unmappable)
+	if ((ret && ret != ECGNOVERSIONCONVERT) ||
+	    (ret == ECGNOVERSIONCONVERT && !ignore_unmappable))
 		/*
-		 * The user has specified that we should ignore any errors
-		 * due to being unable to map from v1 to v2 or vice versa
+		 * If the user not has specified that we ignore any errors
+		 * due to being unable to map from v1 to v2 or vice versa,
+		 * return error, else ignore the error and continue.
 		 */
-		ret = 0;
-	else if (ret)
 		goto err;
 
 	ret = get_values(cg_list, cg_list_len);


### PR DESCRIPTION
Fix unused value, reported by the Coverity tool:

CID 320879 (#1 of 1): Unused value (UNUSED_VALUE)assigned_value:
Assigning value 0 to ret here, but that stored value is overwritten before
it can be used.

If the mapping from v1->v2 and vice versa fail, with `-i (ignore-unmappable)`
set, ret is set to zero and is immediately over-written, re-arrange the check,
and adjust the commentary to avoid clobbering ret, by taking the error path
when `-i` is unset or else continuing when set, skipping to set ret to zero.