### PR TITLE
api: cg_move_task_files() - rearrange code to avoid extra check

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -3166,12 +3166,8 @@ static int cg_move_task_files(FILE *input_tasks, FILE *output_tasks)
 			break;
 
 		ret = fprintf(output_tasks, "%d", tids);
-		if (ret < 0) {
-			if (errno == ESRCH)
-				ret = 0;
-			else
-				break;
-		}
+		if (ret < 0 && errno != ESRCH)
+			break;
 
 		/* Flush the file, we need only one process per write() call. */
 		ret = fflush(output_tasks);


### PR DESCRIPTION
Fix unused variables, reported by the Coverity tool:

CID 320878 (#1 of 1): Unused value (UNUSED_VALUE)assigned_value:
Assigning value 0 to ret here, but that stored value is overwritten before
it can be used.

Currently, in `cg_move_task_files()`, the ret is checked for `ESRCH` and
set to zero, if true, and for other error values it executes the error path
but immediately the ret is over-written without reading the set zero,
re-arrange the code to such that only the error path is executed and
ret is not set to zero.