### PR TITLE
tools: cgconfig/cgrulesengd - skip parsing non .conf files

### DIFF
--- a/src/tools/tools-common.c
+++ b/src/tools/tools-common.c
@@ -207,7 +207,15 @@ int cgroup_string_list_add_directory(struct cgroup_string_list *list, char *dirn
 		errno = 0;
 		item = readdir(d);
 		if (item && (item->d_type == DT_REG || item->d_type == DT_LNK)) {
-			char *tmp;
+			char *tmp, *file_ext;
+
+			/* we are interested in .conf files, skip others */
+			file_ext = strstr(item->d_name, ".conf");
+			if (!file_ext)
+				continue;
+
+			if (strcmp(file_ext, ".conf") || strlen(item->d_name) == 5)
+				continue;
 
 			ret = asprintf(&tmp, "%s/%s", dirname, item->d_name);
 			if (ret < 0) {


### PR DESCRIPTION
Currently, the list of files to be parsed is constructed by reading the
directories passed with `-L` command line option or by cgrulesend
from `/etc/cgconfig.d`.  The directories might also host non-configuration
files, parsing them will result in failure.

Consider the following example:
```
 # ls /etc/cgconfig.d
 cgconfig-oradb.conf  cgconfig-oradb.conf.rpmsave

 # /usr/sbin/cgconfigparser -l /etc/cgconfig.conf -L /etc/cgconfig.d -s 1664
 /usr/sbin/cgconfigparser; error loading /etc/cgconfig.d/cgconfig-oradb.conf.rpmsave:
 Cgroup, the requested group parameter does not exist
```
fix it by skipping files with non .conf extensions, while building the list
of files to be parsed for cgroup configurations.