### PR TITLE
[RFC] Introduce cython-lint

### DIFF
--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -219,7 +219,7 @@ cdef class Cgroup:
                 raise RuntimeError("Failed to get controller {}".format(
                                    ctrl_name))
 
-        if setting_value == None:
+        if setting_value is None:
             ret = cgroup.cgroup_add_value_string(cgcp,
                       c_str(setting_name), NULL)
         else:
@@ -377,7 +377,7 @@ cdef class Cgroup:
         mount_points = []
         ret = cgroup.cgroup_list_mount_points(version, &a)
         if ret is not 0:
-            raise RuntimeError("cgroup_list_mount_points failed: {}".format(ret));
+            raise RuntimeError("cgroup_list_mount_points failed: {}".format(ret))
 
         i = 0
         while a[i]:
@@ -812,6 +812,6 @@ cdef class Cgroup:
         cgroup.cgroup_set_default_logger(log_level)
 
     def __dealloc__(self):
-        cgroup.cgroup_free(&self._cgp);
+        cgroup.cgroup_free(&self._cgp)
 
 # vim: set et ts=4 sw=4:

--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -11,7 +11,7 @@
 """ Python bindings for the libcgroup library
 """
 
-__author__ =  'Tom Hromatka <tom.hromatka@oracle.com>'
+__author__ = 'Tom Hromatka <tom.hromatka@oracle.com>'
 __date__ = "25 October 2021"
 
 from posix.types cimport pid_t, mode_t
@@ -47,12 +47,15 @@ cdef class LogLevel:
     CGROUP_LOG_INFO = cgroup.CGROUP_LOG_INFO
     CGROUP_LOG_DEBUG = cgroup.CGROUP_LOG_DEBUG
 
+
 def c_str(string):
     return bytes(string, "ascii")
+
 
 def indent(in_str, cnt):
     leading_indent = cnt * ' '
     return ''.join(leading_indent + line for line in in_str.splitlines(True))
+
 
 class Controller:
     def __init__(self, name):
@@ -81,6 +84,7 @@ class Controller:
             return False
 
         return True
+
 
 cdef class Cgroup:
     """ Python object representing a libcgroup cgroup """

--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -18,7 +18,6 @@ from posix.types cimport pid_t, mode_t
 from libc.stdlib cimport malloc, free
 from libc.string cimport strcpy
 cimport cgroup
-import os
 
 CONTROL_NAMELEN_MAX = 32
 

--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -161,7 +161,6 @@ cdef class Cgroup:
         Does not modify the cgroup sysfs
         """
         cdef cgroup.cgroup_controller * cgcp
-        cdef cgroup.cgroup * cgp
 
         cgcp = cgroup.cgroup_add_controller(self._cgp,
                                             c_str(ctrl_name))

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.cython-lint]
+max-line-length = 100
+# E128 - continuation line under-indented for visual indent
+ignore = ['E128']


### PR DESCRIPTION
This patch series fixes issues reported by [Cython-lint](https://github.com/MarcoGorelli/cython-lint) tool, for the files under `src/python`
and also add a configuration file to ignore warnings from the tool:
- Warn only if the line is greater than 100 characters
- E128 - ignore errors of visual indentation.