### PR TITLE
python: Rename __set_default_systemd_cgroup()

### DIFF
--- a/src/python/libcgroup.pyx
+++ b/src/python/libcgroup.pyx
@@ -570,7 +570,7 @@ cdef class Cgroup:
             raise RuntimeError("cgroup_create_scope2 failed: {}".format(ret))
 
     @staticmethod
-    def __set_default_systemd_cgroup():
+    def _set_default_systemd_cgroup():
         """Set systemd_default_cgroup
 
         Arguments:
@@ -619,7 +619,7 @@ cdef class Cgroup:
             raise RuntimeError("Failed to write the default slice/scope")
 
         if set_default:
-            Cgroup.__set_default_systemd_cgroup()
+            Cgroup._set_default_systemd_cgroup()
 
     @staticmethod
     def clear_default_systemd_scope():
@@ -636,7 +636,7 @@ cdef class Cgroup:
             pass
 
         try:
-            Cgroup.__set_default_systemd_cgroup()
+            Cgroup._set_default_systemd_cgroup()
         except RuntimeError:
             pass
 

--- a/tests/ftests/071-sudo-set_default_systemd_cgroup.py
+++ b/tests/ftests/071-sudo-set_default_systemd_cgroup.py
@@ -45,11 +45,11 @@ def test(config):
     cause = None
 
     #
-    # Test 1 - Ensure __set_default_systemd_cgroup() throws an exception if
+    # Test 1 - Ensure _set_default_systemd_cgroup() throws an exception if
     #          libcgroup doesn't set a default (slice/scope) cgroup path
     #
     try:
-        Cgroup.__set_default_systemd_cgroup()
+        Cgroup._set_default_systemd_cgroup()
     except RuntimeError as re:
         if 'Failed to set' not in str(re):
             result = consts.TEST_FAILED
@@ -57,7 +57,7 @@ def test(config):
                     'received {}'.format(str(re))
     else:
         result = consts.TEST_FAILED
-        cause = '__set_default_systemd_cgroup() erroneously passed'
+        cause = '_set_default_systemd_cgroup() erroneously passed'
 
     #
     # Test 2 - write_default_systemd_scope() should succeed if the slice/scope


### PR DESCRIPTION
Rename __set_default_systemd_cgroup() to _set_default_systemd_cgroup() to avoid Python name mangling