### PR TITLE
api.c: fix unused variable in cgroup_parse_rules_file()

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -596,10 +596,10 @@ static int cgroup_parse_rules_file(char *filename, bool cache, uid_t muid, gid_t
 	struct cgroup_rule *newrule = NULL;
 
 	/* Structure to get GID from group name */
-	struct group *grp = NULL;
+	struct group *grp;
 
 	/* Structure to get UID from user name */
-	struct passwd *pwd = NULL;
+	struct passwd *pwd;
 
 	/* Temporary storage for a configuration rule */
 	char key[CGROUP_RULE_MAXKEY] = { '\0' };
@@ -665,6 +665,10 @@ static int cgroup_parse_rules_file(char *filename, bool cache, uid_t muid, gid_t
 			cgroup_warn("skipped child of invalid rule, line %d.\n", linenum);
 			continue;
 		}
+
+		/* clear the buffer. */
+		grp = NULL;
+		pwd = NULL;
 
 		/*
 		 * If there is something left, it should be a rule.  Otherwise,
@@ -883,10 +887,6 @@ static int cgroup_parse_rules_file(char *filename, bool cache, uid_t muid, gid_t
 		for (i = 0; lst->tail->controllers[i]; i++)
 			cgroup_dbg(" %s", lst->tail->controllers[i]);
 		cgroup_dbg("\n");
-
-		/* Finally, clear the buffer. */
-		grp = NULL;
-		pwd = NULL;
 	}
 
 	/* If we make it here, there were no errors. */


### PR DESCRIPTION
Fix an unused variable warning, reported by the Coverity tool:

CID 320877 (#1 of 1): Unused value (UNUSED_VALUE) assigned_pointer:
Assigning value NULL to pwd here, but that stored value is overwritten
before it can be used.

Move the `grp, pwd` variables assignment to the beginning of the while
loop in the `cgroup_parse_rules_file().

```
Tested with following cgrules
-----------------------------
$ cat /etc/cgrules.conf
student         devices         /usergroup/students
@admin          *               admingroup/
peter           cpu             test1/
%               memory          test2/
*               *               default/

$ sudo CGROUP_LOGLEVEL=DEBUG ./src/daemon/cgrulesengd -d -n Parsing configuration file /etc/cgrules.conf.
Added rule student (UID: 1001, GID: -1) -> /usergroup/students for controllers: devices
Added rule @admin (UID: -1, GID: 1004) -> admingroup/ for controllers: *
Added rule peter (UID: 1003, GID: -1) -> test1/ for controllers: CPU
Added rule % (UID: 1003, GID: -1) -> test2/ for controllers: memory
Added rule * (UID: -2, GID: -2) -> default/ for controllers: *
Parsing of configuration file complete.
```