### PR TITLE
tools/cgsnapshot: fix string null terminate in parse_controllers()

### DIFF
--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -529,8 +529,7 @@ static int is_ctlr_on_list(char controllers[CG_CONTROLLER_MAX][FILENAME_MAX],
 
 	/* Lets reset the controllers to intersection of controller ∩ wanted_conts */
 	for (i = 0; tmp_controllers[i][0] != '\0'; i++) {
-		strncpy(controllers[i], tmp_controllers[i], FILENAME_MAX - 1);
-		(controllers[i])[FILENAME_MAX - 1] = '\0';
+		snprintf(controllers[i], FILENAME_MAX, "%s", tmp_controllers[i]);
 		ret = 1;
 	}
 	(controllers[i])[0] = '\0';


### PR DESCRIPTION
Fix string not null terminated warning, reported by the Coverity tool:

CID 258299 (#2 of 2): String not null terminated (STRING_NULL)18.
string_null: Passing unterminated string *controllers to display_controller_data,
which expects a null-terminated string.

use `snprintf()` instead of `strncpy()` and manually terminate the string
to keep Coverity happy.