### PR TITLE
man/cgred.conf: fix spelling of --nodaemon option

### DIFF
--- a/doc/man/cgred.conf.5
+++ b/doc/man/cgred.conf.5
@@ -21,7 +21,7 @@ variable specifies the file to which logs will be written
 
 .TP
 \fBNODAEMON\fR
-if it is equal to "--nodamon" then
+if it is equal to "--nodaemon" then
 run cgred in non-daemon mode
 
 .TP


### PR DESCRIPTION
Fix the spelling `--nodamon` ->  `--nodaemon`