### PR TITLE
cgsnapshot: Fix compiler truncation warning

### DIFF
--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -529,7 +529,12 @@ static int is_ctlr_on_list(char controllers[CG_CONTROLLER_MAX][FILENAME_MAX],
 
 	/* Lets reset the controllers to intersection of controller ∩ wanted_conts */
 	for (i = 0; tmp_controllers[i][0] != '\0'; i++) {
-		snprintf(controllers[i], FILENAME_MAX, "%s", tmp_controllers[i]);
+		/*
+		 * gcc complains about truncation when using snprintf() and
+		 * and coverity complains about truncation when using strncpy().
+		 * Avoid both these warnings by directly invoking memcpy()
+		 */
+		memcpy(controllers[i], tmp_controllers[i], sizeof(controllers[i]));
 		ret = 1;
 	}
 	(controllers[i])[0] = '\0';


### PR DESCRIPTION
Fix the following warning when running `make distcheck`

```
	../../../../src/tools/cgsnapshot.c: In function ‘is_ctlr_on_list’:
	../../../../src/tools/cgsnapshot.c:532:57: warning: ‘%s’ directive output may be truncated writing up to 409599 bytes into a region of size 4096 [-Wformat-truncation=]
	  532 |                 snprintf(controllers[i], FILENAME_MAX, "%s", tmp_controllers[i]);
	      |                                                         ^~
```