### PR TITLE
configure.ac: add check for systemd library and header files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,6 +236,20 @@ if test x$with_pam = xtrue; then
 		header files!])])
 fi
 
+if test x$with_systemd = xtrue; then
+       AC_CHECK_LIB([systemd],
+                    [sd_bus_message_new_method_call],
+                    [],
+                    [AC_MSG_ERROR([Cannot compile systemd support without
+		    libsystemd!])])
+
+       AC_CHECK_HEADERS(
+               [systemd/sd-bus.h],
+               [],
+               [AC_MSG_ERROR([Cannot compile systemd support - missing
+	       systemd header files!])])
+fi
+
 AX_CODE_COVERAGE
 
 AC_CONFIG_FILES([Makefile


### PR DESCRIPTION
systemd support is now enabled by default, unless explicitly disabled
during the `./configure` by passing `--enable-systemd=no`. The make
may fail with:
```
systemd.c:9:10: fatal error: systemd/sd-bus.h: No such file or directory
    9 | #include <systemd/sd-bus.h>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```
if the host system is missing the systemd library and development files,
due to missing checks for their existence in `./configure.ac`. This patch add them.

Fixes: https://github.com/libcgroup/libcgroup/issues/387
Reported-by: Tomasz Kłoczko <kloczek@github.com>