### PR TITLE
checkpatch improvements

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -17,3 +17,8 @@
 # Ignore new typedefs introduction warnings for now. We need to revisit files
 # introducing it and remove it.
 --ignore NEW_TYPEDEFS
+
+
+# Ignore Kernel str* function recommendations
+--ignore STRCPY
+--ignore STRNCPY

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -88,6 +88,8 @@ extern "C" {
 #define max(x, y) ((y) < (x)?(x):(y))
 #define min(x, y) ((y) > (x)?(x):(y))
 
+#define ARRAY_SIZE(x)	(sizeof(x) / sizeof((x)[0]))
+
 struct control_value {
 	char name[FILENAME_MAX];
 	char value[CG_CONTROL_VALUE_MAX];


### PR DESCRIPTION
This patch series adds two patches, that improve the `checkpatch.pl`
checks by customizing the warnings we care about.  The first patch
add more `--ignore` types for string functions, which `checkpatch.pl`
complains about, assuming it is checking against the kernel source
and the second patch introduces `ARRAY_SIZE()` macro to calculate
the array size, as suggested by the `checkpatch.pl`, which will be
used by future patches. 