### PR TITLE
Use ARRAY_SIZE macro helper across source

### DIFF
--- a/src/abstraction-map.c
+++ b/src/abstraction-map.c
@@ -42,7 +42,7 @@ const struct cgroup_abstraction_map cgroup_v1_to_v2_map[] = {
 	{cgroup_convert_unmappable, "cpuset.sched_load_balance", NULL, NULL, NULL},
 	{cgroup_convert_unmappable, "cpuset.sched_relax_domain_level", NULL, NULL, NULL},
 };
-const int cgroup_v1_to_v2_map_sz = sizeof(cgroup_v1_to_v2_map) / sizeof(cgroup_v1_to_v2_map[0]);
+const int cgroup_v1_to_v2_map_sz = ARRAY_SIZE(cgroup_v1_to_v2_map);
 
 const struct cgroup_abstraction_map cgroup_v2_to_v1_map[] = {
 	/* cpu controller */
@@ -59,4 +59,4 @@ const struct cgroup_abstraction_map cgroup_v2_to_v1_map[] = {
 	{cgroup_convert_cpuset_to_exclusive, "cpuset.cpus.partition", NULL,
 		"cpuset.cpu_exclusive", NULL},
 };
-const int cgroup_v2_to_v1_map_sz = sizeof(cgroup_v2_to_v1_map) / sizeof(cgroup_v2_to_v1_map[0]);
+const int cgroup_v2_to_v1_map_sz = ARRAY_SIZE(cgroup_v2_to_v1_map);

--- a/src/api.c
+++ b/src/api.c
@@ -4994,7 +4994,7 @@ const char *cgroup_strerror(int code)
 			"unknown error" : errtext;
 #endif
 	}
-	if (idx >= sizeof(cgroup_strerror_codes)/sizeof(cgroup_strerror_codes[0]))
+	if (idx >= ARRAY_SIZE(cgroup_strerror_codes))
 		return "Invalid error code";
 
 	return cgroup_strerror_codes[idx];

--- a/src/systemd.c
+++ b/src/systemd.c
@@ -23,7 +23,7 @@ static const char * const modes[] = {
 	"ignore-dependencies",	/* CGROUP_SYSTEMD_MODE_IGNORE_DEPS */
 	"ignore-requirements",	/* CGROUP_SYSTEMD_MODE_IGNORE_REQS */
 };
-static_assert((sizeof(modes) / sizeof(modes[0])) == CGROUP_SYSTEMD_MODE_CNT,
+static_assert(ARRAY_SIZE(modes) == CGROUP_SYSTEMD_MODE_CNT,
 	      "modes[] array must be same length as CGROUP_SYSTEMD_MODE_CNT");
 
 static const char * const sender = "org.freedesktop.systemd1";

--- a/tests/gunit/006-cgroup_get_cgroup.cpp
+++ b/tests/gunit/006-cgroup_get_cgroup.cpp
@@ -39,8 +39,7 @@ static const char * const CONTROLLERS[] = {
 	"namespaces",
 	"netns",
 };
-static const int CONTROLLERS_CNT =
-	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+static const int CONTROLLERS_CNT = ARRAY_SIZE(CONTROLLERS);
 
 static const char * const NAMES[][MAX_NAMES] = {
 	{"tasks", "cpu.shares", "cpu.weight", "cpu.foo", NULL},
@@ -50,7 +49,7 @@ static const char * const NAMES[][MAX_NAMES] = {
 	{"tasks", "namespaces.blah", NULL, NULL, NULL},
 	{"tasks", "netns.foo", "netns.bar", "netns.baz", NULL},
 };
-static const int NAMES_CNT = sizeof(NAMES) / sizeof(NAMES[0]);
+static const int NAMES_CNT = ARRAY_SIZE(NAMES);
 
 static const char * const VALUES[][MAX_NAMES] = {
 	{"1234", "512", "100", "abc123", NULL},
@@ -60,7 +59,7 @@ static const char * const VALUES[][MAX_NAMES] = {
 	{"59832", "The Quick Brown Fox", NULL, NULL, NULL},
 	{"987\n654", "root", "/sys/fs", "0xdeadbeef", NULL},
 };
-static const int VALUES_CNT = sizeof(VALUES) / sizeof(VALUES[0]);
+static const int VALUES_CNT = ARRAY_SIZE(VALUES);
 
 static const char * const CG_NAME = "tomcatcg";
 static const mode_t MODE = S_IRWXU | S_IRWXG | S_IRWXO;

--- a/tests/gunit/008-cgroup_process_v2_mount.cpp
+++ b/tests/gunit/008-cgroup_process_v2_mount.cpp
@@ -24,8 +24,7 @@ static const char * const CONTROLLERS[] = {
 	"pids",
 	"rdma",
 };
-static const int CONTROLLERS_CNT =
-	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+static const int CONTROLLERS_CNT = ARRAY_SIZE(CONTROLLERS);
 
 static int mnt_tbl_idx = 0;
 

--- a/tests/gunit/009-cgroup_set_values_recursive.cpp
+++ b/tests/gunit/009-cgroup_set_values_recursive.cpp
@@ -20,7 +20,7 @@ static const char * const NAMES[] = {
 	"cpu.foo",
 	"cpu.bar"
 };
-static const int NAMES_CNT = sizeof(NAMES) / sizeof(NAMES[0]);
+static const int NAMES_CNT = ARRAY_SIZE(NAMES);
 
 static const char * const VALUES[] = {
 	"999",
@@ -28,7 +28,7 @@ static const char * const VALUES[] = {
 	"random",
 	"data"
 };
-static const int VALUES_CNT = sizeof(VALUES) / sizeof(VALUES[0]);
+static const int VALUES_CNT = ARRAY_SIZE(VALUES);
 
 
 class SetValuesRecursiveTest : public ::testing::Test {

--- a/tests/gunit/012-cgroup_create_cgroup.cpp
+++ b/tests/gunit/012-cgroup_create_cgroup.cpp
@@ -23,8 +23,7 @@ static const char * const CONTROLLERS[] = {
 	"namespaces",
 	"netns",
 };
-static const int CONTROLLERS_CNT =
-	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+static const int CONTROLLERS_CNT = ARRAY_SIZE(CONTROLLERS);
 
 static cg_version_t VERSIONS[] = {
 	CGROUP_V1,
@@ -34,8 +33,7 @@ static cg_version_t VERSIONS[] = {
 	CGROUP_V1,
 	CGROUP_V2,
 };
-static const int VERSIONS_CNT =
-	sizeof(VERSIONS) / sizeof(VERSIONS[0]);
+static const int VERSIONS_CNT = ARRAY_SIZE(VERSIONS);
 
 class CgroupCreateCgroupTest : public ::testing::Test {
 	protected:

--- a/tests/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/tests/gunit/015-cgroupv2_controller_enabled.cpp
@@ -23,8 +23,7 @@ static const char * const CHILD_DIRS[] = {
 	"test3-ctrlrenabled",
 	"test4-ctrlrdisabled",
 };
-static const int CHILD_DIRS_CNT =
-	sizeof(CHILD_DIRS) / sizeof(CHILD_DIRS[0]);
+static const int CHILD_DIRS_CNT = ARRAY_SIZE(CHILD_DIRS);
 
 static const char * const CONTROLLERS[] = {
 	"cpu",
@@ -34,8 +33,7 @@ static const char * const CONTROLLERS[] = {
 	"net_cls",
 	"pids",
 };
-static const int CONTROLLERS_CNT =
-	sizeof(CONTROLLERS) / sizeof(CONTROLLERS[0]);
+static const int CONTROLLERS_CNT = ARRAY_SIZE(CONTROLLERS);
 
 static const enum cg_version_t VERSIONS[] = {
 	CGROUP_V2,


### PR DESCRIPTION
This patch series uses `ARRAY_SIZE()` macro helper to calculate array
size across the source tree, including the test cases.