### PR TITLE
Fix coding standard changes across the source tree

### DIFF
--- a/include/libcgroup/systemd.h
+++ b/include/libcgroup/systemd.h
@@ -127,11 +127,11 @@ void cgroup_cleanup_systemd_opts(void);
  * libcgroup commands, cgget, etc., will utilize this slice and scope when
  * constructing the libcgroup path
  *
- * @param slice Slice name, e.g. libcgroup.slice
- * @param scope Scope name, e.g. database.scope
+ * @param slice systemd slice name, e.g. libcgroup.slice
+ * @param scope systemd scope name, e.g. database.scope
  */
 int cgroup_write_systemd_default_cgroup(const char * const slice,
-				        const char * const scope);
+					const char * const scope);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/samples/c/create_systemd_scope.c
+++ b/samples/c/create_systemd_scope.c
@@ -13,22 +13,22 @@
 
 /*
  * To compile and link this program:
- * 	(From the root of the libcgroup source code directory)
- * 	$ ./bootstrap
- * 	$ ./configure --sysconfdir=/etc --localstatedir=/var \
- * 	  --enable-opaque-hierarchy="name=systemd" --enable-systemd \
- * 	  --enable-python --enable-samples
- * 	$ make
+ *	(From the root of the libcgroup source code directory)
+ *	$ ./bootstrap
+ *	$ ./configure --sysconfdir=/etc --localstatedir=/var \
+ *	  --enable-opaque-hierarchy="name=systemd" --enable-systemd \
+ *	  --enable-python --enable-samples
+ *	$ make
  *
  * Add the libcgroup idle thread to your PATH.  (Some distros restrict the
  * modification of the $PATH environment variable when invoking sudo, so you
  * will need to manually copy the executable to your path.)
- * 	$ sudo cp src/libcgroup_systemd_idle_thread /a/path/in/your/sudo/path
+ *	$ sudo cp src/libcgroup_systemd_idle_thread /a/path/in/your/sudo/path
  *
  * To run this program:
  *      $ # Note that there are more options.  Run `create_systemd_scope -h` for more info
- * 	$ sudo LD_LIBRARY_PATH=src/.libs ./samples/c/create_systemd_scope \
- * 	  --slice <yourslicename> --scope <yourscopename>
+ *	$ sudo LD_LIBRARY_PATH=src/.libs ./samples/c/create_systemd_scope \
+ *	  --slice <yourslicename> --scope <yourscopename>
  */
 
 /*

--- a/samples/c/get_setup_mode.c
+++ b/samples/c/get_setup_mode.c
@@ -5,7 +5,7 @@
  * Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
  *
  * Description: This file contains the sample code to demonstrate usage of
- * 		cgroup_setup_mode() API.
+ *		cgroup_setup_mode() API.
  */
 
 #include <stdio.h>
@@ -25,7 +25,7 @@ int main(void)
 	}
 
 	setup_mode = cgroup_setup_mode();
-	switch(setup_mode) {
+	switch (setup_mode) {
 	case CGROUP_MODE_LEGACY:
 		printf("cgroup mode: Legacy\n");
 		break;

--- a/src/abstraction-common.c
+++ b/src/abstraction-common.c
@@ -73,7 +73,7 @@ int cgroup_convert_int(struct cgroup_controller * const dst_cgc, const char * co
 		/* now scale from the input range to the output range */
 		out_value = out_value * out_dflt_int / in_dflt_int;
 
-		out_value_str = calloc(sizeof(char), OUT_VALUE_STR_LEN);
+		out_value_str = calloc(OUT_VALUE_STR_LEN, sizeof(char));
 		if (!out_value_str) {
 			ret = ECGOTHER;
 			goto out;

--- a/src/api.c
+++ b/src/api.c
@@ -1257,7 +1257,7 @@ STATIC int cgroup_process_v2_mnt(struct mntent *ent, int *mnt_tbl_idx)
 			goto out;
 		}
 
-		while(t->next != NULL)
+		while (t->next != NULL)
 			t = t->next;
 		t->next = tmp;
 
@@ -1396,7 +1396,7 @@ static int check_mount_point_opt(const char *mnt, const char *mnt_opt, int * con
 	}
 
 	*is_set = 0;
-	while((mntopt = hasmntopt(ent, mnt_opt))) {
+	while ((mntopt = hasmntopt(ent, mnt_opt))) {
 		mnt_opt_delim = mntopt[strlen(mnt_opt)];
 		if (mnt_opt_delim == '\0' || mnt_opt_delim == ',') {
 			*is_set  = 1;
@@ -2341,11 +2341,12 @@ STATIC int cgroup_set_values_recursive(const char * const base,
 		ret = (stat(path, &path_stat));
 		if (ret < 0) {
 			last_errno = errno;
-			error = ECGROUPVALUENOTEXIST;;
+			error = ECGROUPVALUENOTEXIST;
 			goto err;
 		}
 
-		if (!(path_stat.st_mode & S_IWUSR))
+		/* 0200 == S_IWUSR */
+		if (!(path_stat.st_mode & 0200))
 			continue;
 
 		cgroup_dbg("setting %s to \"%s\", pathlen %d\n", path, cv->value, ret);
@@ -2384,8 +2385,8 @@ err:
  * @param ctrl_name Name of the controller to check
  * @param output parameter that indicates whether the controller is enabled
  * @param file to open and parse
- * 	0 = cgroup.subtree_control
- * 	1 = cgroup.controllers
+ *	0 = cgroup.subtree_control
+ *	1 = cgroup.controllers
  */
 STATIC int __cgroupv2_get_enabled(const char *path, const char *ctrl_name,
 				  bool * const enabled, int file_enum)
@@ -3399,14 +3400,14 @@ int cgroup_delete_cgroup_ext(struct cgroup *cgroup, int flags)
 				if (first_error == 0 &&
 				    (ret != ECGROUPNOTEXIST ||
 				    (ret == ECGROUPNOTEXIST && cgrp_del_on_shared_mnt == 0))) {
-						first_errno = last_errno;
-						first_error = ECGOTHER;
+					first_errno = last_errno;
+					first_error = ECGOTHER;
 				}
 				continue;
 			}
 
 			if (is_cgrp_ctrl_shared_mnt(controller_name))
-					cgrp_del_on_shared_mnt = 1;
+				cgrp_del_on_shared_mnt = 1;
 
 			if (parent_name == NULL) {
 				/* Root group is being deleted. */
@@ -4819,9 +4820,8 @@ int cgroup_init_rules_cache(void)
 
 	/* Attempt to read the configuration file and cache the rules. */
 	ret = cgroup_parse_rules(true, CGRULE_INVALID, CGRULE_INVALID, NULL);
-	if (ret) {
+	if (ret)
 		cgroup_dbg("Could not initialize rule cache, error was: %d\n", ret);
-	}
 
 	return ret;
 }
@@ -4990,7 +4990,7 @@ const char *cgroup_strerror(int code)
 #ifdef STRERROR_R_CHAR_P
 		return strerror_r(cgroup_get_last_errno(), errtext, MAXLEN);
 #else
-		return strerror_r(cgroup_get_last_errno(), errtext, sizeof (errtext)) ?
+		return strerror_r(cgroup_get_last_errno(), errtext, sizeof(errtext)) ?
 			"unknown error" : errtext;
 #endif
 	}
@@ -5118,7 +5118,7 @@ int cgroup_walk_tree_begin(const char *controller, const char *base_path, int de
 	if (!cg_build_path(base_path, full_path, controller))
 		return ECGOTHER;
 
-	entry = calloc(sizeof(struct cgroup_tree_handle), 1);
+	entry = calloc(1, sizeof(struct cgroup_tree_handle));
 
 	if (!entry) {
 		last_errno = errno;
@@ -6328,7 +6328,7 @@ static int search_and_append_mnt_path(struct cg_mount_point **mount_point, char 
 	struct cg_mount_point *mnt_point, *mnt_tmp, *mnt_prev;
 
 	mnt_tmp = *mount_point;
-	while(mnt_tmp) {
+	while (mnt_tmp) {
 		if (strcmp(mnt_tmp->path, path) == 0)
 			return ECGVALUEEXISTS;
 
@@ -6401,9 +6401,9 @@ int cgroup_list_mount_points(const enum cg_version_t cgrp_version, char ***mount
 	 * paths are not part of the cg_mount_table.  Check and append
 	 * them to mnt_paths.
 	 */
-	if (cgrp_version == CGROUP_V2 && cg_cgroup_v2_empty_mount_paths ) {
+	if (cgrp_version == CGROUP_V2 && cg_cgroup_v2_empty_mount_paths) {
 		mount_point = cg_cgroup_v2_empty_mount_paths;
-		while(mount_point) {
+		while (mount_point) {
 			ret = search_and_append_mnt_path(&mnt_tmp, mount_point->path);
 			if (ret)
 				goto err;
@@ -6413,7 +6413,7 @@ int cgroup_list_mount_points(const enum cg_version_t cgrp_version, char ***mount
 		}
 	}
 
-	mnt_paths = malloc(sizeof(char*) * (idx + 1));
+	mnt_paths = malloc(sizeof(char *) * (idx + 1));
 	if (mnt_paths == NULL) {
 		last_errno = errno;
 		ret = ECGOTHER;
@@ -6439,7 +6439,7 @@ int cgroup_list_mount_points(const enum cg_version_t cgrp_version, char ***mount
 err:
 	pthread_rwlock_unlock(&cg_mount_table_lock);
 
-	while(mnt_tmp) {
+	while (mnt_tmp) {
 		mount_point = mnt_tmp;
 		mnt_tmp = mnt_tmp->next;
 		free(mount_point);
@@ -6474,9 +6474,8 @@ enum cg_setup_mode_t cgroup_setup_mode(void)
 	struct statfs cgrp_buf;
 	int i, ret = 0;
 
-	if (!cgroup_initialized) {
+	if (!cgroup_initialized)
 		return ECGROUPNOTINITIALIZED;
-	}
 
 	setup_mode = CGROUP_MODE_UNK;
 

--- a/src/config.c
+++ b/src/config.c
@@ -106,8 +106,8 @@ static pthread_rwlock_t systemd_default_cgroup_lock = PTHREAD_RWLOCK_INITIALIZER
  * cgroup_systemd_opts is dynamically allocated, hence having head
  * and tail helps in traversing.
  */
-static struct cgroup_systemd_opts *cgroup_systemd_opts_head = NULL;
-static struct cgroup_systemd_opts *cgroup_systemd_opts_tail = NULL;
+static struct cgroup_systemd_opts *cgroup_systemd_opts_head;
+static struct cgroup_systemd_opts *cgroup_systemd_opts_tail;
 
 static int config_create_slice_scope(char * const tmp_systemd_default_cgroup);
 #endif
@@ -599,6 +599,7 @@ void cgroup_config_cleanup_mount_table(void)
 int cgroup_config_insert_into_namespace_table(char *name, char *nspath)
 {
 	char *ns_tbl_name, *ns_tbl_path;
+
 	if (namespace_table_index >= CG_CONTROLLER_MAX)
 		return 0;
 
@@ -606,7 +607,7 @@ int cgroup_config_insert_into_namespace_table(char *name, char *nspath)
 
 	ns_tbl_name = config_namespace_table[namespace_table_index].name;
 	strncpy(ns_tbl_name, name, CONTROL_NAMELEN_MAX - 1);
-	ns_tbl_name[CONTROL_NAMELEN_MAX - 1 ] = '\0';
+	ns_tbl_name[CONTROL_NAMELEN_MAX - 1] = '\0';
 
 	ns_tbl_path = config_namespace_table[namespace_table_index].mount.path;
 	strncpy(ns_tbl_path, nspath, FILENAME_MAX - 1);
@@ -1798,9 +1799,9 @@ int cgroup_load_templates_cache_from_files(int *file_index)
 		if (template_table_index == 0)
 			/* the rules cache is empty */
 			return cgroup_init_templates_cache(CGCONFIG_CONF_FILE);
-		else
-			/* cache is not empty */
-			return cgroup_reload_cached_templates(CGCONFIG_CONF_FILE);
+
+		/* cache is not empty */
+		return cgroup_reload_cached_templates(CGCONFIG_CONF_FILE);
 	}
 
 	if (template_table) {

--- a/src/daemon/cgrulesengd.c
+++ b/src/daemon/cgrulesengd.c
@@ -223,6 +223,7 @@ static int cgre_store_parent_info(pid_t pid)
 	if (array_pi.index >= array_pi.num_allocation) {
 		int alloc = array_pi.num_allocation + NUM_PER_REALLOCATIOM;
 		void *new_array = realloc(array_pi.parent_info, sizeof(info) * alloc);
+
 		if (!new_array) {
 			flog(LOG_WARNING, "Failed to allocate memory\n");
 			return 1;
@@ -314,6 +315,7 @@ static int cgre_store_unchanged_process(pid_t pid, int flags)
 	if (array_unch.index >= array_unch.num_allocation) {
 		int alloc = array_unch.num_allocation + NUM_PER_REALLOCATIOM;
 		void *new_array = realloc(array_unch.proc, sizeof(unchanged_pid_t) * alloc);
+
 		if (!new_array) {
 			flog(LOG_WARNING, "Failed to allocate memory\n");
 			return 1;

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -241,8 +241,8 @@ void init_cgroup_table(struct cgroup *cgroups, size_t count);
  * Main mounting structures
  *
  * cg_mount_table_lock must be held to access:
- * 	cg_mount_table
- * 	cg_cgroup_v2_mount_path
+ *	cg_mount_table
+ *	cg_cgroup_v2_mount_path
  */
 extern struct cg_mount_table_s cg_mount_table[CG_CONTROLLER_MAX];
 extern char cg_cgroup_v2_mount_path[FILENAME_MAX];

--- a/src/libcgroup_systemd_idle_thread.c
+++ b/src/libcgroup_systemd_idle_thread.c
@@ -1,10 +1,10 @@
 #include <unistd.h>
 
-#define SECS_PER_DAY   (60 * 60 *24)
+#define SECS_PER_DAY   (60 * 60 * 24)
 
 int main(void)
 {
-	while(1)
+	while (1)
 		sleep(1 * SECS_PER_DAY);
 
 	return 0;

--- a/src/systemd.c
+++ b/src/systemd.c
@@ -124,7 +124,7 @@ int cgroup_create_scope(const char * const scope_name, const char * const slice_
 		}
 
 		if (child_pid == 0) {
-			char *args[] = {"libcgroup_systemd_idle_thread", NULL};
+			static char * const args[] = {"libcgroup_systemd_idle_thread", NULL};
 
 			/*
 			 * Have the child sleep forever.  Systemd will delete the scope if
@@ -241,7 +241,7 @@ int cgroup_create_scope(const char * const scope_name, const char * const slice_
 	}
 
 	/* The callback will null out the job_path pointer on completion */
-	while(job_path) {
+	while (job_path) {
 		sdret = sd_bus_process(bus, NULL);
 		if (sdret < 0) {
 			cgroup_err("failed to process the sd bus: %d\n", errno);

--- a/src/tools/cgclassify.c
+++ b/src/tools/cgclassify.c
@@ -41,7 +41,7 @@ static int rollback_pid_cgroups(pid_t pid);
 struct cgroup_info {
 	char ctrl_name[CONTROL_NAMELEN_MAX];
 	char cgrp_path[FILENAME_MAX];
-}info[MAX_MNT_ELEMENTS + 1];
+} info[MAX_MNT_ELEMENTS + 1];
 
 static void usage(int status, const char *program_name)
 {
@@ -302,7 +302,7 @@ static pid_t find_scope_pid(pid_t pid, int capture)
 	char *_ctrl_name = NULL;
 	int idx, ret, size = 0;
 	pid_t *pids;
-	int i=0;
+	int i = 0;
 
 	/*
 	 * Let's parse the cgroup of the pid, to check if its in one or
@@ -329,7 +329,7 @@ static pid_t find_scope_pid(pid_t pid, int capture)
 		if (strstr(buffer, "::")) {
 			snprintf(ctrl_name, CONTROL_NAMELEN_MAX, "unified");
 			ret = sscanf(buffer, "%d::%4096s\n", &idx, cgroup_name);
-		} else{
+		} else {
 			ret = sscanf(buffer, "%d:%[^:]:%4096s\n", &idx, ctrl_name, cgroup_name);
 		}
 

--- a/src/tools/cgconfig.c
+++ b/src/tools/cgconfig.c
@@ -166,9 +166,8 @@ int main(int argc, char *argv[])
 		goto free_cgroup;
 	}
 
-	if (dirm_change | filem_change) {
+	if (dirm_change | filem_change)
 		cgroup_set_permissions(default_group, dir_mode, file_mode, tasks_mode);
-	}
 
 	error = cgroup_config_set_default(default_group);
 	if (error) {

--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -99,7 +99,7 @@ static int create_systemd_scope(struct cgroup * const cg, const char * const pro
 		 * the usual "0" on success.
 		 */
 		ret = 0;
-        }
+	}
 
 err:
 	return ret;
@@ -328,11 +328,10 @@ int main(int argc, char *argv[])
 		if (dirm_change | filem_change)
 			cgroup_set_permissions(cgroup, dir_mode, file_mode, tasks_mode);
 
-		if (create_scope) {
+		if (create_scope)
 			ret = create_systemd_scope(cgroup, argv[0], set_default_scope, scope_pid);
-		} else {
+		else
 			ret = cgroup_create_cgroup(cgroup, 0);
-		}
 		if (ret) {
 			err("%s: can't create cgroup %s: %s\n", argv[0], cgroup->name,
 			    cgroup_strerror(ret));

--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -839,7 +839,7 @@ static int find_cgroup_mount_type(void)
 	int ret = 0;
 
 	setup_mode = cgroup_setup_mode();
-	switch(setup_mode) {
+	switch (setup_mode) {
 	case CGROUP_MODE_LEGACY:
 		info("Legacy Mode (Cgroup v1 only).\n");
 		break;
@@ -866,7 +866,7 @@ static int print_controller_version(void)
 	int ret = 0;
 
 	/* perf_event controller is the one with the lengthiest name */
-	info("%-11s\t%-7s\n", "#Controller","Version");
+	info("%-11s\t%-7s\n", "#Controller", "Version");
 	ret = cgroup_get_controller_begin(&handle, &controller);
 	while (ret == 0) {
 		ret = cgroup_get_controller_version(controller.name, &version);

--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -179,9 +179,9 @@ int is_on_list(char *name, struct deny_list_type *list)
 	/* go through the list of all values */
 	while (record != NULL) {
 		/* if the variable name is found */
-		if (strcmp(record->name, name) == 0) {
+		if (strcmp(record->name, name) == 0)
 			return 1; /* return its value */
-		}
+
 		record = record->next;
 	}
 
@@ -531,7 +531,7 @@ static int is_ctlr_on_list(char controllers[CG_CONTROLLER_MAX][FILENAME_MAX],
 	for (i = 0; tmp_controllers[i][0] != '\0'; i++) {
 		/*
 		 * gcc complains about truncation when using snprintf() and
-		 * and coverity complains about truncation when using strncpy().
+		 * coverity complains about truncation when using strncpy().
 		 * Avoid both these warnings by directly invoking memcpy()
 		 */
 		memcpy(controllers[i], tmp_controllers[i], sizeof(controllers[i]));
@@ -661,9 +661,8 @@ static void parse_mountpoint(cont_name_t cont_names[CG_CONTROLLER_MAX], char *na
 			/* controller is on the list */
 			if (show_mountpoints(name)) {
 				/* the controller is not mounted */
-				if ((flags & FL_SILENT) == 0) {
+				if ((flags & FL_SILENT) == 0)
 					err("ERROR: %s hierarchy not mounted\n", name);
-				}
 			break;
 			}
 		break;
@@ -695,9 +694,9 @@ static int parse_mountpoints(cont_name_t cont_names[CG_CONTROLLER_MAX], const ch
 	}
 
 	if (ret != ECGEOF) {
-		if ((flags &  FL_SILENT) != 0) {
+		if ((flags &  FL_SILENT) != 0)
 			err("E: in get next controller %s\n", cgroup_strerror(ret));
-		}
+
 		final_ret = ret;
 	}
 
@@ -712,9 +711,9 @@ static int parse_mountpoints(cont_name_t cont_names[CG_CONTROLLER_MAX], const ch
 	}
 
 	if (ret != ECGEOF) {
-		if ((flags &  FL_SILENT) != 0) {
+		if ((flags &  FL_SILENT) != 0)
 			err("E: in get next controller %s\n", cgroup_strerror(ret));
-		}
+
 		final_ret = ret;
 	}
 

--- a/src/tools/tools-common.c
+++ b/src/tools/tools-common.c
@@ -161,6 +161,7 @@ int cgroup_string_list_add_item(struct cgroup_string_list *list, const char *ite
 
 	if (list->size <= list->count) {
 		char **tmp = realloc(list->items, sizeof(char *) * list->size*2);
+
 		if (tmp == NULL)
 			return ECGFAIL;
 		list->items = tmp;

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -802,10 +802,10 @@ char *cgroup_get_cgroup_name(struct cgroup *cgroup)
  */
 bool is_cgroup_mode_legacy(void)
 {
-       enum cg_setup_mode_t setup_mode;
+	enum cg_setup_mode_t setup_mode;
 
-       setup_mode = cgroup_setup_mode();
-       return (setup_mode == CGROUP_MODE_LEGACY);
+	setup_mode = cgroup_setup_mode();
+	return (setup_mode == CGROUP_MODE_LEGACY);
 }
 
 /*
@@ -814,10 +814,10 @@ bool is_cgroup_mode_legacy(void)
  */
 bool is_cgroup_mode_hybrid(void)
 {
-       enum cg_setup_mode_t setup_mode;
+	enum cg_setup_mode_t setup_mode;
 
-       setup_mode = cgroup_setup_mode();
-       return (setup_mode == CGROUP_MODE_HYBRID);
+	setup_mode = cgroup_setup_mode();
+	return (setup_mode == CGROUP_MODE_HYBRID);
 }
 
 /*
@@ -826,8 +826,8 @@ bool is_cgroup_mode_hybrid(void)
  */
 bool is_cgroup_mode_unified(void)
 {
-       enum cg_setup_mode_t setup_mode;
+	enum cg_setup_mode_t setup_mode;
 
-       setup_mode = cgroup_setup_mode();
-       return (setup_mode == CGROUP_MODE_UNIFIED);
+	setup_mode = cgroup_setup_mode();
+	return (setup_mode == CGROUP_MODE_UNIFIED);
 }

--- a/tests/gunit/001-path.cpp
+++ b/tests/gunit/001-path.cpp
@@ -129,7 +129,7 @@ TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatchWithName)
  *
  * This test finds a matching controller in the mount table.  The
  * namespace is valid, but the cgroup name is NULL.  This exercises
- * exercises the `if (cg_namespace_table[i])` statement
+ * the `if (cg_namespace_table[i])` statement
  * https://github.com/libcgroup/libcgroup/blob/62f76650db84c0a25f76ece3a79d9d16a1e9f931/src/api.c#L1278
  */
 TEST_F(BuildPathV1Test, BuildPathV1_ControllerMatchWithNs)


### PR DESCRIPTION
This patchset fixes most of the `checkpatch.pl` warnings in the `*.[ch]`, `*.cpp`
files across the source tree, to make it a coding standard complaint. 