### PR TITLE
Fix spelling across the source tree

### DIFF
--- a/include/libcgroup/config.h
+++ b/include/libcgroup/config.h
@@ -71,7 +71,7 @@ int cgroup_config_unload_config(const char *pathname, int flags);
  * then.
  *
  * @param new_default New default permissions from this group are copied to
- * libcgroup internal structures. I.e., this group can be freed immediatelly
+ * libcgroup internal structures. I.e., this group can be freed immediately
  * after this function returns.
  */
 int cgroup_config_set_default(struct cgroup *new_default);

--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -236,7 +236,7 @@ int cgroup_create_cgroup(struct cgroup *cgroup, int ignore_ownership);
  * @endcode
  * @todo what is this good for? Why the list of controllers added by
  * cgroup_add_controller() is not used, like in cgroup_create_cgroup()? I can't
- * crate subgroup of root group in just one hierarchy with this function!
+ * create subgroup of root group in just one hierarchy with this function!
  *
  * @param cgroup The cgroup to create. Only it's name is used, everything else
  *	is discarded.
@@ -321,7 +321,7 @@ int cgroup_get_cgroup(struct cgroup *cgroup);
 
 /**
  * Copy all controllers, their parameters and values. Group name, permissions
- * and ownerships are not coppied. All existing controllers
+ * and ownerships are not copied. All existing controllers
  * in the source group are discarded.
  *
  * @param dst Destination group.

--- a/include/libcgroup/iterators.h
+++ b/include/libcgroup/iterators.h
@@ -44,7 +44,7 @@ extern "C" {
  *
  * @todo not all iterators follow this pattern, e.g. cgroup_walk_tree_begin()
  * can result both in a state that  cgroup_walk_tree_end() is not needed
- * and will sigsegv and in a state that cgroup_walk_tree_end() is needed
+ * and will SIGSEGV and in a state that cgroup_walk_tree_end() is needed
  * to free allocated memory. Complete review is needed!
  * @par Example of iterator usage:
  * @code
@@ -190,7 +190,7 @@ int cgroup_walk_tree_set_flags(void **handle, int flags);
  * @param handle The handle to be used during iteration.
  * @param buffer The buffer to read the value into.
  * The buffer is always zero-terminated.
- * @param max Maximal lenght of the buffer
+ * @param max Maximal length of the buffer
  * @return #ECGEOF when the stats file is empty.
  */
 
@@ -208,7 +208,7 @@ int cgroup_read_value_begin(const char * const controller, const char *path,
  * @param data returned the string.
  * @param buffer The buffer to read the value into.
  * The buffer is always zero-terminated.
- * @param max Maximal lenght of the buffer
+ * @param max Maximal length of the buffer
  * @return #ECGEOF when the iterator finishes getting the list of stats.
  */
 int cgroup_read_value_next(void **handle, char *buffer, int max);
@@ -222,7 +222,7 @@ int cgroup_read_value_end(void **handle);
  * @}
  *
  * @name Read group stats
- * libcgroup's cgroup_get_value_string() reads only relatively short parametrs
+ * libcgroup's cgroup_get_value_string() reads only relatively short parameters
  * of a group. Use following functions to read @c stats parameter, which can
  * be quite long.
  */

--- a/samples/c/test_functions.c
+++ b/samples/c/test_functions.c
@@ -137,7 +137,7 @@ struct cgroup *create_new_cgroup_ds(int ctl, const char *grpname,
 	strncpy(group, grpname, sizeof(group) - 1);
 	retval = set_controller(ctl, controller_name, control_file);
 	if (retval) {
-		fprintf(stderr, "Setting controller failled\n");
+		fprintf(stderr, "Setting controller failed\n");
 		return NULL;
 	}
 
@@ -581,7 +581,7 @@ int check_fsmounted(int multimnt)
 
 	tmp_entry = (struct mntent *) malloc(sizeof(struct mntent));
 	if (!tmp_entry) {
-		perror("Error: failled to mallloc for mntent\n");
+		perror("Error: failed to malloc for mntent\n");
 		ret = errno;
 		goto error;
 	}
@@ -798,7 +798,7 @@ void test_cgroup_get_cgroup(int ctl1, int ctl2, struct uid_gid_t ids, int i)
 	int ret;
 
 	/*
-	 * No need to test the next 3 scenarios separately for Multimnt
+	 * No need to test the next 3 scenarios separately for multimnt
 	 * so testing them only under single mount
 	 */
 	if (fs_mounted == FS_MOUNTED) {

--- a/src/abstraction-common.h
+++ b/src/abstraction-common.h
@@ -70,10 +70,10 @@ int cgroup_convert_passthrough(struct cgroup_controller * const dst_cgc,
 			       void *in_dflt, void *out_dflt);
 
 /**
- * Convert from an unmapple setting
+ * Convert from an unmappable setting
  *
  * @param dst_cgc Destination cgroup controller (unused)
- * @param in_value Contents of the input setting (unsed)
+ * @param in_value Contents of the input setting (unused)
  * @param out_setting Destination cgroup setting (unused)
  * @param in_dflt Default value of the input setting (unused)
  * @param out_dflt Default value of the output setting (unused)

--- a/src/api.c
+++ b/src/api.c
@@ -54,7 +54,7 @@ const struct cgroup_library_version library_version = {
 };
 
 /*
- * The errno which happend the last time (have to be thread specific)
+ * The errno which happened the last time (have to be thread specific)
  */
 __thread int last_errno;
 
@@ -912,7 +912,7 @@ finish:
  * CGRULES_CONF_FILE. This way we keep the back compatibility.
  *
  * Original description of this function moved to cgroup_parse_rules_file.
- * Also cloned and all occurences of file changed to files.
+ * Also cloned and all occurrences of file changed to files.
  *
  * Parse the configuration files that maps UID/GIDs to cgroups. If ever the
  * configuration files are modified, applications should call this function to
@@ -982,7 +982,7 @@ static int cgroup_parse_rules(bool cache, uid_t muid, gid_t mgid, const char *mp
 
 		/*
 		 * Cannot read directory. However, CGRULES_CONF_FILE is
-		 * succesfully parsed. Thus return as a success for back
+		 * successfully parsed. Thus return as a success for back
 		 * compatibility.
 		 */
 		pthread_rwlock_unlock(&rl_lock);
@@ -1001,7 +1001,7 @@ static int cgroup_parse_rules(bool cache, uid_t muid, gid_t mgid, const char *mp
 
 				/*
 				 * Cannot read directory.
-				 * However, CGRULES_CONF_FILE is succesfully
+				 * However, CGRULES_CONF_FILE is successfully
 				 * parsed. Thus return as a success for back
 				 * compatibility.
 				 */
@@ -1310,7 +1310,7 @@ STATIC int cgroup_process_v2_mnt(struct mntent *ent, int *mnt_tbl_idx)
 			continue;
 		}
 
-		/* This controller is not in the mount table.  add it */
+		/* This controller is not in the mount table.  Add it */
 		cgroup_cg_mount_table_append(controller, ent->mnt_dir, CGROUP_V2, mnt_tbl_idx,
 					     controller, shared_mnt);
 
@@ -3152,7 +3152,7 @@ err_nomem:
  * Move all processes from one task file to another.
  * @param input_tasks Pre-opened file to read tasks from.
  * @param output_tasks Pre-opened file to write tasks to.
- * @return 0 on succes, >0 on error.
+ * @return 0 on success, >0 on error.
  */
 static int cg_move_task_files(FILE *input_tasks, FILE *output_tasks)
 {
@@ -4255,7 +4255,7 @@ static int add_controller(struct cgroup **pgroup, char *group_name,
 	int ret = 0;
 
 	if  (group == NULL) {
-		/* It is the first controllerc the group have to be created */
+		/* It is the first controller the group have to be created */
 		group = cgroup_new_cgroup(group_name);
 		if (group == NULL) {
 			ret = ECGFAIL;
@@ -4884,7 +4884,7 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller, char *
 	/*
 	 * Why do we grab the cg_mount_table_lock?, the reason is that the
 	 * cgroup of a pid can change via the cgroup_attach_task_pid() call.
-	 * To make sure, we return consitent and safe results, we acquire the
+	 * To make sure, we return consistent and safe results, we acquire the
 	 * lock upfront. We can optimize by acquiring and releasing
 	 * the lock in the while loop, but that will be more expensive.
 	 */
@@ -5616,13 +5616,13 @@ STATIC int cg_get_cgroups_from_proc_cgroups(pid_t pid, char *cgroup_list[],
 		 * 7:devices:/user.slice
 		 */
 
-		/* Read in the cgroup number.  we don't care about it */
+		/* Read in the cgroup number.  We don't care about it */
 		stok_buff = strtok(buf, ":");
 		/* Read in the controller name */
 		stok_buff = strtok(NULL, ":");
 
 		/*
-		 * After this point, we have allocated memory.  if we return
+		 * After this point, we have allocated memory.  If we return
 		 * an error code after this, it's up to us to free the memory
 		 * we allocated
 		 */

--- a/src/config.c
+++ b/src/config.c
@@ -962,7 +962,7 @@ static int config_validate_namespaces(void)
 		}
 
 		/*
-		 * We want to handle all the subsytems that are mounted
+		 * We want to handle all the subsystems that are mounted
 		 * together. So initialize j to start from the next point
 		 * in the mount table.
 		 */
@@ -1028,7 +1028,7 @@ out_error:
  * looking to load namespace configurations.
  *
  * This function will order the namespace table in the same fashion as how
- * the mou table is setup.
+ * the mount table is setup.
  *
  * Also it will setup namespaces for all the controllers mounted. In case a
  * controller does not have a namespace assigned to it, it will set it to null.
@@ -1355,8 +1355,8 @@ static int cgroup_config_try_unmount(struct cg_mount_table_s *mount_info)
 	}
 	cgroup_walk_tree_end(&handle);
 	if (ret == 0) {
-		cgroup_dbg("won't unmount %s: hieararchy is not empty\n", mount_info->name);
-		return 0; /* the hieararchy is not empty */
+		cgroup_dbg("won't unmount %s: hierarchy is not empty\n", mount_info->name);
+		return 0; /* the hierarchy is not empty */
 	}
 	if (ret != ECGEOF)
 		return ret;
@@ -1858,7 +1858,7 @@ int cgroup_load_templates_cache_from_files(int *file_index)
 
 /*
  * Create a given cgroup, based on template configuration if it is present
- * if the template is not present cgroup is creted using cgroup_create_cgroup
+ * if the template is not present cgroup is created using cgroup_create_cgroup
  */
 int cgroup_config_create_template_group(struct cgroup *cgroup, char *template_name, int flags)
 {

--- a/src/daemon/cgrulesengd.c
+++ b/src/daemon/cgrulesengd.c
@@ -803,7 +803,7 @@ close_and_exit:
 /**
  * Start logging. Opens syslog and/or log file and sets log level.
  *	@param logp Path of the log file, NULL if no log file was specified
- *	@param logf Syslog facility, NULL if no facility was specified
+ *	@param logf syslog facility, NULL if no facility was specified
  *	@param logv Log verbosity, 1 is the default, 0 = no logging, 4 = everything
  */
 static void cgre_start_log(const char *logp, int logf, int logv)
@@ -869,7 +869,7 @@ static void cgre_start_log(const char *logp, int logf, int logv)
  * parent process.  Note too that stdout, stdin, and stderr are closed in
  * daemon mode, and a file descriptor for a log file is opened.
  *	@param logp Path of the log file, NULL if no log file was specified
- *	@param logf Syslog facility, 0 if no facility was specified
+ *	@param logf syslog facility, 0 if no facility was specified
  *	@param daemon False to turn off daemon mode (no fork, leave FDs open)
  *	@param logv Log verbosity, 1 is the default, 0 = no logging, 5 = everything
  *	@return 0 on success, > 0 on error
@@ -1042,7 +1042,7 @@ int main(int argc, char *argv[])
 	/* Patch to the log file */
 	const char *logp = NULL;
 
-	/* Syslog facility */
+	/* syslog facility */
 	int facility = 0;
 
 	/* Verbose level */
@@ -1278,7 +1278,7 @@ int main(int argc, char *argv[])
 
 	flog(LOG_INFO, "Started the CGroup Rules Engine Daemon.\n");
 
-	/* We loop endlesly in this function, unless we encounter an error. */
+	/* We loop endlessly in this function, unless we encounter an error. */
 	ret =  cgre_create_netlink_socket_process_msg();
 
 finished:

--- a/src/daemon/cgrulesengd.h
+++ b/src/daemon/cgrulesengd.h
@@ -85,7 +85,7 @@ int cgre_handle_message(struct cn_msg *cn_hdr);
  * parent process.  Note too that stdout, stdin, and stderr are closed in
  * daemon mode, and a file descriptor for a log file is opened.
  *	@param logp Path of the log file, NULL if no log file was specified
- *	@param logf Syslog facility, NULL if no facility was specified
+ *	@param logf syslog facility, NULL if no facility was specified
  *	@param daemon False to turn off daemon mode (no fork, leave FDs open)
  *	@param logv Log verbosity:
  *		2 is the default, 0 = no logging, 5 = everything

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -38,7 +38,7 @@ extern "C" {
 
 /*
  * Max number of mounted hierarchies. Event if one controller is mounted
- * per hier, it can not exceed CG_CONTROLLER_MAX
+ * per hierarchy, it can not exceed CG_CONTROLLER_MAX
  */
 #define CG_HIER_MAX  CG_CONTROLLER_MAX
 
@@ -149,7 +149,7 @@ struct cgroup_rules_data {
 
 	/* Details of user under consideration for destination cgroup */
 	struct passwd *pw;
-	/* Gid of the process */
+	/* gid of the process */
 	gid_t gid;
 };
 

--- a/src/pam/pam_cgroup.c
+++ b/src/pam/pam_cgroup.c
@@ -110,7 +110,7 @@ PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, cons
 
 	D(("user name is %s", user_name));
 
-	/* Initialize libcg */
+	/* Initialize libcgroup */
 	ret = cgroup_init();
 	if (ret) {
 		if (ctrl & PAM_DEBUG_ARG)
@@ -118,7 +118,7 @@ PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, cons
 		return PAM_SESSION_ERR;
 	}
 
-	D(("Initialized libcgroup successfuly."));
+	D(("Initialized libcgroup successfully."));
 
 	/* Determine the pid of the task */
 	pid = getpid();

--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -95,7 +95,7 @@ static int create_systemd_scope(struct cgroup * const cg, const char * const pro
 		}
 
 		/*
-		 * the default was successfully set.  override the return of "1" back to
+		 * the default was successfully set.  Override the return of "1" back to
 		 * the usual "0" on success.
 		 */
 		ret = 0;
@@ -156,7 +156,7 @@ int main(int argc, char *argv[])
 	int i, j;
 	int c;
 
-	/* no parametr on input */
+	/* no parameter on input */
 	if (argc < 2) {
 		usage(1, argv[0]);
 		exit(EXIT_BADARGS);
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	/* initialize libcg */
+	/* initialize libcgroup */
 	ret = cgroup_init();
 	if (ret) {
 		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));

--- a/src/tools/cgxset.c
+++ b/src/tools/cgxset.c
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
 	int ret = 0;
 	int c;
 
-	/* no parametr on input */
+	/* no parameter on input */
 	if (argc < 2) {
 		err("Usage is %s -r <name=value> <relative path to cgroup>\n", argv[0]);
 		return -1;

--- a/src/tools/lscgroup.c
+++ b/src/tools/lscgroup.c
@@ -149,7 +149,7 @@ static int print_cgroup(struct cgroup_group_spec *cgroup_spec, int flags)
 				if (ret)
 					return ret;
 				if ((flags & FL_LIST) != 0) {
-					/* we succesfully finish printing */
+					/* we successfully finish printing */
 					output = 0;
 					break;
 				}
@@ -284,7 +284,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	/* initialize libcg */
+	/* initialize libcgroup */
 	ret = cgroup_init();
 	if (ret) {
 		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));

--- a/src/tools/lssubsys.c
+++ b/src/tools/lssubsys.c
@@ -109,7 +109,7 @@ static int print_all_controllers_in_hierarchy(const char *tname, int hierarchy, 
 			goto end;
 
 		/*
-		 * v1 controllers should be in the hierachy.
+		 * v1 controllers should be in the hierarchy.
 		 * v2 controllers will have a hierarchy value of zero
 		 */
 		if (version == CGROUP_V1 && info.hierarchy != hierarchy)
@@ -165,7 +165,7 @@ static int cgroup_list_all_controllers(const char *tname, cont_name_t cont_name[
 	ret = cgroup_get_all_controller_begin(&handle, &info);
 	while (ret == 0) {
 		if (info.hierarchy == 0) {
-			/* the controller is not attached to any hierachy */
+			/* the controller is not attached to any hierarchy */
 			if (flags & FL_ALL) {
 				/* display only if -a flag is set */
 				info("%s\n", info.name);

--- a/src/tools/tools-common.c
+++ b/src/tools/tools-common.c
@@ -62,7 +62,7 @@ int parse_cgroup_spec(struct cgroup_group_spec **cdptr, char *optarg, int capaci
 	if (!pathptr)
 		return -1;
 
-	/* instanciate cgroup_data. */
+	/* instantiate cgroup_data. */
 	cdptr[i] = calloc(1, sizeof(struct cgroup_group_spec));
 	if (!cdptr[i]) {
 		fprintf(stderr, "%s\n", strerror(errno));

--- a/src/tools/tools-common.h
+++ b/src/tools/tools-common.h
@@ -94,7 +94,7 @@ int cgroup_string_list_add_item(struct cgroup_string_list *list, const char *ite
  * (without subdirs) to list of strings.
  * The function exits on error.
  * @param list The list to add files to.
- * @param dirname Full path to directory to examime.
+ * @param dirname Full path to directory to examine.
  * @param program_name Name of the executable, it will be used for
  *	printing errors to stderr.
  */
@@ -105,7 +105,7 @@ int cgroup_string_list_add_directory(struct cgroup_string_list *list, char *dirn
  * Parse file permissions as octal number.
  * @param string A string to parse, must contain 3-4 characters '0'-'7'.
  * @param pmode Parsed mode.
- * @oaram program_name Argv[0] to show error messages.
+ * @oaram program_name argv[0] to show error messages.
  */
 int parse_mode(char *string, mode_t *pmode, const char *program_name);
 
@@ -114,7 +114,7 @@ int parse_mode(char *string, mode_t *pmode, const char *program_name);
  * @param string A string to parse.
  * @param uid Parsed UID (-1 if 'user' is missing in the string).
  * @param gid Parsed GID (-1 if 'group' is missing in the string).
- * @param program_name Argv[0] to show error messages.
+ * @param program_name argv[0] to show error messages.
  */
 int parse_uid_gid(char *string, uid_t *uid, gid_t *gid, const char *program_name);
 


### PR DESCRIPTION
This patchset fixes the spelling mistakes across the file and the word case.
