### PR TITLE
.checkpatch.conf: add FILE_PATH_CHANGES to ignore list

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -18,7 +18,10 @@
 # introducing it and remove it.
 --ignore NEW_TYPEDEFS
 
-
 # Ignore Kernel str* function recommendations
 --ignore STRCPY
 --ignore STRNCPY
+
+# Ignore the suggestion to add file changes (add, move, or delete) to the
+# MAINTAINERS file
+--ignore FILE_PATH_CHANGES


### PR DESCRIPTION
Add `FILE_PATH_CHANGES` to the list of warnings, that is very specific
to Linux Kernel, which is triggered when a file is added, moved, or 
deleted to the source tree. Let's ignore it and this patch also removes
an extra new line in the `.checkpatch.conf`.