### PR TITLE
[RFC] match naming cgrp with upstream Linux

### DIFF
--- a/include/libcgroup/config.h
+++ b/include/libcgroup/config.h
@@ -100,8 +100,7 @@ int cgroup_load_templates_cache_from_files(int *file_index);
  * @param tmpl_files
  */
 struct cgroup_string_list;
-void cgroup_templates_cache_set_source_files(
-	struct cgroup_string_list *tmpl_files);
+void cgroup_templates_cache_set_source_files(struct cgroup_string_list *tmpl_files);
 
 /**
  * Physically create a new control group in kernel, based on given control
@@ -123,9 +122,7 @@ void cgroup_templates_cache_set_source_files(
  * @param template_name Template name used for cgroup setting
  * @param flags Bit flags to change the behavior
  */
-int cgroup_config_create_template_group(
-	struct cgroup *cgroup, char *template_name,
-	int flags);
+int cgroup_config_create_template_group(struct cgroup *cgrp, char *template_name, int flags);
 
 /**
  * @}

--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -159,46 +159,44 @@ struct cgroup *cgroup_new_cgroup(const char *name);
  * Attach new controller to cgroup. This function just modifies internal
  * libcgroup structure, not the kernel control group.
  *
- * @param cgroup
+ * @param cgrp
  * @param name The name of the controller, e.g. "freezer".
  * @return Created controller or NULL on error.
  */
-struct cgroup_controller *cgroup_add_controller(struct cgroup *cgroup,
-						const char *name);
+struct cgroup_controller *cgroup_add_controller(struct cgroup *cgrp, const char *name);
 
 /**
  * Attach all mounted controllers to given cgroup. This function just modifies
  * internal libcgroup structure, not the kernel control group.
  *
- * @param cgroup
+ * @param cgrp
  * @return zero or error number
  */
-int cgroup_add_all_controllers(struct cgroup *cgroup);
+int cgroup_add_all_controllers(struct cgroup *cgrp);
 
 
 /**
  * Return appropriate controller from given group.
  * The controller must be added before using cgroup_add_controller() or loaded
  * from kernel using cgroup_get_cgroup().
- * @param cgroup
+ * @param cgrp
  * @param name The name of the controller, e.g. "freezer".
  */
-struct cgroup_controller *cgroup_get_controller(struct cgroup *cgroup,
-						const char *name);
+struct cgroup_controller *cgroup_get_controller(struct cgroup *cgrp, const char *name);
 
 /**
  * Free internal @c cgroup structure. This function frees also all controllers
  * attached to the @c cgroup, including all parameters and their values.
- * @param cgroup
+ * @param cgrp
  */
-void cgroup_free(struct cgroup **cgroup);
+void cgroup_free(struct cgroup **cgrp);
 
 /**
  * Free internal list of controllers from the group.
  * @todo should this function be public???
- * @param cgroup
+ * @param cgrp
  */
-void cgroup_free_controllers(struct cgroup *cgroup);
+void cgroup_free_controllers(struct cgroup *cgrp);
 
 /**
  * @}
@@ -216,14 +214,14 @@ void cgroup_free_controllers(struct cgroup *cgroup);
  * All parameters set by cgroup_add_value_* functions are written.
  * The created groups has owner which was set by cgroup_set_uid_gid() and
  * permissions set by cgroup_set_permissions.
- * @param cgroup
+ * @param cgrp
  * @param ignore_ownership When nozero, all errors are ignored when setting
  *	owner of the group and/or its tasks file.
  *	@todo what is ignore_ownership good for?
  * @retval #ECGROUPNOTEQUAL if not all specified controller parameters
  *      were successfully set.
  */
-int cgroup_create_cgroup(struct cgroup *cgroup, int ignore_ownership);
+int cgroup_create_cgroup(struct cgroup *cgrp, int ignore_ownership);
 
 /**
  * Physically create new control group in kernel, with all parameters and values
@@ -238,7 +236,7 @@ int cgroup_create_cgroup(struct cgroup *cgroup, int ignore_ownership);
  * cgroup_add_controller() is not used, like in cgroup_create_cgroup()? I can't
  * create subgroup of root group in just one hierarchy with this function!
  *
- * @param cgroup The cgroup to create. Only it's name is used, everything else
+ * @param cgrp The cgroup to create. Only it's name is used, everything else
  *	is discarded.
  * @param ignore_ownership When nozero, all errors are ignored when setting
  *	owner of the group and/or its tasks file.
@@ -246,17 +244,16 @@ int cgroup_create_cgroup(struct cgroup *cgroup, int ignore_ownership);
  * @retval #ECGROUPNOTEQUAL if not all inherited controller parameters
  *      were successfully set (this is expected).
  */
-int cgroup_create_cgroup_from_parent(struct cgroup *cgroup,
-				     int ignore_ownership);
+int cgroup_create_cgroup_from_parent(struct cgroup *cgrp, int ignore_ownership);
 
 /**
  * Physically modify a control group in kernel. All parameters added by
  * cgroup_add_value_ or cgroup_set_value_ are written.
  * Currently it's not possible to change and owner of a group.
  *
- * @param cgroup
+ * @param cgrp
  */
-int cgroup_modify_cgroup(struct cgroup *cgroup);
+int cgroup_modify_cgroup(struct cgroup *cgrp);
 
 /**
  * Physically remove a control group from kernel. The group is removed from
@@ -267,12 +264,12 @@ int cgroup_modify_cgroup(struct cgroup *cgroup);
  * The group being removed must be empty, i.e. without subgroups. Use
  * cgroup_delete_cgroup_ext() for recursive delete.
  *
- * @param cgroup
+ * @param cgrp
  * @param ignore_migration When nozero, all errors are ignored when migrating
  *	tasks from the group to the parent group.
  *	@todo what is ignore_migration good for? rmdir() will fail if tasks were not moved.
  */
-int cgroup_delete_cgroup(struct cgroup *cgroup, int ignore_migration);
+int cgroup_delete_cgroup(struct cgroup *cgrp, int ignore_migration);
 
 /**
  * Physically remove a control group from kernel.
@@ -284,11 +281,11 @@ int cgroup_delete_cgroup(struct cgroup *cgroup, int ignore_migration);
  * are removed but the root group itself is left undeleted.
  * @see cgroup_delete_flag.
  *
- * @param cgroup
+ * @param cgrp
  * @param flags Combination of CGFLAG_DELETE_* flags, which indicate what and
  *	how to delete.
  */
-int cgroup_delete_cgroup_ext(struct cgroup *cgroup, int flags);
+int cgroup_delete_cgroup_ext(struct cgroup *cgrp, int flags);
 
 /**
  * @}
@@ -314,10 +311,10 @@ int cgroup_delete_cgroup_ext(struct cgroup *cgroup, int flags);
  * cgroup_get_uid_gid() if the group is in multiple hierarchies, each with
  * different owner of tasks file?
  *
- * @param cgroup The cgroup to load. Only it's name is used, everything else
+ * @param cgrp The cgroup to load. Only it's name is used, everything else
  *	is replaced.
  */
-int cgroup_get_cgroup(struct cgroup *cgroup);
+int cgroup_get_cgroup(struct cgroup *cgrp);
 
 /**
  * Copy all controllers, their parameters and values. Group name, permissions
@@ -332,15 +329,15 @@ int cgroup_copy_cgroup(struct cgroup *dst, struct cgroup *src);
 /**
  * Compare names, owners, controllers, parameters and values of two groups.
  *
- * @param cgroup_a
- * @param cgroup_b
+ * @param cgrp_a
+ * @param cgrp_b
  *
  * @retval 0  if the groups are the same.
  * @retval #ECGROUPNOTEQUAL if the groups are not the same.
  * @retval #ECGCONTROLLERNOTEQUAL if the only difference are controllers,
  *	parameters or their values.
  */
-int cgroup_compare_cgroup(struct cgroup *cgroup_a, struct cgroup *cgroup_b);
+int cgroup_compare_cgroup(struct cgroup *cgrp_a, struct cgroup *cgrp_b);
 
 
 /**
@@ -352,15 +349,14 @@ int cgroup_compare_cgroup(struct cgroup *cgroup_a, struct cgroup *cgroup_b);
  * @retval 0  if the controllers are the same.
  * @retval #ECGCONTROLLERNOTEQUAL if the controllers are not equal.
  */
-int cgroup_compare_controllers(struct cgroup_controller *cgca,
-			       struct cgroup_controller *cgcb);
+int cgroup_compare_controllers(struct cgroup_controller *cgca, struct cgroup_controller *cgcb);
 
 /**
  * Set owner of the group control files and the @c tasks file. This function
  * modifies only @c libcgroup internal @c cgroup structure, use
  * cgroup_create_cgroup() afterwards to create the group with given owners.
  *
- * @param cgroup
+ * @param cgrp
  * @param tasks_uid UID of the owner of group's @c tasks file.
  * @param tasks_gid GID of the owner of group's @c tasks file.
  * @param control_uid UID of the owner of group's control files (i.e.
@@ -368,7 +364,7 @@ int cgroup_compare_controllers(struct cgroup_controller *cgca,
  * @param control_gid GID of the owner of group's control files (i.e.
  *	parameters).
  */
-int cgroup_set_uid_gid(struct cgroup *cgroup, uid_t tasks_uid, gid_t tasks_gid,
+int cgroup_set_uid_gid(struct cgroup *cgrp, uid_t tasks_uid, gid_t tasks_gid,
 		       uid_t control_uid, gid_t control_gid);
 
 /**
@@ -376,7 +372,7 @@ int cgroup_set_uid_gid(struct cgroup *cgroup, uid_t tasks_uid, gid_t tasks_gid,
  * The data is read from @c libcgroup internal @c cgroup structure, use
  * cgroup_set_uid_gid() or cgroup_get_cgroup() to fill it.
  */
-int cgroup_get_uid_gid(struct cgroup *cgroup, uid_t *tasks_uid,
+int cgroup_get_uid_gid(struct cgroup *cgrp, uid_t *tasks_uid,
 		       gid_t *tasks_gid, uid_t *control_uid,
 		       gid_t *control_gid);
 
@@ -387,12 +383,12 @@ int cgroup_get_uid_gid(struct cgroup *cgroup, uid_t *tasks_uid,
  * the given permissions are masked with the file owner's permissions.
  * For example if a control file has permissions 640 and control_fperm is
  * 471 the result will be 460.
- * @param cgroup
+ * @param cgrp
  * @param control_dperm Directory permission for the group.
  * @param control_fperm File permission for the control files.
  * @param task_fperm File permissions for task file.
  */
-void cgroup_set_permissions(struct cgroup *cgroup,
+void cgroup_set_permissions(struct cgroup *cgrp,
 			    mode_t control_dperm, mode_t control_fperm,
 			    mode_t task_fperm);
 
@@ -430,8 +426,7 @@ int cgroup_add_value_string(struct cgroup_controller *controller,
  * @param value
  *
  */
-int cgroup_add_value_int64(struct cgroup_controller *controller,
-			   const char *name, int64_t value);
+int cgroup_add_value_int64(struct cgroup_controller *controller, const char *name, int64_t value);
 
 /**
  * Add parameter and its value to internal @c libcgroup structures.
@@ -454,8 +449,7 @@ int cgroup_add_value_uint64(struct cgroup_controller *controller,
  * @param value
  *
  */
-int cgroup_add_value_bool(struct cgroup_controller *controller,
-			  const char *name, bool value);
+int cgroup_add_value_bool(struct cgroup_controller *controller, const char *name, bool value);
 
 /**
  * Read a parameter value from @c libcgroup internal structures.
@@ -472,8 +466,7 @@ int cgroup_add_value_bool(struct cgroup_controller *controller,
  * @param name The name of the parameter.
  * @param value
  */
-int cgroup_get_value_string(struct cgroup_controller *controller,
-			    const char *name, char **value);
+int cgroup_get_value_string(struct cgroup_controller *controller, const char *name, char **value);
 /**
  * Read a parameter value from @c libcgroup internal structures.
  * Use @c cgroup_get_cgroup() to fill these structures with data from kernel.
@@ -482,8 +475,7 @@ int cgroup_get_value_string(struct cgroup_controller *controller,
  * @param name The name of the parameter.
  * @param value
  */
-int cgroup_get_value_int64(struct cgroup_controller *controller,
-			   const char *name, int64_t *value);
+int cgroup_get_value_int64(struct cgroup_controller *controller, const char *name, int64_t *value);
 
 /**
  * Read a parameter value from @c libcgroup internal structures.
@@ -504,8 +496,7 @@ int cgroup_get_value_uint64(struct cgroup_controller *controller,
  * @param name The name of the parameter.
  * @param value
  */
-int cgroup_get_value_bool(struct cgroup_controller *controller,
-			  const char *name, bool *value);
+int cgroup_get_value_bool(struct cgroup_controller *controller, const char *name, bool *value);
 
 /**
  * Set a parameter value in @c libcgroup internal structures.
@@ -549,8 +540,7 @@ int cgroup_set_value_uint64(struct cgroup_controller *controller,
  * @param name The name of the parameter.
  * @param value
  */
-int cgroup_set_value_bool(struct cgroup_controller *controller,
-			  const char *name, bool value);
+int cgroup_set_value_bool(struct cgroup_controller *controller, const char *name, bool value);
 
 /**
  * Return the number of variables for the specified controller in @c libcgroup
@@ -601,20 +591,20 @@ int cgroup_get_threads(const char *name, const char *controller, pid_t **pids, i
 
 /**
  * Change permission of files and directories of given group
- * @param cgroup The cgroup which permissions should be changed
+ * @param cgrp The cgroup which permissions should be changed
  * @param dir_mode The permission mode of group directory
  * @param dirm_change Denotes whether the directory change should be done
  * @param file_mode The permission mode of group files
  * @param filem_change Denotes whether the directory change should be done
  */
-int cg_chmod_recursive(struct cgroup *cgroup, mode_t dir_mode,
+int cg_chmod_recursive(struct cgroup *cgrp, mode_t dir_mode,
 		       int dirm_change, mode_t file_mode, int filem_change);
 
 /**
  *  Get the name of the cgroup from a given cgroup
- *  @param cgroup The cgroup whose name is needed
+ *  @param cgrp The cgroup whose name is needed
  */
-char *cgroup_get_cgroup_name(struct cgroup *cgroup);
+char *cgroup_get_cgroup_name(struct cgroup *cgrp);
 
 /*
  * Convert from one cgroup version to another version
@@ -628,9 +618,9 @@ char *cgroup_get_cgroup_name(struct cgroup *cgroup);
  *         ECGFAIL conversion failed
  *         ECGCONTROLLERNOTEQUAL incorrect controller version provided
  */
-int cgroup_convert_cgroup(struct cgroup * const out_cgroup,
+int cgroup_convert_cgroup(struct cgroup * const out_cgrp,
 			  enum cg_version_t out_version,
-			  const struct cgroup * const in_cgroup,
+			  const struct cgroup * const in_cgrp,
 			  enum cg_version_t in_version);
 
 /**
@@ -641,8 +631,7 @@ int cgroup_convert_cgroup(struct cgroup * const out_cgroup,
  *	@return 0 success and list of mounts paths in mount_paths
  *		ECGOTHER on failure and mount_paths is NULL.
  */
-int cgroup_list_mount_points(const enum cg_version_t cgrp_version,
-			     char ***mount_paths);
+int cgroup_list_mount_points(const enum cg_version_t cgrp_version, char ***mount_paths);
 
 /**
  * Get the cgroup version of a controller.  Version is set to CGROUP_UNK
@@ -651,8 +640,7 @@ int cgroup_list_mount_points(const enum cg_version_t cgrp_version,
  * @param controller The controller of interest
  * @param version The version of the controller
  */
-int cgroup_get_controller_version(const char * const controller,
-				  enum cg_version_t * const version);
+int cgroup_get_controller_version(const char * const controller, enum cg_version_t * const version);
 
 /**
  * Get the current group setup mode (legacy/unified/hybrid)
@@ -665,18 +653,18 @@ enum cg_setup_mode_t cgroup_setup_mode(void);
  * Return the number of controllers for the specified cgroup in libcgroup
  * internal structures.
  *
- * @param cgroup
+ * @param cgrp
  * @return Count of the controllers or -1 on error.
  */
-int cgroup_get_controller_count(struct cgroup *cgroup);
+int cgroup_get_controller_count(struct cgroup *cgrp);
 
 /**
  * Return requested controller from given group
  *
- * @param cgroup
+ * @param cgrp
  * @param index The index into the cgroup controller list
  */
-struct cgroup_controller *cgroup_get_controller_by_index(struct cgroup *cgroup, int index);
+struct cgroup_controller *cgroup_get_controller_by_index(struct cgroup *cgrp, int index);
 
 /**
  * Given a controller pointer, get the name of the controller

--- a/include/libcgroup/iterators.h
+++ b/include/libcgroup/iterators.h
@@ -163,8 +163,7 @@ int cgroup_walk_tree_begin(const char *controller, const char *base_path, int de
  * @param base_level Value of base_level returned by cgroup_walk_tree_begin().
  * @return #ECGEOF when we are done walking through the nodes.
  */
-int cgroup_walk_tree_next(int depth, void **handle,
-			  struct cgroup_file_info *info, int base_level);
+int cgroup_walk_tree_next(int depth, void **handle, struct cgroup_file_info *info, int base_level);
 
 /**
  * Release the iterator.
@@ -275,14 +274,13 @@ int cgroup_read_stats_end(void **handle);
 
 /**
  * Read the tasks file to get the list of tasks in a cgroup.
- * @param cgroup Name of the cgroup.
+ * @param cgrp Name of the cgroup.
  * @param controller Name of the cgroup subsystem.
  * @param handle The handle to be used in the iteration.
  * @param pid The pid read from the tasks file.
  * @return #ECGEOF when the group does not contain any tasks.
  */
-int cgroup_get_task_begin(const char *cgroup, const char *controller, void **handle,
-			  pid_t *pid);
+int cgroup_get_task_begin(const char *cgrp, const char *controller, void **handle, pid_t *pid);
 
 /**
  * Read the next task value.
@@ -376,8 +374,7 @@ struct controller_data {
  * @param handle The handle to be used for iteration.
  * @param info The structure which will be filled with controller data.
  */
-int cgroup_get_all_controller_begin(void **handle,
-	struct controller_data *info);
+int cgroup_get_all_controller_begin(void **handle, struct controller_data *info);
 /**
  * Read next controllers from /proc/cgroups.
  * @param handle The handle to be used for iteration.
@@ -407,8 +404,7 @@ int cgroup_get_all_controller_end(void **handle);
  * @param path Buffer to fill the path into. The buffer must be at least
  * FILENAME_MAX characters long.
  */
-int cgroup_get_subsys_mount_point_begin(const char *controller, void **handle,
-					char *path);
+int cgroup_get_subsys_mount_point_begin(const char *controller, void **handle, char *path);
 
 /**
  * Read next mount point of the hierarchy with given controller.

--- a/include/libcgroup/systemd.h
+++ b/include/libcgroup/systemd.h
@@ -68,7 +68,7 @@ int cgroup_create_scope(const char * const scope_name, const char * const slice_
 /**
  * Create a systemd scope
  *
- * @param cgroup
+ * @param cgrp
  * @param ignore_ownership When nonzero, all errors are ignored when setting owner of the group
  *	owner of the group and/or its tasks file
  * @param opts Scope creation options structure instance
@@ -77,7 +77,7 @@ int cgroup_create_scope(const char * const scope_name, const char * const slice_
  *
  * @note The cgroup->name field should be of the form "foo.slice/bar.scope"
  */
-int cgroup_create_scope2(struct cgroup *cgroup, int ignore_ownership,
+int cgroup_create_scope2(struct cgroup *cgrp, int ignore_ownership,
 			 const struct cgroup_systemd_scope_opts * const opts);
 
 /**

--- a/include/libcgroup/tasks.h
+++ b/include/libcgroup/tasks.h
@@ -47,16 +47,16 @@ enum cgroup_daemon_type {
 
 /**
  * Move current task (=thread) to given control group.
- * @param cgroup Destination control group.
+ * @param cgrp Destination control group.
  */
-int cgroup_attach_task(struct cgroup *cgroup);
+int cgroup_attach_task(struct cgroup *cgrp);
 
 /**
  * Move given task (=thread) to given control group.
- * @param cgroup Destination control group.
+ * @param cgrp Destination control group.
  * @param tid The task to move.
  */
-int cgroup_attach_task_pid(struct cgroup *cgroup, pid_t tid);
+int cgroup_attach_task_pid(struct cgroup *cgrp, pid_t tid);
 
 /**
  * Changes the cgroup of a task based on the path provided.  In this case,
@@ -69,8 +69,7 @@ int cgroup_attach_task_pid(struct cgroup *cgroup, pid_t tid);
  *
  * @todo should this function be really public?
  */
-int cgroup_change_cgroup_path(const char *path, pid_t pid,
-			      const char * const controllers[]);
+int cgroup_change_cgroup_path(const char *path, pid_t pid, const char * const controllers[]);
 
 /**
  * Get the current control group path where the given task is.
@@ -80,8 +79,7 @@ int cgroup_change_cgroup_path(const char *path, pid_t pid,
  *	The patch is relative to the root of the hierarchy. The caller must
  *	free this memory.
  */
-int cgroup_get_current_controller_path(pid_t pid, const char *controller,
-				       char **current_path);
+int cgroup_get_current_controller_path(pid_t pid, const char *controller, char **current_path);
 
 /**
  * @}
@@ -153,8 +151,7 @@ int cgroup_change_all_cgroups(void);
  * @param flags Bit flags to change the behavior, as defined in enum #cgflags.
  * @todo Determine thread-safeness and fix of not safe.
  */
-int cgroup_change_cgroup_flags(uid_t uid, gid_t gid,
-			       const char *procname, pid_t pid, int flags);
+int cgroup_change_cgroup_flags(uid_t uid, gid_t gid, const char *procname, pid_t pid, int flags);
 
 /**
  * Changes the cgroup of a program based on the rules in the config file.  If a
@@ -169,8 +166,7 @@ int cgroup_change_cgroup_flags(uid_t uid, gid_t gid,
  * @param flags Bit flags to change the behavior, as defined in enum #cgflags.
  * @todo Determine thread-safeness and fix if not safe.
  */
-int cgroup_change_cgroup_uid_gid_flags(uid_t uid, gid_t gid,
-				       pid_t pid, int flags);
+int cgroup_change_cgroup_uid_gid_flags(uid_t uid, gid_t gid, pid_t pid, int flags);
 
 /**
  * Provides backwards-compatibility with older versions of the API.  This

--- a/include/libcgroup/tools.h
+++ b/include/libcgroup/tools.h
@@ -30,7 +30,7 @@ extern "C" {
  * requested version.  If successful, cg will be populated with
  * the setting-value pairs.
  *
- * @param cg Input/Output cgroup. Must be initialized and freed by the caller
+ * @param cgrp Input/Output cgroup. Must be initialized and freed by the caller
  * @param version Cgroup version of cg  If set to CGROUP_UNK, the versions
  *		  stored within each controller will be used.  Otherwise this
  *		  value will be used to override the cg param's controller
@@ -38,20 +38,19 @@ extern "C" {
  * @param ignore_unmappable Ignore failures due to settings that cannot be
  *			    converted from one cgroup version to another
  */
-int cgroup_cgxget(struct cgroup **cg,
-		  enum cg_version_t version, bool ignore_unmappable);
+int cgroup_cgxget(struct cgroup **cgrp, enum cg_version_t version, bool ignore_unmappable);
 
 /**
  * Write the setting-value pairs in *cg to the cgroup sysfs.
  * cgroup_cgxset() will perform the necessary conversions to match the
  * "on-disk" format prior to writing to the cgroup sysfs.
  *
- * @param cg cgroup instance that will be written to the cgroup sysfs
- * @param version Cgroup version of *cg
+ * @param cgrp cgroup instance that will be written to the cgroup sysfs
+ * @param version Cgroup version of *cgrp
  * @param ignore_unmappable Ignore failures due to settings that cannot be
  *                          converted from one cgroup version to another
  */
-int cgroup_cgxset(const struct cgroup * const cg,
+int cgroup_cgxset(const struct cgroup * const cgrp,
 		  enum cg_version_t version, bool ignore_unmappable);
 
 #ifdef __cplusplus

--- a/samples/c/create_systemd_scope.c
+++ b/samples/c/create_systemd_scope.c
@@ -184,16 +184,16 @@ error:
 
 static int create_tmp_cgroup(const struct example_opts * const opts)
 {
-	struct cgroup *cg;
+	struct cgroup *cgrp;
 	int ret = 0;
 
-	cg = cgroup_new_cgroup(TMP_CGNAME);
-	if (!cg) {
+	cgrp = cgroup_new_cgroup(TMP_CGNAME);
+	if (!cgrp) {
 		printf("Failed to allocate the cgroup struct.  Are we out of memory?\n");
 		goto error;
 	}
 
-	ret = cgroup_create_cgroup(cg, 1);
+	ret = cgroup_create_cgroup(cgrp, 1);
 	if (ret) {
 		printf("Failed to write the cgroup to /sys/fs/cgroup: %d: %s\n",
 		       ret, cgroup_strerror(ret));
@@ -201,15 +201,15 @@ static int create_tmp_cgroup(const struct example_opts * const opts)
 	}
 
 error:
-	if (cg)
-		cgroup_free(&cg);
+	if (cgrp)
+		cgroup_free(&cgrp);
 
 	return ret;
 }
 
 static int move_pids_to_tmp_cgroup(const struct example_opts * const opts)
 {
-	struct cgroup *cg = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret, pid_cnt, i;
 	pid_t *pids = NULL;
 	int saved_ret = 0;
@@ -227,14 +227,14 @@ static int move_pids_to_tmp_cgroup(const struct example_opts * const opts)
 		goto error;
 	}
 
-	cg = cgroup_new_cgroup(TMP_CGNAME);
-	if (!cg) {
+	cgrp = cgroup_new_cgroup(TMP_CGNAME);
+	if (!cgrp) {
 		printf("Failed to allocate the cgroup struct.  Are we out of memory?\n");
 		goto error;
 	}
 
 	for (i = 0; i < pid_cnt; i++) {
-		ret = cgroup_attach_task_pid(cg, pids[i]);
+		ret = cgroup_attach_task_pid(cgrp, pids[i]);
 		if (ret) {
 			printf("Failed to attach pid %d to %s\n", pids[i], TMP_CGNAME);
 			/*
@@ -251,8 +251,8 @@ error:
 	if (pids)
 		free(pids);
 
-	if (cg)
-		cgroup_free(&cg);
+	if (cgrp)
+		cgroup_free(&cgrp);
 
 	if (ret == 0 && saved_ret)
 		ret = saved_ret;
@@ -263,20 +263,19 @@ error:
 static int create_high_priority_cgroup(const struct example_opts * const opts)
 {
 	struct cgroup_controller *ctrl;
-	struct cgroup *cg;
+	struct cgroup *cgrp;
 	int ret = 0;
 
-	cg = cgroup_new_cgroup(HIGH_CGNAME);
-	if (!cg) {
+	cgrp = cgroup_new_cgroup(HIGH_CGNAME);
+	if (!cgrp) {
 		printf("Failed to allocate the cgroup struct.  Are we out of memory?\n");
 		ret = ECGFAIL;
 		goto error;
 	}
 
-	ctrl = cgroup_add_controller(cg, "cpu");
+	ctrl = cgroup_add_controller(cgrp, "cpu");
 	if (!ctrl) {
-		printf("Failed to add the cpu controller to the %s cgroup struct\n",
-		       HIGH_CGNAME);
+		printf("Failed to add the cpu controller to the %s cgroup struct\n", HIGH_CGNAME);
 		ret = ECGFAIL;
 		goto error;
 	}
@@ -288,7 +287,7 @@ static int create_high_priority_cgroup(const struct example_opts * const opts)
 		goto error;
 	}
 
-	ctrl = cgroup_add_controller(cg, "memory");
+	ctrl = cgroup_add_controller(cgrp, "memory");
 	if (!ctrl) {
 		printf("Failed to add the memory controller to the %s cgroup struct\n",
 		       HIGH_CGNAME);
@@ -303,7 +302,7 @@ static int create_high_priority_cgroup(const struct example_opts * const opts)
 		goto error;
 	}
 
-	ret = cgroup_create_cgroup(cg, 0);
+	ret = cgroup_create_cgroup(cgrp, 0);
 	if (ret) {
 		printf("Failed to write the %s cgroup to /sys/fs/cgroup: %d: %s\n",
 		       HIGH_CGNAME, ret, cgroup_strerror(ret));
@@ -311,8 +310,8 @@ static int create_high_priority_cgroup(const struct example_opts * const opts)
 	}
 
 error:
-	if (cg)
-		cgroup_free(&cg);
+	if (cgrp)
+		cgroup_free(&cgrp);
 
 	return ret;
 }
@@ -320,20 +319,19 @@ error:
 static int create_medium_priority_cgroup(const struct example_opts * const opts)
 {
 	struct cgroup_controller *ctrl;
-	struct cgroup *cg;
+	struct cgroup *cgrp;
 	int ret = 0;
 
-	cg = cgroup_new_cgroup(MED_CGNAME);
-	if (!cg) {
+	cgrp = cgroup_new_cgroup(MED_CGNAME);
+	if (!cgrp) {
 		printf("Failed to allocate the cgroup struct.  Are we out of memory?\n");
 		ret = ECGFAIL;
 		goto error;
 	}
 
-	ctrl = cgroup_add_controller(cg, "cpu");
+	ctrl = cgroup_add_controller(cgrp, "cpu");
 	if (!ctrl) {
-		printf("Failed to add the cpu controller to the %s cgroup struct\n",
-		       MED_CGNAME);
+		printf("Failed to add the cpu controller to the %s cgroup struct\n", MED_CGNAME);
 		ret = ECGFAIL;
 		goto error;
 	}
@@ -345,7 +343,7 @@ static int create_medium_priority_cgroup(const struct example_opts * const opts)
 		goto error;
 	}
 
-	ctrl = cgroup_add_controller(cg, "memory");
+	ctrl = cgroup_add_controller(cgrp, "memory");
 	if (!ctrl) {
 		printf("Failed to add the memory controller to the %s cgroup struct\n",
 		       MED_CGNAME);
@@ -360,7 +358,7 @@ static int create_medium_priority_cgroup(const struct example_opts * const opts)
 		goto error;
 	}
 
-	ret = cgroup_create_cgroup(cg, 0);
+	ret = cgroup_create_cgroup(cgrp, 0);
 	if (ret) {
 		printf("Failed to write the %s cgroup to /sys/fs/cgroup: %d: %s\n",
 		       MED_CGNAME, ret, cgroup_strerror(ret));
@@ -368,8 +366,8 @@ static int create_medium_priority_cgroup(const struct example_opts * const opts)
 	}
 
 error:
-	if (cg)
-		cgroup_free(&cg);
+	if (cgrp)
+		cgroup_free(&cgrp);
 
 	return ret;
 }
@@ -377,20 +375,19 @@ error:
 static int create_low_priority_cgroup(const struct example_opts * const opts)
 {
 	struct cgroup_controller *ctrl;
-	struct cgroup *cg;
+	struct cgroup *cgrp;
 	int ret = 0;
 
-	cg = cgroup_new_cgroup(LOW_CGNAME);
-	if (!cg) {
+	cgrp = cgroup_new_cgroup(LOW_CGNAME);
+	if (!cgrp) {
 		printf("Failed to allocate the cgroup struct.  Are we out of memory?\n");
 		ret = ECGFAIL;
 		goto error;
 	}
 
-	ctrl = cgroup_add_controller(cg, "cpu");
+	ctrl = cgroup_add_controller(cgrp, "cpu");
 	if (!ctrl) {
-		printf("Failed to add the cpu controller to the %s cgroup struct\n",
-		       LOW_CGNAME);
+		printf("Failed to add the cpu controller to the %s cgroup struct\n", LOW_CGNAME);
 		ret = ECGFAIL;
 		goto error;
 	}
@@ -402,7 +399,7 @@ static int create_low_priority_cgroup(const struct example_opts * const opts)
 		goto error;
 	}
 
-	ctrl = cgroup_add_controller(cg, "memory");
+	ctrl = cgroup_add_controller(cgrp, "memory");
 	if (!ctrl) {
 		printf("Failed to add the memory controller to the %s cgroup struct\n",
 		       LOW_CGNAME);
@@ -417,7 +414,7 @@ static int create_low_priority_cgroup(const struct example_opts * const opts)
 		goto error;
 	}
 
-	ret = cgroup_create_cgroup(cg, 0);
+	ret = cgroup_create_cgroup(cgrp, 0);
 	if (ret) {
 		printf("Failed to write the %s cgroup to /sys/fs/cgroup: %d: %s\n",
 		       LOW_CGNAME, ret, cgroup_strerror(ret));
@@ -425,13 +422,13 @@ static int create_low_priority_cgroup(const struct example_opts * const opts)
 	}
 
 error:
-	if (cg)
-		cgroup_free(&cg);
+	if (cgrp)
+		cgroup_free(&cgrp);
 
 	return ret;
 }
 
-static int create_process(pid_t * const pid, const char * const cgname)
+static int create_process(pid_t * const pid, const char * const cgrp_name)
 {
 	int ret = 0;
 
@@ -444,7 +441,7 @@ static int create_process(pid_t * const pid, const char * const cgname)
 		/*
 		 * This is the child process.  Move it to the requested cgroup
 		 */
-		ret = cgroup_change_cgroup_path(cgname, getpid(), NULL);
+		ret = cgroup_change_cgroup_path(cgrp_name, getpid(), NULL);
 		if (ret)
 			exit(0);
 
@@ -461,7 +458,7 @@ error:
 
 static int delete_tmp_cgroup(void)
 {
-	struct cgroup *cg = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret, pid_cnt, i;
 	int saved_errno = 0;
 	pid_t *pids = NULL;
@@ -484,13 +481,13 @@ static int delete_tmp_cgroup(void)
 		}
 	}
 
-	cg = cgroup_new_cgroup(TMP_CGNAME);
-	if (!cg) {
+	cgrp = cgroup_new_cgroup(TMP_CGNAME);
+	if (!cgrp) {
 		printf("Failed to allocate the cgroup struct.  Are we out of memory?\n");
 		goto error;
 	}
 
-	ret = cgroup_delete_cgroup(cg, 1);
+	ret = cgroup_delete_cgroup(cgrp, 1);
 	if (ret)
 		printf("Failed to delete the %s cgroup: %d: %s\n", TMP_CGNAME, ret,
 		       cgroup_strerror(ret));
@@ -499,8 +496,8 @@ error:
 	if (pids)
 		free(pids);
 
-	if (cg)
-		cgroup_free(&cg);
+	if (cgrp)
+		cgroup_free(&cgrp);
 
 	if (ret == 0 && saved_errno)
 		ret = ECGFAIL;

--- a/samples/c/empty_cgroup_v2.c
+++ b/samples/c/empty_cgroup_v2.c
@@ -15,7 +15,7 @@
 
 int main(int argc, char **argv)
 {
-	struct cgroup *cgroup = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret = 0;
 
 	ret = cgroup_init();
@@ -24,17 +24,17 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	cgroup = cgroup_new_cgroup(CGRP_NAME);
-	if (!cgroup) {
+	cgrp = cgroup_new_cgroup(CGRP_NAME);
+	if (!cgrp) {
 		fprintf(stderr, "Failed to allocate cgroup %s\n", CGRP_NAME);
 		exit(1);
 	}
 
-	ret = cgroup_create_cgroup(cgroup, 0);
+	ret = cgroup_create_cgroup(cgrp, 0);
 	if (ret)
 		fprintf(stderr, "Failed to create cgroup %s\n", CGRP_NAME);
 
-	cgroup_free(&cgroup);
+	cgroup_free(&cgrp);
 
 	return ret;
 }

--- a/samples/c/get_variable_names.c
+++ b/samples/c/get_variable_names.c
@@ -8,9 +8,9 @@
 
 int main(int argc, char *argv[])
 {
-	struct cgroup_controller *group_controller = NULL;
-	struct cgroup *group = NULL;
-	char group_name[] = "/";
+	struct cgroup_controller *cgrp_controller = NULL;
+	struct cgroup *cgrp = NULL;
+	char cgrp_name[] = "/";
 	char *name;
 	int count;
 	int ret;
@@ -27,31 +27,31 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	group = cgroup_new_cgroup(group_name);
-	if (group == NULL) {
-		printf("cannot create group '%s'\n", group_name);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	if (cgrp == NULL) {
+		printf("cannot create cgrp '%s'\n", cgrp_name);
 		return -1;
 	}
 
-	ret = cgroup_get_cgroup(group);
+	ret = cgroup_get_cgroup(cgrp);
 	if (ret != 0) {
 		printf("cannot read group '%s': %s\n",
-			group_name, cgroup_strerror(ret));
+			cgrp_name, cgroup_strerror(ret));
 	}
 
 	for (i = 1; i < argc; i++) {
 
-		group_controller = cgroup_get_controller(group, argv[i]);
-		if (group_controller == NULL) {
+		cgrp_controller = cgroup_get_controller(cgrp, argv[i]);
+		if (cgrp_controller == NULL) {
 			printf("cannot find controller '%s' in group '%s'\n",
-			       argv[i], group_name);
+			       argv[i], cgrp_name);
 			ret = -1;
 			continue;
 		}
 
-		count = cgroup_get_value_name_count(group_controller);
+		count = cgroup_get_value_name_count(cgrp_controller);
 		for (j = 0; j < count; j++) {
-			name = cgroup_get_value_name(group_controller, j);
+			name = cgroup_get_value_name(cgrp_controller, j);
 			if (name != NULL)
 				printf("%s\n", name);
 		}

--- a/samples/c/read_stats.c
+++ b/samples/c/read_stats.c
@@ -23,10 +23,8 @@ int read_stats(char *path, char *controller)
 	printf("Stats for %s:\n", path);
 	printf("%s: %s", stat.name, stat.value);
 
-	while ((ret = cgroup_read_stats_next(&handle, &stat)) !=
-			ECGEOF) {
+	while ((ret = cgroup_read_stats_next(&handle, &stat)) != ECGEOF)
 		printf("%s: %s", stat.name, stat.value);
-	}
 
 	cgroup_read_stats_end(&handle);
 	printf("\n");
@@ -36,7 +34,7 @@ int read_stats(char *path, char *controller)
 int main(int argc, char *argv[])
 {
 	struct cgroup_file_info info;
-	char cgroup_path[FILENAME_MAX];
+	char cgrp_path[FILENAME_MAX];
 	char *controller;
 	int root_len;
 	void *handle;
@@ -44,8 +42,7 @@ int main(int argc, char *argv[])
 	int ret;
 
 	if (argc < 2) {
-		fprintf(stderr, "Usage %s: <controller name>\n",
-			argv[0]);
+		fprintf(stderr, "Usage %s: <controller name>\n", argv[0]);
 		exit(EXIT_FAILURE);
 	}
 
@@ -65,8 +62,8 @@ int main(int argc, char *argv[])
 	}
 
 	root_len = strlen(info.full_path) - 1;
-	strncpy(cgroup_path, info.path, FILENAME_MAX - 1);
-	ret = read_stats(cgroup_path, controller);
+	strncpy(cgrp_path, info.path, FILENAME_MAX - 1);
+	ret = read_stats(cgrp_path, controller);
 	if (ret < 0)
 		exit(EXIT_FAILURE);
 
@@ -74,9 +71,9 @@ int main(int argc, char *argv[])
 			ECGEOF) {
 		if (info.type != CGROUP_FILE_TYPE_DIR)
 			continue;
-		strncpy(cgroup_path, info.full_path + root_len, FILENAME_MAX - 1);
-		strcat(cgroup_path, "/");
-		ret = read_stats(cgroup_path, controller);
+		strncpy(cgrp_path, info.full_path + root_len, FILENAME_MAX - 1);
+		strcat(cgrp_path, "/");
+		ret = read_stats(cgrp_path, controller);
 		if (ret < 0)
 			exit(EXIT_FAILURE);
 	}

--- a/samples/c/test_named_hierarchy.c
+++ b/samples/c/test_named_hierarchy.c
@@ -12,32 +12,30 @@
 int main(void)
 {
 	struct cgroup_controller *cgc;
-	struct cgroup *cgroup;
+	struct cgroup *cgrp;
 	int ret;
 
 	ret = cgroup_init();
 	if (ret) {
-		printf("FAIL: cgroup_init failed with %s\n",
-		       cgroup_strerror(ret));
+		printf("FAIL: cgroup_init failed with %s\n", cgroup_strerror(ret));
 		exit(3);
 	}
 
-	cgroup = cgroup_new_cgroup("test");
-	if (!cgroup) {
+	cgrp = cgroup_new_cgroup("test");
+	if (!cgrp) {
 		printf("FAIL: cgroup_new_cgroup failed\n");
 		exit(3);
 	}
 
-	cgc = cgroup_add_controller(cgroup, "name=test");
+	cgc = cgroup_add_controller(cgrp, "name=test");
 	if (!cgc) {
 		printf("FAIL: cgroup_add_controller failed\n");
 		exit(3);
 	}
 
-	ret = cgroup_create_cgroup(cgroup, 1);
+	ret = cgroup_create_cgroup(cgrp, 1);
 	if (ret) {
-		printf("FAIL: cgroup_create_cgroup failed with %s\n",
-		       cgroup_strerror(ret));
+		printf("FAIL: cgroup_create_cgroup failed with %s\n", cgroup_strerror(ret));
 		exit(3);
 	}
 

--- a/samples/c/walk_task.c
+++ b/samples/c/walk_task.c
@@ -8,12 +8,12 @@
 
 int main(int argc, char *argv[])
 {
-	char *group = NULL;
+	char *cgrp = NULL;
 	void *handle;
 	int ret, i;
 
 	if (argc < 2) {
-		printf("No list of groups provided\n");
+		printf("No list of cgroups provided\n");
 		return -1;
 	}
 
@@ -26,10 +26,10 @@ int main(int argc, char *argv[])
 	for (i = 1; i < argc; i++) {
 		pid_t pid;
 
-		group = strdup(argv[i]);
-		printf("Printing the details of groups %s\n", group);
+		cgrp = strdup(argv[i]);
+		printf("Printing the details of cgroups %s\n", cgrp);
 
-		ret = cgroup_get_task_begin(group, "cpu", &handle, &pid);
+		ret = cgroup_get_task_begin(cgrp, "cpu", &handle, &pid);
 		while (!ret) {
 			printf("Pid is %u\n", pid);
 			ret = cgroup_get_task_next(&handle, &pid);
@@ -37,13 +37,12 @@ int main(int argc, char *argv[])
 				printf("cgroup_get_task_next failed with %s\n",
 				       cgroup_strerror(ret));
 				if (ret == ECGOTHER)
-					printf("failure with %s\n",
-					       strerror(errno));
+					printf("failure with %s\n", strerror(errno));
 				return -1;
 			}
 		}
-		free(group);
-		group = NULL;
+		free(cgrp);
+		cgrp = NULL;
 		ret = cgroup_get_task_end(&handle);
 	}
 

--- a/samples/c/wrapper_test.c
+++ b/samples/c/wrapper_test.c
@@ -7,33 +7,33 @@
 
 int main(void)
 {
-	struct cgroup *cgroup;
 	struct cgroup_controller *cgc;
+	struct cgroup *cgrp;
 	int fail = 0;
 
-	cgroup = cgroup_new_cgroup("test");
-	cgc = cgroup_add_controller(cgroup, "cpu");
+	cgrp = cgroup_new_cgroup("test");
+	cgc = cgroup_add_controller(cgrp, "cpu");
 
 	cgroup_add_value_int64(cgc, "cpu.shares", 2048);
 	cgroup_add_value_uint64(cgc, "cpu.something", 1000);
 	cgroup_add_value_bool(cgc, "cpu.bool", 1);
 
-	if (!strcmp(cgroup->controller[0]->values[0]->name, "cpu.shares")) {
-		if (strcmp(cgroup->controller[0]->values[0]->value, "2048")) {
+	if (!strcmp(cgrp->controller[0]->values[0]->name, "cpu.shares")) {
+		if (strcmp(cgrp->controller[0]->values[0]->value, "2048")) {
 			printf("FAIL for add_value_int\n");
 			fail = 1;
 		}
 	}
 
-	if (!strcmp(cgroup->controller[0]->values[1]->name, "cpu.something")) {
-		if (strcmp(cgroup->controller[0]->values[1]->value, "1000")) {
+	if (!strcmp(cgrp->controller[0]->values[1]->name, "cpu.something")) {
+		if (strcmp(cgrp->controller[0]->values[1]->value, "1000")) {
 			printf("FAIL for add_value_uint\n");
 			fail = 1;
 		}
 	}
 
-	if (!strcmp(cgroup->controller[0]->values[2]->name, "cpu.bool")) {
-		if (strcmp(cgroup->controller[0]->values[2]->value, "1")) {
+	if (!strcmp(cgrp->controller[0]->values[2]->name, "cpu.bool")) {
+		if (strcmp(cgrp->controller[0]->values[2]->value, "1")) {
 			printf("FAIL for add_value_bool\n");
 			fail = 1;
 		}

--- a/src/abstraction-common.c
+++ b/src/abstraction-common.c
@@ -219,16 +219,16 @@ out:
 	return ret;
 }
 
-int cgroup_convert_cgroup(struct cgroup * const out_cgroup, enum cg_version_t out_version,
-			  const struct cgroup * const in_cgroup, enum cg_version_t in_version)
+int cgroup_convert_cgroup(struct cgroup * const out_cgrp, enum cg_version_t out_version,
+			  const struct cgroup * const in_cgrp, enum cg_version_t in_version)
 {
 	struct cgroup_controller *cgc;
 	bool unmappable = false;
 	int ret = 0;
 	int i;
 
-	for (i = 0; i < in_cgroup->index; i++) {
-		cgc = cgroup_add_controller(out_cgroup, in_cgroup->controller[i]->name);
+	for (i = 0; i < in_cgrp->index; i++) {
+		cgc = cgroup_add_controller(out_cgrp, in_cgrp->controller[i]->name);
 		if (cgc == NULL) {
 			ret = ECGFAIL;
 			goto out;
@@ -236,9 +236,9 @@ int cgroup_convert_cgroup(struct cgroup * const out_cgroup, enum cg_version_t ou
 
 		/* the user has overridden the version */
 		if (in_version == CGROUP_V1 || in_version == CGROUP_V2)
-			in_cgroup->controller[i]->version = in_version;
+			in_cgrp->controller[i]->version = in_version;
 
-		if (strcmp(CGROUP_FILE_PREFIX, cgc->name) == 0)
+		if (strcmp(CGRP_FILE_PREFIX, cgc->name) == 0)
 			/*
 			 * libcgroup only supports accessing cgroup.* files
 			 * on cgroup v2 filesystems.
@@ -253,7 +253,7 @@ int cgroup_convert_cgroup(struct cgroup * const out_cgroup, enum cg_version_t ou
 				goto out;
 		}
 
-		ret = convert_controller(&cgc, in_cgroup->controller[i]);
+		ret = convert_controller(&cgc, in_cgrp->controller[i]);
 		if (ret == ECGNOVERSIONCONVERT) {
 			/*
 			 * Ignore unmappable errors while they happen, as
@@ -267,7 +267,7 @@ int cgroup_convert_cgroup(struct cgroup * const out_cgroup, enum cg_version_t ou
 				 * and was removed.  It's up to us to manage
 				 * the controller count
 				 */
-				out_cgroup->index--;
+				out_cgrp->index--;
 		} else if (ret) {
 			/* immediately fail on all other errors */
 			goto out;

--- a/src/abstraction-cpu.c
+++ b/src/abstraction-cpu.c
@@ -25,14 +25,14 @@ static const char * const CPU_MAX = "cpu.max";
 static const char * const CFS_QUOTA_US = "cpu.cfs_quota_us";
 static const char * const CFS_PERIOD_US = "cpu.cfs_period_us";
 
-static int read_setting(const char * const cgroup_name, const char * const controller_name,
+static int read_setting(const char * const cgrp_name, const char * const controller_name,
 			const char * const setting_name, char ** const value)
 {
 	char tmp_line[LL_MAX];
 	void *handle;
 	int ret;
 
-	ret = cgroup_read_value_begin(controller_name, cgroup_name, setting_name, &handle,
+	ret = cgroup_read_value_begin(controller_name, cgrp_name, setting_name, &handle,
 				      tmp_line, LL_MAX);
 	if (ret == ECGEOF)
 		goto read_end;

--- a/src/daemon/cgrulesengd.c
+++ b/src/daemon/cgrulesengd.c
@@ -174,11 +174,11 @@ void flog(int level, const char *format, ...)
  * Libcgroup logging callback. It must translate libcgroup log levels
  * to cgrulesengd native (=syslog).
  */
-void flog_cgroup(void *userdata, int cgroup_level, const char *format, va_list ap)
+void flog_cgroup(void *userdata, int cgrp_level, const char *format, va_list ap)
 {
 	int level = 0;
 
-	switch (cgroup_level) {
+	switch (cgrp_level) {
 	case CGROUP_LOG_ERROR:
 		level = LOG_ERR;
 		break;

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -64,15 +64,15 @@ extern "C" {
 #define CGRULES_CONF_DIR		"/etc/cgrules.d"
 #define CGRULES_MAX_FIELDS_PER_LINE	3
 
-#define CGROUP_BUFFER_LEN	(5 * FILENAME_MAX)
+#define CGRP_BUFFER_LEN	(5 * FILENAME_MAX)
 
 /* Maximum length of a key(<user>:<process name>) in the daemon config file */
-#define CGROUP_RULE_MAXKEY	(LOGIN_NAME_MAX + FILENAME_MAX + 1)
+#define CGRP_RULE_MAXKEY	(LOGIN_NAME_MAX + FILENAME_MAX + 1)
 
 /* Maximum length of a line in the daemon config file */
-#define CGROUP_RULE_MAXLINE	(FILENAME_MAX + CGROUP_RULE_MAXKEY + CG_CONTROLLER_MAX + 3)
+#define CGRP_RULE_MAXLINE	(FILENAME_MAX + CGRP_RULE_MAXKEY + CG_CONTROLLER_MAX + 3)
 
-#define CGROUP_FILE_PREFIX	"cgroup"
+#define CGRP_FILE_PREFIX	"cgroup"
 
 /* cgroup v2 files */
 #define CGV2_CONTROLLERS_FILE   "cgroup.controllers"
@@ -87,7 +87,7 @@ extern "C" {
 #define cgroup_dbg(x...)	cgroup_log(CGROUP_LOG_DEBUG, x)
 #define cgroup_cont(x...)	cgroup_log(CGROUP_LOG_CONT, x)
 
-#define CGROUP_DEFAULT_LOGLEVEL CGROUP_LOG_ERROR
+#define CGRP_DEFAULT_LOGLEVEL	CGROUP_LOG_ERROR
 
 #define max(x, y) ((y) < (x)?(x):(y))
 #define min(x, y) ((y) > (x)?(x):(y))
@@ -239,7 +239,7 @@ int cgroup_get_procname_from_procfs(pid_t pid, char **procname);
 int cg_mkdir_p(const char *path);
 struct cgroup *create_cgroup_from_name_value_pairs(const char *name,
 						struct control_value *name_value, int nv_number);
-void init_cgroup_table(struct cgroup *cgroups, size_t count);
+void init_cgroup_table(struct cgroup *cgrps, size_t count);
 
 /*
  * Main mounting structures
@@ -353,13 +353,13 @@ char *cg_build_path_locked(const char *setting, char *path, const char *controll
  * Given a cgroup controller and a setting within it, populate the setting's value
  *
  * @param ctrl_dir dirent representation of the setting, e.g. memory.stat
- * @param cgroup current cgroup
+ * @param cgrp current cgroup
  * @param cgc current cgroup controller
  * @param cg_index Index into the cg_mount_table of the cgroup
  *
  * @note The cg_mount_table_lock must be held prior to calling this function
  */
-int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgroup, struct cgroup_controller *cgc,
+int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgrp, struct cgroup_controller *cgc,
 		    int cg_index);
 
 /**
@@ -408,7 +408,7 @@ void cgroup_free_controller(struct cgroup_controller *ctrl);
 #define TEST_PROC_PID_CGROUP_FILE "test-procpidcgroup"
 
 int cgroup_parse_rules_options(char *options, struct cgroup_rule * const rule);
-int cg_get_cgroups_from_proc_cgroups(pid_t pid, char *cgroup_list[], char *controller_list[],
+int cg_get_cgroups_from_proc_cgroups(pid_t pid, char *cgrp_list[], char *controller_list[],
 				     int list_len);
 bool cgroup_compare_ignore_rule(const struct cgroup_rule * const rule, pid_t pid,
 				const char * const procname);

--- a/src/log.c
+++ b/src/log.c
@@ -74,7 +74,7 @@ int cgroup_parse_log_level_str(const char *levelstr)
 	if (strcasecmp(levelstr, "DEBUG") == 0)
 		return CGROUP_LOG_DEBUG;
 
-	return CGROUP_DEFAULT_LOGLEVEL;
+	return CGRP_DEFAULT_LOGLEVEL;
 }
 
 void cgroup_set_loglevel(int loglevel)
@@ -87,6 +87,6 @@ void cgroup_set_loglevel(int loglevel)
 		if (level_str != NULL)
 			cgroup_loglevel = cgroup_parse_log_level_str(level_str);
 		else
-			cgroup_loglevel = CGROUP_DEFAULT_LOGLEVEL;
+			cgroup_loglevel = CGRP_DEFAULT_LOGLEVEL;
 	}
 }

--- a/src/tools/cgconfig.c
+++ b/src/tools/cgconfig.c
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 	mode_t file_mode = NO_PERMS;
 	mode_t dir_mode = NO_PERMS;
 
-	struct cgroup *default_group = NULL;
+	struct cgroup *default_cgrp = NULL;
 	int filem_change = 0;
 	int dirm_change = 0;
 	int ret, error = 0;
@@ -153,23 +153,23 @@ int main(int argc, char *argv[])
 	}
 
 	/* set default permissions */
-	default_group = cgroup_new_cgroup("default");
-	if (!default_group) {
+	default_cgrp = cgroup_new_cgroup("default");
+	if (!default_cgrp) {
 		error = -1;
 		err("%s: cannot create default cgroup\n", argv[0]);
 		goto err;
 	}
 
-	error = cgroup_set_uid_gid(default_group, tuid, tgid, auid, agid);
+	error = cgroup_set_uid_gid(default_cgrp, tuid, tgid, auid, agid);
 	if (error) {
 		err("%s: cannot set default UID and GID: %s\n", argv[0], cgroup_strerror(error));
 		goto free_cgroup;
 	}
 
 	if (dirm_change | filem_change)
-		cgroup_set_permissions(default_group, dir_mode, file_mode, tasks_mode);
+		cgroup_set_permissions(default_cgrp, dir_mode, file_mode, tasks_mode);
 
-	error = cgroup_config_set_default(default_group);
+	error = cgroup_config_set_default(default_cgrp);
 	if (error) {
 		err("%s: cannot set config parser defaults: %s\n", argv[0],
 		    cgroup_strerror(error));
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
 	}
 
 free_cgroup:
-	cgroup_free(&default_group);
+	cgroup_free(&default_cgrp);
 err:
 	cgroup_string_list_free(&cfg_files);
 

--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -71,33 +71,33 @@ static int get_controller_from_name(const char * const name, char **controller)
 	return 0;
 }
 
-static int create_cg(struct cgroup **cg_list[], int * const cg_list_len)
+static int create_cgrp(struct cgroup **cgrp_list[], int * const cgrp_list_len)
 {
-	*cg_list = realloc(*cg_list, ((*cg_list_len) + 1) * sizeof(struct cgroup *));
-	if ((*cg_list) == NULL)
+	*cgrp_list = realloc(*cgrp_list, ((*cgrp_list_len) + 1) * sizeof(struct cgroup *));
+	if ((*cgrp_list) == NULL)
 		return ECGCONTROLLERCREATEFAILED;
 
-	memset(&(*cg_list)[*cg_list_len], 0, sizeof(struct cgroup *));
+	memset(&(*cgrp_list)[*cgrp_list_len], 0, sizeof(struct cgroup *));
 
-	(*cg_list)[*cg_list_len] = cgroup_new_cgroup("");
-	if ((*cg_list)[*cg_list_len] == NULL)
+	(*cgrp_list)[*cgrp_list_len] = cgroup_new_cgroup("");
+	if ((*cgrp_list)[*cgrp_list_len] == NULL)
 		return ECGCONTROLLERCREATEFAILED;
 
-	(*cg_list_len)++;
+	(*cgrp_list_len)++;
 
 	return 0;
 }
 
-static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
+static int parse_a_flag(struct cgroup **cgrp_list[], int * const cgrp_list_len)
 {
 	struct cgroup_mount_point controller;
 	struct cgroup_controller *cgc;
-	struct cgroup *cg = NULL;
+	struct cgroup *cgrp = NULL;
 	void *handle;
 	int ret = 0;
 
-	if ((*cg_list_len) == 0) {
-		ret = create_cg(cg_list, cg_list_len);
+	if ((*cgrp_list_len) == 0) {
+		ret = create_cgrp(cgrp_list, cgrp_list_len);
 		if (ret)
 			goto out;
 	}
@@ -107,13 +107,13 @@ static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
 	 * an optarg at the end with no flag.  Let's temporarily populate
 	 * the first cgroup with the requested control values.
 	 */
-	cg = (*cg_list)[0];
+	cgrp = (*cgrp_list)[0];
 
 	ret = cgroup_get_controller_begin(&handle, &controller);
 	while (ret == 0) {
-		cgc = cgroup_get_controller(cg, controller.name);
+		cgc = cgroup_get_controller(cgrp, controller.name);
 		if (!cgc) {
-			cgc = cgroup_add_controller(cg, controller.name);
+			cgc = cgroup_add_controller(cgrp, controller.name);
 			if (!cgc) {
 				err("cgget: cannot find controller '%s'\n", controller.name);
 				ret = ECGOTHER;
@@ -139,16 +139,16 @@ out:
 	return ret;
 }
 
-static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
+static int parse_r_flag(struct cgroup **cgrp_list[], int * const cgrp_list_len,
 			const char * const cntl_value)
 {
 	char *cntl_value_controller = NULL;
 	struct cgroup_controller *cgc;
-	struct cgroup *cg = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret = 0;
 
-	if ((*cg_list_len) == 0) {
-		ret = create_cg(cg_list, cg_list_len);
+	if ((*cgrp_list_len) == 0) {
+		ret = create_cgrp(cgrp_list, cgrp_list_len);
 		if (ret)
 			goto out;
 	}
@@ -158,15 +158,15 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 	 * an optarg at the end with no flag.  Let's temporarily populate
 	 * the first cgroup with the requested control values.
 	 */
-	cg = (*cg_list)[0];
+	cgrp = (*cgrp_list)[0];
 
 	ret = get_controller_from_name(cntl_value, &cntl_value_controller);
 	if (ret)
 		goto out;
 
-	cgc = cgroup_get_controller(cg, cntl_value_controller);
+	cgc = cgroup_get_controller(cgrp, cntl_value_controller);
 	if (!cgc) {
-		cgc = cgroup_add_controller(cg, cntl_value_controller);
+		cgc = cgroup_add_controller(cgrp, cntl_value_controller);
 		if (!cgc) {
 			err("cgget: cannot find controller '%s'\n", cntl_value_controller);
 			ret = ECGOTHER;
@@ -183,20 +183,20 @@ out:
 	return ret;
 }
 
-static int parse_g_flag_no_colon(struct cgroup **cg_list[], int * const cg_list_len,
+static int parse_g_flag_no_colon(struct cgroup **cgrp_list[], int * const cgrp_list_len,
 				 const char * const ctrl_str)
 {
 	struct cgroup_controller *cgc;
-	struct cgroup *cg = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret = 0;
 
-	if ((*cg_list_len) > 1) {
+	if ((*cgrp_list_len) > 1) {
 		ret = ECGMAXVALUESEXCEEDED;
 		goto out;
 	}
 
-	if ((*cg_list_len) == 0) {
-		ret = create_cg(cg_list, cg_list_len);
+	if ((*cgrp_list_len) == 0) {
+		ret = create_cgrp(cgrp_list, cgrp_list_len);
 		if (ret)
 			goto out;
 	}
@@ -206,11 +206,11 @@ static int parse_g_flag_no_colon(struct cgroup **cg_list[], int * const cg_list_
 	 * will be an optarg at the end with no flag.  Let's temporarily
 	 * populate the first cgroup with the requested control values.
 	 */
-	cg = *cg_list[0];
+	cgrp = *cgrp_list[0];
 
-	cgc = cgroup_get_controller(cg, ctrl_str);
+	cgc = cgroup_get_controller(cgrp, ctrl_str);
 	if (!cgc) {
-		cgc = cgroup_add_controller(cg, ctrl_str);
+		cgc = cgroup_add_controller(cgrp, ctrl_str);
 		if (!cgc) {
 			err("cgget: cannot find controller '%s'\n", ctrl_str);
 			ret = ECGOTHER;
@@ -222,18 +222,18 @@ out:
 	return ret;
 }
 
-static int split_cgroup_name(const char * const ctrl_str, char *cg_name)
+static int split_cgroup_name(const char * const ctrl_str, char *cgrp_name)
 {
 	char *colon;
 
 	colon = strchr(ctrl_str, ':');
 	if (colon == NULL) {
 		/* ctrl_str doesn't contain a ":" */
-		cg_name[0] = '\0';
+		cgrp_name[0] = '\0';
 		return ECGINVAL;
 	}
 
-	strncpy(cg_name, &colon[1], FILENAME_MAX - 1);
+	strncpy(cgrp_name, &colon[1], FILENAME_MAX - 1);
 
 	return 0;
 }
@@ -277,22 +277,22 @@ out:
 	return ret;
 }
 
-static int parse_g_flag_with_colon(struct cgroup **cg_list[], int * const cg_list_len,
+static int parse_g_flag_with_colon(struct cgroup **cgrp_list[], int * const cgrp_list_len,
 				   const char * const ctrl_str)
 {
 	struct cgroup_controller *cgc;
-	struct cgroup *cg = NULL;
+	struct cgroup *cgrp = NULL;
 	char **controllers = NULL;
 	int controllers_len = 0;
 	int i, ret = 0;
 
-	ret = create_cg(cg_list, cg_list_len);
+	ret = create_cgrp(cgrp_list, cgrp_list_len);
 	if (ret)
 		goto out;
 
-	cg = (*cg_list)[(*cg_list_len) - 1];
+	cgrp = (*cgrp_list)[(*cgrp_list_len) - 1];
 
-	ret = split_cgroup_name(ctrl_str, cg->name);
+	ret = split_cgroup_name(ctrl_str, cgrp->name);
 	if (ret)
 		goto out;
 
@@ -301,9 +301,9 @@ static int parse_g_flag_with_colon(struct cgroup **cg_list[], int * const cg_lis
 		goto out;
 
 	for (i = 0; i < controllers_len; i++) {
-		cgc = cgroup_get_controller(cg, controllers[i]);
+		cgc = cgroup_get_controller(cgrp, controllers[i]);
 		if (!cgc) {
-			cgc = cgroup_add_controller(cg, controllers[i]);
+			cgc = cgroup_add_controller(cgrp, controllers[i]);
 			if (!cgc) {
 				err("cgget: cannot find controller '%s'\n", controllers[i]);
 				ret = ECGOTHER;
@@ -319,17 +319,17 @@ out:
 	return ret;
 }
 
-static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
-			  int * const cg_list_len, bool first_cg_is_dummy)
+static int parse_opt_args(int argc, char *argv[], struct cgroup **cgrp_list[],
+			  int * const cgrp_list_len, bool first_cgrp_is_dummy)
 {
-	struct cgroup *cg = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret = 0;
 
 	/*
 	 * The first cgroup was temporarily populated and requires the
 	 * user to provide a cgroup name as an opt
 	 */
-	if (argv[optind] == NULL && first_cg_is_dummy) {
+	if (argv[optind] == NULL && first_cgrp_is_dummy) {
 		usage(1, argv[0]);
 		exit(EXIT_BADARGS);
 	}
@@ -343,50 +343,50 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 	 * Example of a command that will hit this code:
 	 *	$ cgget -g cpu:mycgroup mycgroup
 	 */
-	if (argv[optind] != NULL && (*cg_list_len) > 0 &&
-	    strcmp((*cg_list)[0]->name, "") != 0) {
+	if (argv[optind] != NULL && (*cgrp_list_len) > 0 &&
+	    strcmp((*cgrp_list)[0]->name, "") != 0) {
 		usage(1, argv[0]);
 		exit(EXIT_BADARGS);
 	}
 
 	while (argv[optind] != NULL) {
-		if ((*cg_list_len) > 0)
-			cg = (*cg_list)[(*cg_list_len) - 1];
+		if ((*cgrp_list_len) > 0)
+			cgrp = (*cgrp_list)[(*cgrp_list_len) - 1];
 		else
-			cg = NULL;
+			cgrp = NULL;
 
-		if ((*cg_list_len) == 0) {
+		if ((*cgrp_list_len) == 0) {
 			/*
 			 * The user didn't provide a '-r' or '-g' flag.
 			 * The parse_a_flag() function can be reused here
 			 * because we both have the same use case - gather
 			 * all the data about this particular cgroup.
 			 */
-			ret = parse_a_flag(cg_list, cg_list_len);
+			ret = parse_a_flag(cgrp_list, cgrp_list_len);
 			if (ret)
 				goto out;
 
-			strncpy((*cg_list)[(*cg_list_len) - 1]->name, argv[optind],
-				sizeof((*cg_list)[(*cg_list_len) - 1]->name) - 1);
-		} else if (cg != NULL && strlen(cg->name) == 0) {
+			strncpy((*cgrp_list)[(*cgrp_list_len) - 1]->name, argv[optind],
+				sizeof((*cgrp_list)[(*cgrp_list_len) - 1]->name) - 1);
+		} else if (cgrp != NULL && strlen(cgrp->name) == 0) {
 			/*
 			 * this cgroup was created based upon control/value
 			 * pairs or with a -g <controller> option.  we'll
 			 * populate it with the parameter provided by the user
 			 */
-			strncpy(cg->name, argv[optind], sizeof(cg->name) - 1);
+			strncpy(cgrp->name, argv[optind], sizeof(cgrp->name) - 1);
 		} else {
-			ret = create_cg(cg_list, cg_list_len);
+			ret = create_cgrp(cgrp_list, cgrp_list_len);
 			if (ret)
 				goto out;
 
-			ret = cgroup_copy_cgroup((*cg_list)[(*cg_list_len) - 1],
-						 (*cg_list)[(*cg_list_len) - 2]);
+			ret = cgroup_copy_cgroup((*cgrp_list)[(*cgrp_list_len) - 1],
+						 (*cgrp_list)[(*cgrp_list_len) - 2]);
 			if (ret)
 				goto out;
 
-			strncpy((*cg_list)[(*cg_list_len) - 1]->name, argv[optind],
-				sizeof((*cg_list)[(*cg_list_len) - 1]->name) - 1);
+			strncpy((*cgrp_list)[(*cgrp_list_len) - 1]->name, argv[optind],
+				sizeof((*cgrp_list)[(*cgrp_list_len) - 1]->name) - 1);
 		}
 		optind++;
 	}
@@ -395,12 +395,12 @@ out:
 	return ret;
 }
 
-static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * const cg_list_len,
-		      int * const mode)
+static int parse_opts(int argc, char *argv[], struct cgroup **cgrp_list[],
+		      int * const cgrp_list_len, int * const mode)
 {
 	bool do_not_fill_controller = false;
-	bool first_cgroup_is_dummy = false;
-	bool cgroup_mount_type = false;
+	bool first_cgrp_is_dummy = false;
+	bool cgrp_mount_type = false;
 	bool fill_controller = false;
 	bool print_ctrl_ver = false;
 	int ret = 0;
@@ -430,32 +430,32 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * c
 			break;
 		case 'r':
 			do_not_fill_controller = true;
-			first_cgroup_is_dummy = true;
-			ret = parse_r_flag(cg_list, cg_list_len, optarg);
+			first_cgrp_is_dummy = true;
+			ret = parse_r_flag(cgrp_list, cgrp_list_len, optarg);
 			if (ret)
 				goto err;
 			break;
 		case 'g':
 			fill_controller = true;
 			if (strchr(optarg, ':') == NULL) {
-				first_cgroup_is_dummy = true;
-				ret = parse_g_flag_no_colon(cg_list, cg_list_len, optarg);
+				first_cgrp_is_dummy = true;
+				ret = parse_g_flag_no_colon(cgrp_list, cgrp_list_len, optarg);
 				if (ret)
 					goto err;
 			} else {
-				ret = parse_g_flag_with_colon(cg_list, cg_list_len, optarg);
+				ret = parse_g_flag_with_colon(cgrp_list, cgrp_list_len, optarg);
 				if (ret)
 					goto err;
 			}
 			break;
 		case 'a':
 			fill_controller = true;
-			ret = parse_a_flag(cg_list, cg_list_len);
+			ret = parse_a_flag(cgrp_list, cgrp_list_len);
 			if (ret)
 				goto err;
 			break;
 		case 'm':
-			cgroup_mount_type = true;
+			cgrp_mount_type = true;
 			break;
 		case 'c':
 			print_ctrl_ver = true;
@@ -473,13 +473,13 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * c
 	}
 
 	/* '-m' and '-c' should not used with other options */
-	if ((cgroup_mount_type || print_ctrl_ver) &&
+	if ((cgrp_mount_type || print_ctrl_ver) &&
 	    (fill_controller || do_not_fill_controller)) {
 		usage(1, argv[0]);
 		exit(EXIT_BADARGS);
 	}
 
-	if (cgroup_mount_type) {
+	if (cgrp_mount_type) {
 		ret = find_cgroup_mount_type();
 		if (ret)
 			goto err;
@@ -491,7 +491,7 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * c
 			goto err;
 	}
 
-	ret = parse_opt_args(argc, argv, cg_list, cg_list_len, first_cgroup_is_dummy);
+	ret = parse_opt_args(argc, argv, cgrp_list, cgrp_list_len, first_cgrp_is_dummy);
 	if (ret)
 		goto err;
 
@@ -499,7 +499,7 @@ err:
 	return ret;
 }
 
-static int get_cv_value(struct control_value * const cv, const char * const cg_name,
+static int get_cv_value(struct control_value * const cv, const char * const cgrp_name,
 			const char * const controller_name)
 {
 	bool is_multiline = false;
@@ -507,7 +507,7 @@ static int get_cv_value(struct control_value * const cv, const char * const cg_n
 	char tmp_line[LL_MAX];
 	int ret;
 
-	ret = cgroup_read_value_begin(controller_name, cg_name, cv->name, &handle, tmp_line,
+	ret = cgroup_read_value_begin(controller_name, cgrp_name, cv->name, &handle, tmp_line,
 				      LL_MAX);
 	if (ret == ECGEOF)
 		goto read_end;
@@ -523,7 +523,7 @@ static int get_cv_value(struct control_value * const cv, const char * const cg_n
 			tmp_ret = cgroup_test_subsys_mounted(controller_name);
 			if (tmp_ret == 0) {
 				err("cgget: cannot find controller '%s' in group '%s'\n",
-				    controller_name, cg_name);
+				    controller_name, cgrp_name);
 			} else {
 				err("variable file read failed %s\n", cgroup_strerror(ret));
 			}
@@ -595,7 +595,7 @@ static int indent_multiline_value(struct control_value * const cv)
 	return 0;
 }
 
-static int fill_empty_controller(struct cgroup * const cg, struct cgroup_controller * const cgc)
+static int fill_empty_controller(struct cgroup * const cgrp, struct cgroup_controller * const cgc)
 {
 	char cgrp_ctrl_path[FILENAME_MAX] = { '\0' };
 	char mnt_path[FILENAME_MAX] = { '\0' };
@@ -635,7 +635,7 @@ static int fill_empty_controller(struct cgroup * const cg, struct cgroup_control
 	 * line:
 	 * cgget -g cpu:/foo
 	 */
-	if (cg->name[0] == '/' && cg->name[1] != '\0' &&
+	if (cgrp->name[0] == '/' && cgrp->name[1] != '\0' &&
 	    strncmp(mnt_path + (mnt_path_len - 7), ".scope/", 7) == 0) {
 		snprintf(tmp, FILENAME_MAX, "%s", dirname(mnt_path));
 		strncpy(mnt_path, tmp, FILENAME_MAX - 1);
@@ -653,13 +653,13 @@ static int fill_empty_controller(struct cgroup * const cg, struct cgroup_control
 		}
 	}
 #endif
-	strncat(mnt_path, cg->name, FILENAME_MAX - mnt_path_len - 1);
+	strncat(mnt_path, cgrp->name, FILENAME_MAX - mnt_path_len - 1);
 	mnt_path[sizeof(mnt_path) - 1] = '\0';
 
 	if (access(mnt_path, F_OK))
 		goto out;
 
-	if (!cg_build_path_locked(cg->name, cgrp_ctrl_path, cg_mount_table[i].name))
+	if (!cg_build_path_locked(cgrp->name, cgrp_ctrl_path, cg_mount_table[i].name))
 		goto out;
 
 	dir = opendir(cgrp_ctrl_path);
@@ -673,7 +673,7 @@ static int fill_empty_controller(struct cgroup * const cg, struct cgroup_control
 		if (ctrl_dir->d_type != DT_REG)
 			continue;
 
-		ret = cgroup_fill_cgc(ctrl_dir, cg, cgc, i);
+		ret = cgroup_fill_cgc(ctrl_dir, cgrp, cgc, i);
 		if (ret == ECGFAIL)
 			goto out;
 
@@ -702,20 +702,20 @@ out:
 	return ret;
 }
 
-static int get_controller_values(struct cgroup * const cg, struct cgroup_controller * const cgc)
+static int get_controller_values(struct cgroup * const cgrp, struct cgroup_controller * const cgc)
 {
 	int ret = 0;
 	int i;
 
 	for (i = 0; i < cgc->index; i++) {
-		ret = get_cv_value(cgc->values[i], cg->name, cgc->name);
+		ret = get_cv_value(cgc->values[i], cgrp->name, cgc->name);
 		if (ret)
 			goto out;
 	}
 
 	if (cgc->index == 0) {
 		/* fill the entire controller since no values were provided */
-		ret = fill_empty_controller(cg, cgc);
+		ret = fill_empty_controller(cgrp, cgc);
 		if (ret)
 			goto out;
 	}
@@ -724,13 +724,13 @@ out:
 	return ret;
 }
 
-static int get_cgroup_values(struct cgroup * const cg)
+static int get_cgroup_values(struct cgroup * const cgrp)
 {
 	int ret = 0;
 	int i;
 
-	for (i = 0; i < cg->index; i++) {
-		ret = get_controller_values(cg, cg->controller[i]);
+	for (i = 0; i < cgrp->index; i++) {
+		ret = get_controller_values(cgrp, cgrp->controller[i]);
 		if (ret)
 			break;
 	}
@@ -738,13 +738,13 @@ static int get_cgroup_values(struct cgroup * const cg)
 	return ret;
 }
 
-static int get_values(struct cgroup *cg_list[], int cg_list_len)
+static int get_values(struct cgroup *cgrp_list[], int cgrp_list_len)
 {
 	int ret = 0;
 	int i;
 
-	for (i = 0; i < cg_list_len; i++) {
-		ret = get_cgroup_values(cg_list[i]);
+	for (i = 0; i < cgrp_list_len; i++) {
+		ret = get_cgroup_values(cgrp_list[i]);
 		if (ret)
 			break;
 	}
@@ -796,8 +796,8 @@ static void print_cgroups(struct cgroup *cg_list[], int cg_list_len, int mode)
 int main(int argc, char *argv[])
 {
 	int mode = MODE_SHOW_NAMES | MODE_SHOW_HEADERS;
-	struct cgroup **cg_list = NULL;
-	int cg_list_len = 0;
+	struct cgroup **cgrp_list = NULL;
+	int cgrp_list_len = 0;
 	int ret = 0, i;
 
 	/* No parameter on input? */
@@ -816,7 +816,7 @@ int main(int argc, char *argv[])
 	mode |= MODE_SYSTEMD_DELEGATE;
 #endif
 
-	ret = parse_opts(argc, argv, &cg_list, &cg_list_len, &mode);
+	ret = parse_opts(argc, argv, &cgrp_list, &cgrp_list_len, &mode);
 	if (ret)
 		goto err;
 
@@ -824,15 +824,15 @@ int main(int argc, char *argv[])
 	if (mode & MODE_SYSTEMD_DELEGATE)
 		cgroup_set_default_systemd_cgroup();
 
-	ret = get_values(cg_list, cg_list_len);
+	ret = get_values(cgrp_list, cgrp_list_len);
 	if (ret)
 		goto err;
 
-	print_cgroups(cg_list, cg_list_len, mode);
+	print_cgroups(cgrp_list, cgrp_list_len, mode);
 
 err:
-	for (i = 0; i < cg_list_len; i++)
-		cgroup_free(&(cg_list[i]));
+	for (i = 0; i < cgrp_list_len; i++)
+		cgroup_free(&(cgrp_list[i]));
 
 	return ret;
 }

--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -33,29 +33,29 @@ static char *program_name;
 /* cgroup.subtree_control -r name, value */
 static struct control_value *cgrp_subtree_ctrl_val;
 
-static struct cgroup *copy_name_value_from_cgroup(char src_cg_path[FILENAME_MAX])
+static struct cgroup *copy_name_value_from_cgroup(char src_cgrp_path[FILENAME_MAX])
 {
-	struct cgroup *src_cgroup;
+	struct cgroup *src_cgrp;
 	int ret = 0;
 
 	/* create source cgroup */
-	src_cgroup = cgroup_new_cgroup(src_cg_path);
-	if (!src_cgroup) {
+	src_cgrp = cgroup_new_cgroup(src_cgrp_path);
+	if (!src_cgrp) {
 		err("can't create cgroup: %s\n", cgroup_strerror(ECGFAIL));
-		goto scgroup_err;
+		goto scgrp_err;
 	}
 
 	/* copy the name-version values to the cgroup structure */
-	ret = cgroup_get_cgroup(src_cgroup);
+	ret = cgroup_get_cgroup(src_cgrp);
 	if (ret != 0) {
-		err("cgroup %s error: %s\n", src_cg_path, cgroup_strerror(ret));
-		goto scgroup_err;
+		err("cgroup %s error: %s\n", src_cgrp_path, cgroup_strerror(ret));
+		goto scgrp_err;
 	}
 
-	return src_cgroup;
+	return src_cgrp;
 
-scgroup_err:
-	cgroup_free(&src_cgroup);
+scgrp_err:
+	cgroup_free(&src_cgrp);
 
 	return NULL;
 }
@@ -452,7 +452,7 @@ int main(int argc, char *argv[])
 	int recursive = 0;
 	int nv_max = 0;
 
-	char src_cg_path[FILENAME_MAX] = "\0";
+	char src_cgrp_path[FILENAME_MAX] = "\0";
 	struct cgroup *subtree_cgrp = NULL;
 	struct cgroup *src_cgroup = NULL;
 
@@ -532,8 +532,8 @@ int main(int argc, char *argv[])
 				goto err;
 			}
 			flags |= FL_COPY;
-			strncpy(src_cg_path, optarg, FILENAME_MAX);
-			src_cg_path[FILENAME_MAX-1] = '\0';
+			strncpy(src_cgrp_path, optarg, FILENAME_MAX);
+			src_cgrp_path[FILENAME_MAX-1] = '\0';
 			break;
 		case 'R':
 			recursive = 1;
@@ -587,7 +587,7 @@ int main(int argc, char *argv[])
 
 	/* copy the name-value from the given group */
 	if ((flags & FL_COPY) != 0) {
-		src_cgroup = copy_name_value_from_cgroup(src_cg_path);
+		src_cgroup = copy_name_value_from_cgroup(src_cgrp_path);
 		if (src_cgroup == NULL)
 			goto err;
 	}

--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -83,24 +83,24 @@ static int get_controller_from_name(const char * const name, char **controller)
 	return 0;
 }
 
-static int create_cg(struct cgroup **cg_list[], int * const cg_list_len)
+static int create_cg(struct cgroup **cgrp_list[], int * const cgrp_list_len)
 {
-	*cg_list = realloc(*cg_list, ((*cg_list_len) + 1) * sizeof(struct cgroup *));
-	if ((*cg_list) == NULL)
+	*cgrp_list = realloc(*cgrp_list, ((*cgrp_list_len) + 1) * sizeof(struct cgroup *));
+	if ((*cgrp_list) == NULL)
 		return ECGCONTROLLERCREATEFAILED;
 
-	memset(&(*cg_list)[*cg_list_len], 0, sizeof(struct cgroup *));
+	memset(&(*cgrp_list)[*cgrp_list_len], 0, sizeof(struct cgroup *));
 
-	(*cg_list)[*cg_list_len] = cgroup_new_cgroup("");
-	if ((*cg_list)[*cg_list_len] == NULL)
+	(*cgrp_list)[*cgrp_list_len] = cgroup_new_cgroup("");
+	if ((*cgrp_list)[*cgrp_list_len] == NULL)
 		return ECGCONTROLLERCREATEFAILED;
 
-	(*cg_list_len)++;
+	(*cgrp_list_len)++;
 
 	return 0;
 }
 
-static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
+static int parse_a_flag(struct cgroup **cgrp_list[], int * const cgrp_list_len)
 {
 	struct cgroup_mount_point controller;
 	struct cgroup_controller *cgc;
@@ -108,8 +108,8 @@ static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
 	void *handle;
 	int ret = 0;
 
-	if ((*cg_list_len) == 0) {
-		ret = create_cg(cg_list, cg_list_len);
+	if ((*cgrp_list_len) == 0) {
+		ret = create_cg(cgrp_list, cgrp_list_len);
 		if (ret)
 			goto out;
 	}
@@ -119,7 +119,7 @@ static int parse_a_flag(struct cgroup **cg_list[], int * const cg_list_len)
 	 * an optarg at the end with no flag.  Let's temporarily populate
 	 * the first cgroup with the requested control values.
 	 */
-	cg = (*cg_list)[0];
+	cg = (*cgrp_list)[0];
 
 	ret = cgroup_get_controller_begin(&handle, &controller);
 	while (ret == 0) {
@@ -151,7 +151,7 @@ out:
 	return ret;
 }
 
-static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
+static int parse_r_flag(struct cgroup **cgrp_list[], int * const cgrp_list_len,
 			const char * const cntl_value)
 {
 	char *cntl_value_controller = NULL;
@@ -159,8 +159,8 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 	struct cgroup *cg = NULL;
 	int ret = 0;
 
-	if ((*cg_list_len) == 0) {
-		ret = create_cg(cg_list, cg_list_len);
+	if ((*cgrp_list_len) == 0) {
+		ret = create_cg(cgrp_list, cgrp_list_len);
 		if (ret)
 			goto out;
 	}
@@ -170,7 +170,7 @@ static int parse_r_flag(struct cgroup **cg_list[], int * const cg_list_len,
 	 * an optarg at the end with no flag.  Let's temporarily populate
 	 * the first cgroup with the requested control values.
 	 */
-	cg = (*cg_list)[0];
+	cg = (*cgrp_list)[0];
 
 	ret = get_controller_from_name(cntl_value, &cntl_value_controller);
 	if (ret)
@@ -195,20 +195,20 @@ out:
 	return ret;
 }
 
-static int parse_g_flag_no_colon(struct cgroup **cg_list[], int * const cg_list_len,
+static int parse_g_flag_no_colon(struct cgroup **cgrp_list[], int * const cgrp_list_len,
 				 const char * const ctrl_str)
 {
 	struct cgroup_controller *cgc;
 	struct cgroup *cg = NULL;
 	int ret = 0;
 
-	if ((*cg_list_len) > 1) {
+	if ((*cgrp_list_len) > 1) {
 		ret = ECGMAXVALUESEXCEEDED;
 		goto out;
 	}
 
-	if ((*cg_list_len) == 0) {
-		ret = create_cg(cg_list, cg_list_len);
+	if ((*cgrp_list_len) == 0) {
+		ret = create_cg(cgrp_list, cgrp_list_len);
 		if (ret)
 			goto out;
 	}
@@ -219,7 +219,7 @@ static int parse_g_flag_no_colon(struct cgroup **cg_list[], int * const cg_list_
 	 * Let's temporarily populate the first cgroup with the requested
 	 * control values.
 	 */
-	cg = *cg_list[0];
+	cg = *cgrp_list[0];
 
 	cgc = cgroup_get_controller(cg, ctrl_str);
 	if (!cgc) {
@@ -234,18 +234,18 @@ out:
 	return ret;
 }
 
-static int split_cgroup_name(const char * const ctrl_str, char *cg_name)
+static int split_cgroup_name(const char * const ctrl_str, char *cgrp_name)
 {
 	char *colon;
 
 	colon = strchr(ctrl_str, ':');
 	if (colon == NULL) {
 		/* ctrl_str doesn't contain a ":" */
-		cg_name[0] = '\0';
+		cgrp_name[0] = '\0';
 		return ECGINVAL;
 	}
 
-	strncpy(cg_name, &colon[1], FILENAME_MAX - 1);
+	strncpy(cgrp_name, &colon[1], FILENAME_MAX - 1);
 
 	return 0;
 }
@@ -289,7 +289,7 @@ out:
 	return ret;
 }
 
-static int parse_g_flag_with_colon(struct cgroup **cg_list[], int * const cg_list_len,
+static int parse_g_flag_with_colon(struct cgroup **cgrp_list[], int * const cgrp_list_len,
 				   const char * const ctrl_str)
 {
 	struct cgroup_controller *cgc;
@@ -298,11 +298,11 @@ static int parse_g_flag_with_colon(struct cgroup **cg_list[], int * const cg_lis
 	int controllers_len = 0;
 	int i, ret = 0;
 
-	ret = create_cg(cg_list, cg_list_len);
+	ret = create_cg(cgrp_list, cgrp_list_len);
 	if (ret)
 		goto out;
 
-	cg = (*cg_list)[(*cg_list_len) - 1];
+	cg = (*cgrp_list)[(*cgrp_list_len) - 1];
 
 	ret = split_cgroup_name(ctrl_str, cg->name);
 	if (ret)
@@ -330,8 +330,8 @@ out:
 	return ret;
 }
 
-static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
-			  int * const cg_list_len, bool first_cg_is_dummy)
+static int parse_opt_args(int argc, char *argv[], struct cgroup **cgrp_list[],
+			  int * const cgrp_list_len, bool first_cgrp_is_dummy)
 {
 	struct cgroup *cg = NULL;
 	int ret = 0;
@@ -340,7 +340,7 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 	 * The first cgroup was temporarily populated and requires the
 	 * user to provide a cgroup name as an opt
 	 */
-	if (argv[optind] == NULL && first_cg_is_dummy) {
+	if (argv[optind] == NULL && first_cgrp_is_dummy) {
 		usage(1, argv[0]);
 		exit(EXIT_BADARGS);
 	}
@@ -354,30 +354,31 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 	 * Example of a command that will hit this code:
 	 *	$ cgxget -g cpu:mycgroup mycgroup
 	 */
-	if (argv[optind] != NULL && (*cg_list_len) > 0 && strcmp((*cg_list)[0]->name, "") != 0) {
+	if (argv[optind] != NULL && (*cgrp_list_len) > 0 &&
+	    strcmp((*cgrp_list)[0]->name, "") != 0) {
 		usage(1, argv[0]);
 		exit(EXIT_BADARGS);
 	}
 
 	while (argv[optind] != NULL) {
-		if ((*cg_list_len) > 0)
-			cg = (*cg_list)[(*cg_list_len) - 1];
+		if ((*cgrp_list_len) > 0)
+			cg = (*cgrp_list)[(*cgrp_list_len) - 1];
 		else
 			cg = NULL;
 
-		if ((*cg_list_len) == 0) {
+		if ((*cgrp_list_len) == 0) {
 			/*
 			 * The user didn't provide a '-r' or '-g' flag.
 			 * The parse_a_flag() function can be reused here
 			 * because we both have the same use case - gather
 			 * all the data about this particular cgroup.
 			 */
-			ret = parse_a_flag(cg_list, cg_list_len);
+			ret = parse_a_flag(cgrp_list, cgrp_list_len);
 			if (ret)
 				goto out;
 
-			strncpy((*cg_list)[(*cg_list_len) - 1]->name, argv[optind],
-				sizeof((*cg_list)[(*cg_list_len) - 1]->name) - 1);
+			strncpy((*cgrp_list)[(*cgrp_list_len) - 1]->name, argv[optind],
+				sizeof((*cgrp_list)[(*cgrp_list_len) - 1]->name) - 1);
 		} else if (cg != NULL && strlen(cg->name) == 0) {
 			/*
 			 * this cgroup was created based upon control/value
@@ -386,17 +387,17 @@ static int parse_opt_args(int argc, char *argv[], struct cgroup **cg_list[],
 			 */
 			strncpy(cg->name, argv[optind], sizeof(cg->name) - 1);
 		} else {
-			ret = create_cg(cg_list, cg_list_len);
+			ret = create_cg(cgrp_list, cgrp_list_len);
 			if (ret)
 				goto out;
 
-			ret = cgroup_copy_cgroup((*cg_list)[(*cg_list_len) - 1],
-						 (*cg_list)[(*cg_list_len) - 2]);
+			ret = cgroup_copy_cgroup((*cgrp_list)[(*cgrp_list_len) - 1],
+						 (*cgrp_list)[(*cgrp_list_len) - 2]);
 			if (ret)
 				goto out;
 
-			strncpy((*cg_list)[(*cg_list_len) - 1]->name, argv[optind],
-				sizeof((*cg_list)[(*cg_list_len) - 1]->name) - 1);
+			strncpy((*cgrp_list)[(*cgrp_list_len) - 1]->name, argv[optind],
+				sizeof((*cgrp_list)[(*cgrp_list_len) - 1]->name) - 1);
 		}
 
 		optind++;
@@ -406,9 +407,9 @@ out:
 	return ret;
 }
 
-static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * const cg_list_len,
-		      int * const mode, enum cg_version_t * const version,
-		      bool * const ignore_unmappable)
+static int parse_opts(int argc, char *argv[], struct cgroup **cgrp_list[],
+		      int * const cgrp_list_len, int * const mode,
+		      enum cg_version_t * const version, bool * const ignore_unmappable)
 {
 	bool do_not_fill_controller = false;
 	bool first_cgroup_is_dummy = false;
@@ -441,7 +442,7 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * c
 		case 'r':
 			do_not_fill_controller = true;
 			first_cgroup_is_dummy = true;
-			ret = parse_r_flag(cg_list, cg_list_len, optarg);
+			ret = parse_r_flag(cgrp_list, cgrp_list_len, optarg);
 			if (ret)
 				goto err;
 			break;
@@ -449,18 +450,18 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * c
 			fill_controller = true;
 			if (strchr(optarg, ':') == NULL) {
 				first_cgroup_is_dummy = true;
-				ret = parse_g_flag_no_colon(cg_list, cg_list_len, optarg);
+				ret = parse_g_flag_no_colon(cgrp_list, cgrp_list_len, optarg);
 				if (ret)
 					goto err;
 			} else {
-				ret = parse_g_flag_with_colon(cg_list, cg_list_len, optarg);
+				ret = parse_g_flag_with_colon(cgrp_list, cgrp_list_len, optarg);
 				if (ret)
 					goto err;
 			}
 			break;
 		case 'a':
 			fill_controller = true;
-			ret = parse_a_flag(cg_list, cg_list_len);
+			ret = parse_a_flag(cgrp_list, cgrp_list_len);
 			if (ret)
 				goto err;
 			break;
@@ -485,7 +486,7 @@ static int parse_opts(int argc, char *argv[], struct cgroup **cg_list[], int * c
 		exit(EXIT_BADARGS);
 	}
 
-	ret = parse_opt_args(argc, argv, cg_list, cg_list_len, first_cgroup_is_dummy);
+	ret = parse_opt_args(argc, argv, cgrp_list, cgrp_list_len, first_cgroup_is_dummy);
 	if (ret)
 		goto err;
 
@@ -494,7 +495,7 @@ err:
 }
 #endif /* !LIBCG_LIB */
 
-static int get_cv_value(struct control_value * const cv, const char * const cg_name,
+static int get_cv_value(struct control_value * const cv, const char * const cgrp_name,
 			const char * const controller_name)
 {
 	bool is_multiline = false;
@@ -502,7 +503,7 @@ static int get_cv_value(struct control_value * const cv, const char * const cg_n
 	void *handle, *tmp;
 	int ret;
 
-	ret = cgroup_read_value_begin(controller_name, cg_name, cv->name, &handle, tmp_line,
+	ret = cgroup_read_value_begin(controller_name, cgrp_name, cv->name, &handle, tmp_line,
 				      LL_MAX);
 	if (ret == ECGEOF)
 		goto read_end;
@@ -518,7 +519,7 @@ static int get_cv_value(struct control_value * const cv, const char * const cg_n
 			tmp_ret = cgroup_test_subsys_mounted(controller_name);
 			if (tmp_ret == 0) {
 				err("cgxget: cannot find controller '%s' in group '%s'\n",
-				    controller_name, cg_name);
+				    controller_name, cgrp_name);
 			} else {
 				err("variable file read failed %s\n", cgroup_strerror(ret));
 			}
@@ -733,13 +734,13 @@ static int get_cgroup_values(struct cgroup * const cg)
 }
 
 #ifndef LIBCG_LIB
-static int get_values(struct cgroup *cg_list[], int cg_list_len)
+static int get_values(struct cgroup *cgrp_list[], int cgrp_list_len)
 {
 	int ret = 0;
 	int i;
 
-	for (i = 0; i < cg_list_len; i++) {
-		ret = get_cgroup_values(cg_list[i]);
+	for (i = 0; i < cgrp_list_len; i++) {
+		ret = get_cgroup_values(cgrp_list[i]);
 		if (ret)
 			break;
 	}
@@ -780,32 +781,32 @@ static void print_cgroup(const struct cgroup * const cg, int mode)
 		info("\n");
 }
 
-static void print_cgroups(struct cgroup *cg_list[], int cg_list_len, int mode)
+static void print_cgroups(struct cgroup *cgrp_list[], int cgrp_list_len, int mode)
 {
 	int i;
 
-	for (i = 0; i < cg_list_len; i++)
-		print_cgroup(cg_list[i], mode);
+	for (i = 0; i < cgrp_list_len; i++)
+		print_cgroup(cgrp_list[i], mode);
 }
 
-static int convert_cgroups(struct cgroup **cg_list[], int cg_list_len,
+static int convert_cgroups(struct cgroup **cgrp_list[], int cgrp_list_len,
 			   enum cg_version_t in_version, enum cg_version_t out_version)
 {
-	struct cgroup **cg_converted_list;
+	struct cgroup **cgrp_converted_list;
 	int i = 0, j, ret = 0;
 
-	cg_converted_list = malloc(cg_list_len * sizeof(struct cgroup *));
-	if (cg_converted_list == NULL)
+	cgrp_converted_list = malloc(cgrp_list_len * sizeof(struct cgroup *));
+	if (cgrp_converted_list == NULL)
 		goto out;
 
-	for (i = 0; i < cg_list_len; i++) {
-		cg_converted_list[i] = cgroup_new_cgroup((*cg_list)[i]->name);
-		if (cg_converted_list[i] == NULL) {
+	for (i = 0; i < cgrp_list_len; i++) {
+		cgrp_converted_list[i] = cgroup_new_cgroup((*cgrp_list)[i]->name);
+		if (cgrp_converted_list[i] == NULL) {
 			ret = ECGCONTROLLERCREATEFAILED;
 			goto out;
 		}
 
-		ret = cgroup_convert_cgroup(cg_converted_list[i], out_version, (*cg_list)[i],
+		ret = cgroup_convert_cgroup(cgrp_converted_list[i], out_version, (*cgrp_list)[i],
 					    in_version);
 		if (ret)
 			goto out;
@@ -815,17 +816,17 @@ out:
 	if (ret != 0 && ret != ECGNOVERSIONCONVERT) {
 		/* The conversion failed */
 		for (j = 0; j < i; j++)
-			cgroup_free(&(cg_converted_list[j]));
-		free(cg_converted_list);
+			cgroup_free(&(cgrp_converted_list[j]));
+		free(cgrp_converted_list);
 	} else {
 		/*
 		 * The conversion succeeded or was unmappable.
 		 * Free the old list.
 		 */
-		for (i = 0; i < cg_list_len; i++)
-			cgroup_free(&(*cg_list)[i]);
+		for (i = 0; i < cgrp_list_len; i++)
+			cgroup_free(&(*cgrp_list)[i]);
 
-		*cg_list = cg_converted_list;
+		*cgrp_list = cgrp_converted_list;
 	}
 
 	return ret;
@@ -835,9 +836,9 @@ int main(int argc, char *argv[])
 {
 	int mode = MODE_SHOW_NAMES | MODE_SHOW_HEADERS;
 	enum cg_version_t version = CGROUP_UNK;
-	struct cgroup **cg_list = NULL;
+	struct cgroup **cgrp_list = NULL;
 	bool ignore_unmappable = false;
-	int cg_list_len = 0;
+	int cgrp_list_len = 0;
 	int ret = 0, i;
 
 	/* No parameter on input? */
@@ -856,7 +857,8 @@ int main(int argc, char *argv[])
 	mode |= MODE_SYSTEMD_DELEGATE;
 #endif
 
-	ret = parse_opts(argc, argv, &cg_list, &cg_list_len, &mode, &version, &ignore_unmappable);
+	ret = parse_opts(argc, argv, &cgrp_list, &cgrp_list_len, &mode, &version,
+			 &ignore_unmappable);
 	if (ret)
 		goto err;
 
@@ -864,7 +866,7 @@ int main(int argc, char *argv[])
 	if (mode & MODE_SYSTEMD_DELEGATE)
 		cgroup_set_default_systemd_cgroup();
 
-	ret = convert_cgroups(&cg_list, cg_list_len, version, CGROUP_DISK);
+	ret = convert_cgroups(&cgrp_list, cgrp_list_len, version, CGROUP_DISK);
 	if ((ret && ret != ECGNOVERSIONCONVERT) ||
 	    (ret == ECGNOVERSIONCONVERT && !ignore_unmappable))
 		/*
@@ -874,19 +876,19 @@ int main(int argc, char *argv[])
 		 */
 		goto err;
 
-	ret = get_values(cg_list, cg_list_len);
+	ret = get_values(cgrp_list, cgrp_list_len);
 	if (ret)
 		goto err;
 
-	ret = convert_cgroups(&cg_list, cg_list_len, CGROUP_DISK, version);
+	ret = convert_cgroups(&cgrp_list, cgrp_list_len, CGROUP_DISK, version);
 	if (ret)
 		goto err;
 
-	print_cgroups(cg_list, cg_list_len, mode);
+	print_cgroups(cgrp_list, cgrp_list_len, mode);
 
 err:
-	for (i = 0; i < cg_list_len; i++)
-		cgroup_free(&(cg_list[i]));
+	for (i = 0; i < cgrp_list_len; i++)
+		cgroup_free(&(cgrp_list[i]));
 
 	return ret;
 }

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -86,7 +86,7 @@ struct cgroup_controller *cgroup_add_controller(struct cgroup *cgroup, const cha
 	controller->cgroup = cgroup;
 	controller->index = 0;
 
-	if (strcmp(controller->name, CGROUP_FILE_PREFIX) == 0) {
+	if (strcmp(controller->name, CGRP_FILE_PREFIX) == 0) {
 		/*
 		 * Operating on the "cgroup" controller is only allowed
 		 * on cgroup v2 systems

--- a/tests/gunit/003-cg_get_cgroups_from_proc_cgroups.cpp
+++ b/tests/gunit/003-cg_get_cgroups_from_proc_cgroups.cpp
@@ -32,73 +32,67 @@ TEST_F(GetCgroupsFromProcCgroupsTest, ReadSingleLine)
 	char contents[] =
 		"5:pids:/user.slice/user-1000.slice/session-1.scope\n";
 	char *controller_list[LIST_LEN];
-	char *cgroup_list[LIST_LEN];
+	char *cgrp_list[LIST_LEN];
 	pid_t pid = 1234;
 	int ret, i;
 
 	for (i = 0; i < LIST_LEN; i++) {
 		controller_list[i] = NULL;
-		cgroup_list[i] = NULL;
+		cgrp_list[i] = NULL;
 	}
 
 	CreateCgroupProcFile(contents);
 
-	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
-			controller_list, LIST_LEN);
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgrp_list, controller_list, LIST_LEN);
 	ASSERT_EQ(ret, 0);
 	ASSERT_STREQ(controller_list[0], "pids");
-	ASSERT_STREQ(cgroup_list[0],
-		     "user.slice/user-1000.slice/session-1.scope");
+	ASSERT_STREQ(cgrp_list[0], "user.slice/user-1000.slice/session-1.scope");
 }
 
 TEST_F(GetCgroupsFromProcCgroupsTest, ReadSingleLine2)
 {
 #undef LIST_LEN
 #define LIST_LEN 1
-	char contents[] =
-		"5:cpu,cpuacct:/\n";
+	char contents[] = "5:cpu,cpuacct:/\n";
 	char *controller_list[LIST_LEN];
-	char *cgroup_list[LIST_LEN];
+	char *cgrp_list[LIST_LEN];
 	pid_t pid = 1234;
 	int ret, i;
 
 	for (i = 0; i < LIST_LEN; i++) {
 		controller_list[i] = NULL;
-		cgroup_list[i] = NULL;
+		cgrp_list[i] = NULL;
 	}
 
 	CreateCgroupProcFile(contents);
 
-	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
-			controller_list, LIST_LEN);
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgrp_list, controller_list, LIST_LEN);
 	ASSERT_EQ(ret, 0);
 	ASSERT_STREQ(controller_list[0], "cpu,cpuacct");
-	ASSERT_STREQ(cgroup_list[0], "/");
+	ASSERT_STREQ(cgrp_list[0], "/");
 }
 
 TEST_F(GetCgroupsFromProcCgroupsTest, ReadEmptyController)
 {
 #undef LIST_LEN
 #define LIST_LEN 1
-	char contents[] =
-		"0::/user.slice/user-1000.slice/session-1.scope\n";
+	char contents[] = "0::/user.slice/user-1000.slice/session-1.scope\n";
 	char *controller_list[LIST_LEN];
-	char *cgroup_list[LIST_LEN];
+	char *cgrp_list[LIST_LEN];
 	pid_t pid = 1234;
 	int ret, i;
 
 	for (i = 0; i < LIST_LEN; i++) {
 		controller_list[i] = NULL;
-		cgroup_list[i] = NULL;
+		cgrp_list[i] = NULL;
 	}
 
 	CreateCgroupProcFile(contents);
 
-	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
-			controller_list, LIST_LEN);
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgrp_list, controller_list, LIST_LEN);
 	ASSERT_EQ(ret, 0);
 	ASSERT_EQ(controller_list[0], nullptr);
-	ASSERT_EQ(cgroup_list[0], nullptr);
+	ASSERT_EQ(cgrp_list[0], nullptr);
 }
 
 TEST_F(GetCgroupsFromProcCgroupsTest, ReadExampleFile)
@@ -118,45 +112,44 @@ TEST_F(GetCgroupsFromProcCgroupsTest, ReadExampleFile)
 		"1:name=systemd:/user.slice/user-1000.slice/session-1.scope\n"
 		"0::/user.slice/user-1000.slice/session-1.scope\n";
 	char *controller_list[MAX_MNT_ELEMENTS];
-	char *cgroup_list[MAX_MNT_ELEMENTS];
+	char *cgrp_list[MAX_MNT_ELEMENTS];
 	pid_t pid = 5678;
 	int ret, i;
 
 	for (i = 0; i < MAX_MNT_ELEMENTS; i++) {
 		controller_list[i] = NULL;
-		cgroup_list[i] = NULL;
+		cgrp_list[i] = NULL;
 	}
 
 	CreateCgroupProcFile(contents);
 
-	ret = cg_get_cgroups_from_proc_cgroups(pid, cgroup_list,
-			controller_list, MAX_MNT_ELEMENTS);
+	ret = cg_get_cgroups_from_proc_cgroups(pid, cgrp_list, controller_list, MAX_MNT_ELEMENTS);
 	ASSERT_EQ(ret, 0);
 	ASSERT_STREQ(controller_list[0], "memory");
-	ASSERT_STREQ(cgroup_list[0], "user/johndoe/0");
+	ASSERT_STREQ(cgrp_list[0], "user/johndoe/0");
 	ASSERT_STREQ(controller_list[1], "perf_event");
-	ASSERT_STREQ(cgroup_list[1], "/");
+	ASSERT_STREQ(cgrp_list[1], "/");
 	ASSERT_STREQ(controller_list[2], "rdma");
-	ASSERT_STREQ(cgroup_list[2], "/");
+	ASSERT_STREQ(cgrp_list[2], "/");
 	ASSERT_STREQ(controller_list[3], "blkio");
-	ASSERT_STREQ(cgroup_list[3], "user.slice");
+	ASSERT_STREQ(cgrp_list[3], "user.slice");
 	ASSERT_STREQ(controller_list[4], "cpu,cpuacct");
-	ASSERT_STREQ(cgroup_list[4], "myCgroup");
+	ASSERT_STREQ(cgrp_list[4], "myCgroup");
 	ASSERT_STREQ(controller_list[5], "freezer");
-	ASSERT_STREQ(cgroup_list[5], "user/johndoe/0");
+	ASSERT_STREQ(cgrp_list[5], "user/johndoe/0");
 	ASSERT_STREQ(controller_list[6], "net_cls,net_prio");
-	ASSERT_STREQ(cgroup_list[6], "/");
+	ASSERT_STREQ(cgrp_list[6], "/");
 	ASSERT_STREQ(controller_list[7], "pids");
-	ASSERT_STREQ(cgroup_list[7], "user.slice/user-1000.slice/session-1.scope");
+	ASSERT_STREQ(cgrp_list[7], "user.slice/user-1000.slice/session-1.scope");
 	ASSERT_STREQ(controller_list[8], "devices");
-	ASSERT_STREQ(cgroup_list[8], "user.slice");
+	ASSERT_STREQ(cgrp_list[8], "user.slice");
 	ASSERT_STREQ(controller_list[9], "cpuset");
-	ASSERT_STREQ(cgroup_list[9], "/");
+	ASSERT_STREQ(cgrp_list[9], "/");
 	ASSERT_STREQ(controller_list[10], "hugetlb");
-	ASSERT_STREQ(cgroup_list[10], "/");
+	ASSERT_STREQ(cgrp_list[10], "/");
 	ASSERT_STREQ(controller_list[11], "name=systemd");
-	ASSERT_STREQ(cgroup_list[11], "user.slice/user-1000.slice/session-1.scope");
+	ASSERT_STREQ(cgrp_list[11], "user.slice/user-1000.slice/session-1.scope");
 
 	ASSERT_EQ(controller_list[12], nullptr);
-	ASSERT_EQ(cgroup_list[12], nullptr);
+	ASSERT_EQ(cgrp_list[12], nullptr);
 }

--- a/tests/gunit/006-cgroup_get_cgroup.cpp
+++ b/tests/gunit/006-cgroup_get_cgroup.cpp
@@ -113,8 +113,7 @@ class CgroupGetCgroupTest : public ::testing::Test {
 		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
 
 		for (i = 0; i < CONTROLLERS_CNT; i++) {
-			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
-				 "%s", CONTROLLERS[i]);
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX, "%s", CONTROLLERS[i]);
 			snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
 				 "%s/%s", PARENT_DIR, CONTROLLERS[i]);
 			cg_mount_table[i].version = CGROUP_V1;
@@ -162,29 +161,29 @@ class CgroupGetCgroupTest : public ::testing::Test {
 	}
 };
 
-static void vectorize_cg(const struct cgroup * const cg,
-			 vector<string>& cg_vec)
+static void vectorize_cgrp(const struct cgroup * const cgrp,
+			 vector<string>& cgrp_vec)
 {
 	int i, j;
 
-	for (i = 0; i < cg->index; i++) {
-		for (j = 0; j < cg->controller[i]->index; j++) {
-			string cgname(cg->name);
-			string cgcname(cg->controller[i]->name);
-			string name(cg->controller[i]->values[j]->name);
-			string value(cg->controller[i]->values[j]->value);
+	for (i = 0; i < cgrp->index; i++) {
+		for (j = 0; j < cgrp->controller[i]->index; j++) {
+			string cgrp_name(cgrp->name);
+			string cgrp_cname(cgrp->controller[i]->name);
+			string name(cgrp->controller[i]->values[j]->name);
+			string value(cgrp->controller[i]->values[j]->value);
 
-			cg_vec.push_back(cgcname + "+" + cgname + "+" +
+			cgrp_vec.push_back(cgrp_cname + "+" + cgrp_name + "+" +
 					 name + "+" + value);
 		}
 	}
 
-	sort(cg_vec.begin(), cg_vec.end());
+	sort(cgrp_vec.begin(), cgrp_vec.end());
 }
 
 static void vectorize_testdata(vector<string>& test_vec)
 {
-	string cgname(CG_NAME);
+	string cgrp_name(CG_NAME);
 	int i, j;
 
 	for (i = 0; i < CTRL_CNT; i++) {
@@ -199,12 +198,11 @@ static void vectorize_testdata(vector<string>& test_vec)
 				 */
 				continue;
 
-			string cgcname(CONTROLLERS[i]);
+			string cgrp_cname(CONTROLLERS[i]);
 			string name(NAMES[i][j]);
 			string value(VALUES[i][j]);
 
-			test_vec.push_back(cgcname + "+" + cgname + "+" +
-					   name + "+" + value);
+			test_vec.push_back(cgrp_cname + "+" + cgrp_name + "+" + name + "+" + value);
 		}
 	}
 
@@ -213,23 +211,23 @@ static void vectorize_testdata(vector<string>& test_vec)
 
 TEST_F(CgroupGetCgroupTest, CgroupGetCgroup1)
 {
-	vector<string> cg_vec, test_vec;
-	struct cgroup *cg = NULL;
+	vector<string> cgrp_vec, test_vec;
+	struct cgroup *cgrp = NULL;
 	int ret;
 
-	cg = cgroup_new_cgroup(CG_NAME);
-	ASSERT_NE(cg, nullptr);
+	cgrp = cgroup_new_cgroup(CG_NAME);
+	ASSERT_NE(cgrp, nullptr);
 
-	ret = cgroup_get_cgroup(cg);
+	ret = cgroup_get_cgroup(cgrp);
 	ASSERT_EQ(ret, 0);
 
-	vectorize_cg(cg, cg_vec);
+	vectorize_cgrp(cgrp, cgrp_vec);
 	vectorize_testdata(test_vec);
 
-	ASSERT_EQ(cg_vec, test_vec);
+	ASSERT_EQ(cgrp_vec, test_vec);
 
-	if (cg)
-		free(cg);
+	if (cgrp)
+		free(cgrp);
 }
 
 /*
@@ -238,7 +236,7 @@ TEST_F(CgroupGetCgroupTest, CgroupGetCgroup1)
 TEST_F(CgroupGetCgroupTest, CgroupGetCgroup_NoTasksFile)
 {
 	char tmp_path[FILENAME_MAX];
-	struct cgroup *cg = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret;
 
 	snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s/tasks",
@@ -246,12 +244,12 @@ TEST_F(CgroupGetCgroupTest, CgroupGetCgroup_NoTasksFile)
 	ret = rmrf(tmp_path);
 	ASSERT_EQ(ret, 0);
 
-	cg = cgroup_new_cgroup(CG_NAME);
-	ASSERT_NE(cg, nullptr);
+	cgrp = cgroup_new_cgroup(CG_NAME);
+	ASSERT_NE(cgrp, nullptr);
 
-	ret = cgroup_get_cgroup(cg);
+	ret = cgroup_get_cgroup(cgrp);
 	ASSERT_EQ(ret, ECGOTHER);
 
-	if (cg)
-		free(cg);
+	if (cgrp)
+		free(cgrp);
 }

--- a/tests/gunit/012-cgroup_create_cgroup.cpp
+++ b/tests/gunit/012-cgroup_create_cgroup.cpp
@@ -57,15 +57,13 @@ class CgroupCreateCgroupTest : public ::testing::Test {
 		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
 
 		for (i = 0; i < CONTROLLERS_CNT; i++) {
-			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
-				 "%s", CONTROLLERS[i]);
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX, "%s", CONTROLLERS[i]);
 			cg_mount_table[i].version = VERSIONS[i];
 
 			switch (VERSIONS[i]) {
 			case CGROUP_V1:
 				snprintf(cg_mount_table[i].mount.path,
-					 FILENAME_MAX, "%s/%s", PARENT_DIR,
-					 CONTROLLERS[i]);
+					 FILENAME_MAX, "%s/%s", PARENT_DIR, CONTROLLERS[i]);
 
 				ret = mkdir(cg_mount_table[i].mount.path, MODE);
 				ASSERT_EQ(ret, 0);
@@ -75,8 +73,7 @@ class CgroupCreateCgroupTest : public ::testing::Test {
 					 FILENAME_MAX, "%s", PARENT_DIR);
 
 				memset(tmp_path, 0, sizeof(tmp_path));
-				snprintf(tmp_path, FILENAME_MAX - 1,
-					 "%s/cgroup.subtree_control",
+				snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.subtree_control",
 					 PARENT_DIR);
 
 				f = fopen(tmp_path, "w");
@@ -123,8 +120,7 @@ class CgroupCreateCgroupTest : public ::testing::Test {
 	}
 };
 
-static void verify_cgroup_created(const char * const cg_name,
-				  const char * const ctrl)
+static void verify_cgroup_created(const char * const cgrp_name, const char * const ctrl)
 {
 	char tmp_path[FILENAME_MAX];
 	DIR *dir;
@@ -132,11 +128,9 @@ static void verify_cgroup_created(const char * const cg_name,
 	memset(tmp_path, 0, sizeof(tmp_path));
 
 	if (ctrl)
-		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s",
-			 PARENT_DIR, ctrl, cg_name);
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s/%s", PARENT_DIR, ctrl, cgrp_name);
 	else
-		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s",
-			 PARENT_DIR, cg_name);
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s", PARENT_DIR, cgrp_name);
 
 	dir = opendir(tmp_path);
 	ASSERT_NE(dir, nullptr);
@@ -149,8 +143,7 @@ static void verify_subtree_contents(const char * const expected)
 	FILE *f;
 
 	memset(tmp_path, 0, sizeof(tmp_path));
-	snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.subtree_control",
-		 PARENT_DIR);
+	snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.subtree_control", PARENT_DIR);
 	f = fopen(tmp_path, "r");
 	ASSERT_NE(f, nullptr);
 
@@ -161,67 +154,67 @@ static void verify_subtree_contents(const char * const expected)
 
 TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1)
 {
-	struct cgroup_controller *ctrl;
-	struct cgroup *cg = NULL;
+	const char * const cgrp_name = "MyV1Cgroup";
 	const char * const ctrl_name = "cpu";
-	const char * const cg_name = "MyV1Cgroup";
+	struct cgroup_controller *ctrl;
+	struct cgroup *cgrp = NULL;
 	int ret;
 
-	cg = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cg, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	ctrl = cgroup_add_controller(cg, ctrl_name);
+	ctrl = cgroup_add_controller(cgrp, ctrl_name);
 	ASSERT_NE(ctrl, nullptr);
 
-	ret = cgroup_create_cgroup(cg, 1);
+	ret = cgroup_create_cgroup(cgrp, 1);
 	ASSERT_EQ(ret, 0);
 
-	verify_cgroup_created(cg_name, ctrl_name);
+	verify_cgroup_created(cgrp_name, ctrl_name);
 }
 
 TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV2)
 {
-	struct cgroup_controller *ctrl;
-	struct cgroup *cg = NULL;
+	const char * const cgrp_name = "MyV2Cgroup";
 	const char * const ctrl_name = "freezer";
-	const char * const cg_name = "MyV2Cgroup";
+	struct cgroup_controller *ctrl;
+	struct cgroup *cgrp = NULL;
 	int ret;
 
-	cg = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cg, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	ctrl = cgroup_add_controller(cg, ctrl_name);
+	ctrl = cgroup_add_controller(cgrp, ctrl_name);
 	ASSERT_NE(ctrl, nullptr);
 
-	ret = cgroup_create_cgroup(cg, 0);
+	ret = cgroup_create_cgroup(cgrp, 0);
 	ASSERT_EQ(ret, 0);
 
-	verify_cgroup_created(cg_name, NULL);
+	verify_cgroup_created(cgrp_name, NULL);
 	verify_subtree_contents("+freezer");
 }
 
 TEST_F(CgroupCreateCgroupTest, CgroupCreateCgroupV1AndV2)
 {
-	struct cgroup_controller *ctrl;
-	struct cgroup *cg = NULL;
+	const char * const cgrp_name = "MyV1AndV2Cgroup";
 	const char * const ctrl1_name = "memory";
 	const char * const ctrl2_name = "cpuset";
-	const char * const cg_name = "MyV1AndV2Cgroup";
+	struct cgroup_controller *ctrl;
+	struct cgroup *cgrp = NULL;
 	int ret;
 
-	cg = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cg, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	ctrl = cgroup_add_controller(cg, ctrl1_name);
+	ctrl = cgroup_add_controller(cgrp, ctrl1_name);
 	ASSERT_NE(ctrl, nullptr);
 	ctrl = NULL;
-	ctrl = cgroup_add_controller(cg, ctrl2_name);
+	ctrl = cgroup_add_controller(cgrp, ctrl2_name);
 	ASSERT_NE(ctrl, nullptr);
 
-	ret = cgroup_create_cgroup(cg, 1);
+	ret = cgroup_create_cgroup(cgrp, 1);
 	ASSERT_EQ(ret, 0);
 
-	verify_cgroup_created(cg_name, NULL);
-	verify_cgroup_created(cg_name, ctrl2_name);
+	verify_cgroup_created(cgrp_name, NULL);
+	verify_cgroup_created(cgrp_name, ctrl2_name);
 	verify_subtree_contents("+memory");
 }

--- a/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
+++ b/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
@@ -39,13 +39,11 @@ class BuildTasksProcPathTest : public ::testing::Test {
 		int i, ret;
 
 		memset(&cg_mount_table, 0, sizeof(cg_mount_table));
-		memset(cg_namespace_table, 0,
-			CG_CONTROLLER_MAX * sizeof(cg_namespace_table[0]));
+		memset(cg_namespace_table, 0, CG_CONTROLLER_MAX * sizeof(cg_namespace_table[0]));
 
 		// Populate the mount table
 		for (i = 0; i < ENTRY_CNT; i++) {
-			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
-				 "controller%d", i);
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX, "controller%d", i);
 			cg_mount_table[i].index = i;
 
 			ret = snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
@@ -57,8 +55,7 @@ class BuildTasksProcPathTest : public ::testing::Test {
 			if (i == 0)
 				cg_mount_table[i].version = CGROUP_UNK;
 			else
-				cg_mount_table[i].version =
-					(cg_version_t)((i % 2) + 1);
+				cg_mount_table[i].version = (cg_version_t)((i % 2) + 1);
 		}
 
 		// Give a couple of the entries a namespace as well
@@ -70,12 +67,11 @@ class BuildTasksProcPathTest : public ::testing::Test {
 TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_ControllerNotFound)
 {
 	char ctrlname[] = "InvalidCtrlr";
+	char cgrp_name[] = "foo";
 	char path[FILENAME_MAX];
-	char cgname[] = "foo";
 	int ret;
 
-	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
-					    ctrlname);
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgrp_name, ctrlname);
 	ASSERT_EQ(ret, ECGOTHER);
 	ASSERT_STREQ(path, "\0");
 }
@@ -83,12 +79,11 @@ TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_ControllerNotFound)
 TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_UnknownCgVersion)
 {
 	char ctrlname[] = "controller0";
+	char cgrp_name[] = "bar";
 	char path[FILENAME_MAX];
-	char cgname[] = "bar";
 	int ret;
 
-	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
-					    ctrlname);
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgrp_name, ctrlname);
 	ASSERT_EQ(ret, ECGOTHER);
 	ASSERT_STREQ(path, "\0");
 }
@@ -96,11 +91,11 @@ TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_UnknownCgVersion)
 TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1)
 {
 	char ctrlname[] = "controller2";
+	char cgrp_name[] = "Container7";
 	char path[FILENAME_MAX];
-	char cgname[] = "Container7";
 	int ret;
 
-	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgrp_name,
 					    ctrlname);
 	ASSERT_EQ(ret, 0);
 	ASSERT_STREQ(path, "/sys/fs/cgroup/controller2/Container7/tasks");
@@ -109,11 +104,11 @@ TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1)
 TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2)
 {
 	char ctrlname[] = "controller3";
+	char cgrp_name[] = "tomcat";
 	char path[FILENAME_MAX];
-	char cgname[] = "tomcat";
 	int ret;
 
-	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgrp_name,
 					    ctrlname);
 	ASSERT_EQ(ret, 0);
 	ASSERT_STREQ(path, "/sys/fs/cgroup/controller3/tomcat/cgroup.procs");
@@ -122,11 +117,11 @@ TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2)
 TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1WithNs)
 {
 	char ctrlname[] = "controller4";
+	char cgrp_name[] = "database12";
 	char path[FILENAME_MAX];
-	char cgname[] = "database12";
 	int ret;
 
-	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgrp_name,
 					    ctrlname);
 	ASSERT_EQ(ret, 0);
 	ASSERT_STREQ(path, "/sys/fs/cgroup/controller4/ns4/database12/tasks");
@@ -135,11 +130,11 @@ TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1WithNs)
 TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2WithNs)
 {
 	char ctrlname[] = "controller1";
+	char cgrp_name[] = "server";
 	char path[FILENAME_MAX];
-	char cgname[] = "server";
 	int ret;
 
-	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgname,
+	ret = cgroup_build_tasks_procs_path(path, sizeof(path), cgrp_name,
 					    ctrlname);
 	ASSERT_EQ(ret, 0);
 	ASSERT_STREQ(path, "/sys/fs/cgroup/controller1/ns1/server/cgroup.procs");

--- a/tests/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/tests/gunit/015-cgroupv2_controller_enabled.cpp
@@ -55,8 +55,7 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 		int ret;
 
 		/* create the directory */
-		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s",
-			 PARENT_DIR, dirname);
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/%s", PARENT_DIR, dirname);
 		ret = mkdir(tmp_path, MODE);
 		ASSERT_EQ(ret, 0);
 	}
@@ -69,8 +68,7 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 
 		ASSERT_EQ(VERSIONS_CNT, CONTROLLERS_CNT);
 
-		snprintf(tmp_path, FILENAME_MAX - 1,
-			 "%s/cgroup.subtree_control", PARENT_DIR);
+		snprintf(tmp_path, FILENAME_MAX - 1, "%s/cgroup.subtree_control", PARENT_DIR);
 
 		f = fopen(tmp_path, "w");
 		ASSERT_NE(f, nullptr);
@@ -85,10 +83,8 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
 
 		for (i = 0; i < CONTROLLERS_CNT; i++) {
-			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
-				 "%s", CONTROLLERS[i]);
-			snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
-				 "%s", PARENT_DIR);
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX, "%s", CONTROLLERS[i]);
+			snprintf(cg_mount_table[i].mount.path, FILENAME_MAX, "%s", PARENT_DIR);
 			cg_mount_table[i].version = VERSIONS[i];
 		}
 	}
@@ -132,30 +128,30 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 TEST_F(CgroupV2ControllerEnabled, CgroupV1Controller)
 {
 	char ctrlr_name[] = "cpuset";
-	char cg_name[] = "foo";
+	char cgrp_name[] = "foo";
 	int ret;
 
-	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ret = cgroupv2_controller_enabled(cgrp_name, ctrlr_name);
 	ASSERT_EQ(ret, 0);
 }
 
 TEST_F(CgroupV2ControllerEnabled, RootCgroup)
 {
 	char ctrlr_name[] = "cpu";
-	char cg_name[] = "/";
+	char cgrp_name[] = "/";
 	int ret;
 
-	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ret = cgroupv2_controller_enabled(cgrp_name, ctrlr_name);
 	ASSERT_EQ(ret, 0);
 }
 
 TEST_F(CgroupV2ControllerEnabled, ControllerEnabled)
 {
 	char ctrlr_name[] = "pids";
-	char cg_name[] = "test3-ctrlrenabled";
+	char cgrp_name[] = "test3-ctrlrenabled";
 	int ret;
 
-	ret = cgroupv2_controller_enabled(cg_name, ctrlr_name);
+	ret = cgroupv2_controller_enabled(cgrp_name, ctrlr_name);
 	ASSERT_EQ(ret, 0);
 }
 

--- a/tests/gunit/017-API_fuzz_test.cpp
+++ b/tests/gunit/017-API_fuzz_test.cpp
@@ -31,7 +31,7 @@ class APIArgsTest: public :: testing:: Test {
 TEST_F(APIArgsTest, API_cgroup_set_permissions)
 {
 	mode_t dir_mode, ctrl_mode, task_mode;
-	struct cgroup * cgroup = NULL;
+	struct cgroup * cgrp = NULL;
 
 	dir_mode = (S_IRWXU | S_IXGRP | S_IXOTH);
 	ctrl_mode = (S_IRUSR | S_IWUSR | S_IRGRP);
@@ -39,7 +39,7 @@ TEST_F(APIArgsTest, API_cgroup_set_permissions)
 
 	testing::internal::CaptureStdout();
 
-	cgroup_set_permissions(cgroup, dir_mode, ctrl_mode, task_mode);
+	cgroup_set_permissions(cgrp, dir_mode, ctrl_mode, task_mode);
 
 	std::string result = testing::internal::GetCapturedStdout();
 	ASSERT_EQ(result, "Error: Cgroup, operation not allowed\n");
@@ -55,11 +55,11 @@ TEST_F(APIArgsTest, API_cgroup_set_permissions)
  */
 TEST_F(APIArgsTest, API_cgroup_new_cgroup)
 {
-	struct cgroup *cgroup = NULL;
+	struct cgroup *cgrp = NULL;
 	char *name = NULL;
 
-	cgroup = cgroup_new_cgroup(name);
-	ASSERT_EQ(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(name);
+	ASSERT_EQ(cgrp, nullptr);
 }
 
 /**
@@ -73,11 +73,11 @@ TEST_F(APIArgsTest, API_cgroup_new_cgroup)
  */
 TEST_F(APIArgsTest, API_cgroup_set_value_string)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	struct cgroup_controller * cgc = NULL;
-	const char * const cg_ctrl = "cpu";
+	const char * const cgrp_ctrl = "cpu";
 	char * name = NULL, *value = NULL;
-	struct cgroup *cgroup = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret;
 
 	// case 1
@@ -85,11 +85,11 @@ TEST_F(APIArgsTest, API_cgroup_set_value_string)
 	ret = cgroup_set_value_string(cgc, name, value);
 	ASSERT_EQ(ret, 50011);
 
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
-	ASSERT_NE(cgroup, nullptr);
+	cgc = cgroup_add_controller(cgrp, cgrp_ctrl);
+	ASSERT_NE(cgrp, nullptr);
 
 	// case 2
 	// cgc = valid, name = NULL, value = NULL
@@ -129,11 +129,11 @@ TEST_F(APIArgsTest, API_cgroup_set_value_string)
  */
 TEST_F(APIArgsTest, API_cgroup_get_value_string)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	struct cgroup_controller * cgc = NULL;
-	const char * const cg_ctrl = "cpu";
+	const char * const cgrp_ctrl = "cpu";
 	char *name = NULL, *value = NULL;
-	struct cgroup *cgroup = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret;
 
 	// case 1
@@ -141,11 +141,11 @@ TEST_F(APIArgsTest, API_cgroup_get_value_string)
 	ret = cgroup_get_value_string(cgc, name, NULL);
 	ASSERT_EQ(ret, 50011);
 
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
-	ASSERT_NE(cgroup, nullptr);
+	cgc = cgroup_add_controller(cgrp, cgrp_ctrl);
+	ASSERT_NE(cgrp, nullptr);
 
 	// case 2
 	// cgc = valid, name = NULL, value = NULL
@@ -182,31 +182,31 @@ TEST_F(APIArgsTest, API_cgroup_get_value_string)
  */
 TEST_F(APIArgsTest, API_cgroup_add_controller)
 {
-	const char * const cg_name = "FuzzerCgroup";
-	const char * const cg_ctrl = "cpu";
-	const char * const new_cg_ctrl = NULL;
+	const char * const cgrp_name = "FuzzerCgroup";
+	const char * const cgrp_ctrl = "cpu";
+	const char * const new_cgrp_ctrl = NULL;
 	struct cgroup_controller *cgc = NULL;
 	struct cgroup *cgroup = NULL;
 
 	// case 1
 	// cgrp = NULL, name = NULL
-	cgc = cgroup_add_controller(cgroup, new_cg_ctrl);
+	cgc = cgroup_add_controller(cgroup, new_cgrp_ctrl);
 	ASSERT_EQ(cgroup, nullptr);
 
 	// case 2
 	// cgrp = NULL, name = valid
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
+	cgc = cgroup_add_controller(cgroup, cgrp_ctrl);
 	ASSERT_EQ(cgroup, nullptr);
 
-	cgroup = cgroup_new_cgroup(cg_name);
+	cgroup = cgroup_new_cgroup(cgrp_name);
 	ASSERT_NE(cgroup, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
+	cgc = cgroup_add_controller(cgroup, cgrp_ctrl);
 	ASSERT_NE(cgroup, nullptr);
 
 	// case 3
 	// cgrp = valid, name = NULL
-	cgc = cgroup_add_controller(cgroup, new_cg_ctrl);
+	cgc = cgroup_add_controller(cgroup, new_cgrp_ctrl);
 	ASSERT_EQ(cgc, nullptr);
 }
 
@@ -221,10 +221,10 @@ TEST_F(APIArgsTest, API_cgroup_add_controller)
  */
 TEST_F(APIArgsTest, API_cgroup_add_value_string)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	struct cgroup_controller *cgc = NULL;
-	const char * const cg_ctrl = "cpu";
-	struct cgroup *cgroup = NULL;
+	const char * const cgrp_ctrl = "cpu";
+	struct cgroup *cgrp = NULL;
 	char * ctrl_value = NULL;
 	char * ctrl_name = NULL;
 	int ret;
@@ -236,11 +236,11 @@ TEST_F(APIArgsTest, API_cgroup_add_value_string)
 
 	// case 2
 	// cgc = valid, name = NULL, value = NULL
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
-	ASSERT_NE(cgroup, nullptr);
+	cgc = cgroup_add_controller(cgrp, cgrp_ctrl);
+	ASSERT_NE(cgrp, nullptr);
 
 	ret = cgroup_add_value_string(cgc, ctrl_name, ctrl_value);
 	ASSERT_EQ(ret, 50011);
@@ -269,49 +269,49 @@ TEST_F(APIArgsTest, API_cgroup_add_value_string)
 
 TEST_F(APIArgsTest, API_cgroup_get_uid_gid)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	uid_t tasks_uid, control_uid;
 	gid_t tasks_gid, control_gid;
 
-	struct cgroup *cgroup = NULL;
+	struct cgroup *cgrp = NULL;
 	int ret;
 	// case 1
 	// cgroup = NULL, tasks_uid = NULL, tasks_gid = NULL, control_uid = NULL,
 	// control_uid = NULL
-	ret = cgroup_get_uid_gid(cgroup, NULL, NULL, NULL, NULL);
+	ret = cgroup_get_uid_gid(cgrp, NULL, NULL, NULL, NULL);
 	ASSERT_EQ(ret, 50011);
 
 	// case 2
 	// cgroup = valid, tasks_uid = NULL, tasks_gid = NULL, control_uid = NULL,
 	// control_uid = NULL
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	ret = cgroup_get_uid_gid(cgroup, NULL, NULL, NULL, NULL);
+	ret = cgroup_get_uid_gid(cgrp, NULL, NULL, NULL, NULL);
 	ASSERT_EQ(ret, 50011);
 
 	// case 3
 	// cgroup = valid, tasks_uid = valid, tasks_gid = NULL, control_uid = NULL,
 	// control_uid = NULL
-	ret = cgroup_get_uid_gid(cgroup, &tasks_uid, NULL, NULL, NULL);
+	ret = cgroup_get_uid_gid(cgrp, &tasks_uid, NULL, NULL, NULL);
 	ASSERT_EQ(ret, 50011);
 
 	// case 4
 	// cgroup = valid, tasks_uid = valid, tasks_gid = valid, control_uid = NULL,
 	// control_uid = NULL
-	ret = cgroup_get_uid_gid(cgroup, &tasks_uid, &tasks_gid, NULL, NULL);
+	ret = cgroup_get_uid_gid(cgrp, &tasks_uid, &tasks_gid, NULL, NULL);
 	ASSERT_EQ(ret, 50011);
 
 	// case 5
 	// cgroup = valid, tasks_uid = valid, tasks_gid = valid, control_uid = valid,
 	// control_uid = NULL
-	ret = cgroup_get_uid_gid(cgroup, &tasks_uid, &tasks_gid, &control_uid, NULL);
+	ret = cgroup_get_uid_gid(cgrp, &tasks_uid, &tasks_gid, &control_uid, NULL);
 	ASSERT_EQ(ret, 50011);
 
 	// case 6
 	// cgroup = valid, tasks_uid = valid, tasks_gid = valid, control_uid = valid,
 	// control_uid = valid
-	ret = cgroup_get_uid_gid(cgroup, &tasks_uid, &tasks_gid, &control_uid, &control_gid);
+	ret = cgroup_get_uid_gid(cgrp, &tasks_uid, &tasks_gid, &control_uid, &control_gid);
 	ASSERT_EQ(ret, 0);
 }
 
@@ -326,10 +326,10 @@ TEST_F(APIArgsTest, API_cgroup_get_uid_gid)
  */
 TEST_F(APIArgsTest, API_cgroup_set_value_int64)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	struct cgroup_controller * cgc = NULL;
-	const char * const cg_ctrl = "cpu";
-	struct cgroup *cgroup = NULL;
+	const char * const cgrp_ctrl = "cpu";
+	struct cgroup *cgrp = NULL;
 	int64_t value = 1024;
 	char * name = NULL;
 	int ret;
@@ -341,11 +341,11 @@ TEST_F(APIArgsTest, API_cgroup_set_value_int64)
 
 	// case 2
 	// cgc = valid, name = NULL, value = valid
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
-	ASSERT_NE(cgroup, nullptr);
+	cgc = cgroup_add_controller(cgrp, cgrp_ctrl);
+	ASSERT_NE(cgrp, nullptr);
 
 	// set cpu.shares, so that cgc->index > 0
 	ret = cgroup_set_value_int64(cgc, "cpu.shares", 1024);
@@ -381,10 +381,10 @@ TEST_F(APIArgsTest, API_cgroup_set_value_int64)
  */
 TEST_F(APIArgsTest, API_cgroup_get_value_int64)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	struct cgroup_controller * cgc = NULL;
-	const char * const cg_ctrl = "cpu";
-	struct cgroup *cgroup = NULL;
+	const char * const cgrp_ctrl = "cpu";
+	struct cgroup *cgrp = NULL;
 	char * name = NULL;
 	int64_t value;
 	int ret;
@@ -396,11 +396,11 @@ TEST_F(APIArgsTest, API_cgroup_get_value_int64)
 
 	// case 2
 	// cgc = valid, name = NULL, value = NULL
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
-	ASSERT_NE(cgroup, nullptr);
+	cgc = cgroup_add_controller(cgrp, cgrp_ctrl);
+	ASSERT_NE(cgrp, nullptr);
 
 	// set cpu.shares, so that cgc->index > 0
 	ret = cgroup_set_value_int64(cgc, "cpu.shares", 1024);
@@ -437,10 +437,10 @@ TEST_F(APIArgsTest, API_cgroup_get_value_int64)
  */
 TEST_F(APIArgsTest, API_cgroup_set_value_uint64)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	struct cgroup_controller * cgc = NULL;
-	const char * const cg_ctrl = "cpu";
-	struct cgroup *cgroup = NULL;
+	const char * const cgrp_ctrl = "cpu";
+	struct cgroup *cgrp = NULL;
 	u_int64_t value = 1024;
 	char * name = NULL;
 	int ret;
@@ -452,11 +452,11 @@ TEST_F(APIArgsTest, API_cgroup_set_value_uint64)
 
 	// case 2
 	// cgc = valid, name = NULL, value = valid
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
-	ASSERT_NE(cgroup, nullptr);
+	cgc = cgroup_add_controller(cgrp, cgrp_ctrl);
+	ASSERT_NE(cgrp, nullptr);
 
 	// set cpu.shares, so that cgc->index > 0
 	ret = cgroup_set_value_uint64(cgc, "cpu.shares", 1024);
@@ -492,10 +492,10 @@ TEST_F(APIArgsTest, API_cgroup_set_value_uint64)
  */
 TEST_F(APIArgsTest, API_cgroup_get_value_uint64)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	struct cgroup_controller * cgc = NULL;
-	const char * const cg_ctrl = "cpu";
-	struct cgroup *cgroup = NULL;
+	const char * const cgrp_ctrl = "cpu";
+	struct cgroup *cgrp = NULL;
 	char * name = NULL;
 	u_int64_t value;
 	int ret;
@@ -507,11 +507,11 @@ TEST_F(APIArgsTest, API_cgroup_get_value_uint64)
 
 	// case 2
 	// cgc = valid, name = NULL, value = NULL
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
-	ASSERT_NE(cgroup, nullptr);
+	cgc = cgroup_add_controller(cgrp, cgrp_ctrl);
+	ASSERT_NE(cgrp, nullptr);
 
 	// set cpu.shares, so that cgc->index > 0
 	ret = cgroup_set_value_uint64(cgc, "cpu.shares", 1024);
@@ -548,10 +548,10 @@ TEST_F(APIArgsTest, API_cgroup_get_value_uint64)
  */
 TEST_F(APIArgsTest, API_cgroup_set_value_bool)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	struct cgroup_controller * cgc = NULL;
-	const char * const cg_ctrl = "cpuset";
-	struct cgroup *cgroup = NULL;
+	const char * const cgrp_ctrl = "cpuset";
+	struct cgroup *cgrp = NULL;
 	char * name = NULL;
 	bool value = 1;
 	int ret;
@@ -563,11 +563,11 @@ TEST_F(APIArgsTest, API_cgroup_set_value_bool)
 
 	// case 2
 	// cgc = valid, name = NULL, value = valid
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
-	ASSERT_NE(cgroup, nullptr);
+	cgc = cgroup_add_controller(cgrp, cgrp_ctrl);
+	ASSERT_NE(cgrp, nullptr);
 
 	// set cpuset.cpu_exclusive, so that cgc->index > 0
 	ret = cgroup_set_value_bool(cgc, "cpuset.cpu_exclusive", 0);
@@ -603,10 +603,10 @@ TEST_F(APIArgsTest, API_cgroup_set_value_bool)
  */
 TEST_F(APIArgsTest, API_cgroup_get_value_bool)
 {
-	const char * const cg_name = "FuzzerCgroup";
+	const char * const cgrp_name = "FuzzerCgroup";
 	struct cgroup_controller * cgc = NULL;
-	const char * const cg_ctrl = "cpuset";
-	struct cgroup *cgroup = NULL;
+	const char * const cgrp_ctrl = "cpuset";
+	struct cgroup *cgrp = NULL;
 	char * name = NULL;
 	bool value;
 	int ret;
@@ -618,11 +618,11 @@ TEST_F(APIArgsTest, API_cgroup_get_value_bool)
 
 	// case 2
 	// cgc = valid, name = NULL, value = NULL
-	cgroup = cgroup_new_cgroup(cg_name);
-	ASSERT_NE(cgroup, nullptr);
+	cgrp = cgroup_new_cgroup(cgrp_name);
+	ASSERT_NE(cgrp, nullptr);
 
-	cgc = cgroup_add_controller(cgroup, cg_ctrl);
-	ASSERT_NE(cgroup, nullptr);
+	cgc = cgroup_add_controller(cgrp, cgrp_ctrl);
+	ASSERT_NE(cgrp, nullptr);
 
 	// set cpuset.cpu_exclusive, so that cgc->index > 0
 	ret = cgroup_set_value_bool(cgc, "cpuset.cpu_exclusive", 0);


### PR DESCRIPTION
This patchset renames the local variable `cgroup` -> `cgrp` to match
upstream Linux Kernel, across the files (most of the occurrence)
bringing it closer to the Linux kernel cgroup code.
