### PR TITLE
Add a recursive option to cgset

### DIFF
--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -22,6 +22,9 @@ static const struct option long_options[] = {
 	{"rule",	required_argument, NULL, 'r'},
 	{"help",	      no_argument, NULL, 'h'},
 	{"copy-from",	required_argument, NULL, COPY_FROM_OPTION},
+	{"recursive",	  no_argument, NULL, 'R'},
+	{"group",	      no_argument, NULL, 'g'},
+
 	{NULL, 0, NULL, 0}
 };
 
@@ -68,6 +71,9 @@ static void usage(int status, const char *program_name)
 	info("  -r, --variable <name>			Define parameter to set\n");
 	info("  --copy-from <source_cgroup_path>	Control group whose ");
 	info("parameters will be copied\n");
+	printf("  -R recursively walk the targeted cgroup and set the variable <name> "\
+		"to all cgroups in the targeted hierarchy");
+	printf("  -g Used with the -R flag, target a specific hierachy");
 #ifdef WITH_SYSTEMD
 	info("  -b					Ignore default systemd ");
 	info("delegate hierarchy\n");
@@ -129,6 +135,102 @@ err:
 	return ret;
 }
 
+static int walk_cgroups(char (*cg_names)[FILENAME_MAX], int *name_counter, char *target, char *cgname)
+{
+	char controllers[CG_CONTROLLER_MAX][FILENAME_MAX] = {"\0"};
+	char path[FILENAME_MAX];
+	char cgroup_name[FILENAME_MAX];
+	void *handle;
+	int ret = 0;
+	int max = 0;
+	int prefix_len;
+	int lvl;
+
+	struct cgroup_file_info info;
+	struct cgroup *group = NULL;
+	struct cgroup_mount_point controller;
+
+	path[0] = '\0';
+
+	/*
+	Iterate over each cgroup subsystem and compile a list
+	of subsystem and path, keep it a array for now, as we might
+	do something fancy later
+	*/
+
+	ret = cgroup_get_controller_begin(&handle, &controller);
+
+	while (ret == 0) {
+
+		/* Only work the cgroup subsystem we are interested in */
+		if (strncmp(controller.name, target, strlen(target)) == 0)  {
+
+			strncpy(controllers[0], controller.name, FILENAME_MAX);
+			(controllers[0])[FILENAME_MAX-1] = '\0';
+
+			strncpy(path, controller.path, FILENAME_MAX);
+			path[FILENAME_MAX-1] = '\0';
+			max = 1;
+		}
+
+		/* Go to to the next available controller */
+		ret = cgroup_get_controller_next(&handle, &controller);
+	}
+
+	/* Enter*/
+	if (max != 0 && max < CG_CONTROLLER_MAX) {
+		(controllers[max])[0] = '\0';
+
+		/*
+		* start to parse the structure for the first controller -
+		* controller[0] attached to hierarchy
+		*/
+		ret = cgroup_walk_tree_begin(controllers[0], "/", 0, &handle, &info, &lvl);
+		if (ret != 0)
+			return ret;
+
+		prefix_len = strlen(info.full_path);
+
+		/* go through all files and directories */
+		while ((ret = cgroup_walk_tree_next(0, &handle, &info, lvl)) == 0) {
+
+			/* some group starts here */
+			if (info.type == CGROUP_FILE_TYPE_DIR) {
+				/* parse the group name from full_path */
+				strncpy(cgroup_name, &info.full_path[prefix_len], FILENAME_MAX);
+				cgroup_name[FILENAME_MAX-1] = '\0';
+
+				group = cgroup_new_cgroup(cgroup_name);
+				if (group == NULL) {
+					ret = ECGFAIL;
+					goto err;
+				}
+
+				if (ret == 0) {
+					if (strncmp(group->name, cgname, strlen(cgname)) == 0)  {
+						strncpy(cg_names[*name_counter], group->name, FILENAME_MAX);
+						(*name_counter)++;
+					}
+				}
+				cgroup_free(&group);
+			}
+		}
+	}
+
+err:
+	cgroup_get_controller_end(&handle);
+	if (ret != ECGEOF)
+		return ret;
+
+	return 0;
+
+	cgroup_walk_tree_end(&handle);
+	if (ret == ECGEOF)
+		ret = 0;
+
+	return ret;
+}
+
 #ifndef UNIT_TEST
 int main(int argc, char *argv[])
 {
@@ -144,6 +246,12 @@ int main(int argc, char *argv[])
 	int ret = 0;
 	int c;
 
+	int recurse = 0;
+    int name_counter = 0;
+    char cg_names[CG_CONTROLLER_MAX][4096];
+	char target[FILENAME_MAX];
+	char cgname[FILENAME_MAX];
+
 	/* no parameter on input */
 	if (argc < 2) {
 		err("Usage is %s -r <name=value> relative path to cgroup>\n", argv[0]);
@@ -152,20 +260,25 @@ int main(int argc, char *argv[])
 
 	/* parse arguments */
 #ifdef WITH_SYSTEMD
-	while ((c = getopt_long (argc, argv, "r:hb", long_options, NULL)) != -1) {
+	while ((c = getopt_long (argc, argv, "g:r:hbR", long_options, NULL)) != -1) {
 		switch (c) {
 		case 'b':
 			ignore_default_systemd_delegate_slice = 1;
 			break;
 #else
-	while ((c = getopt_long (argc, argv, "r:h", long_options, NULL)) != -1) {
+	while ((c = getopt_long (argc, argv, "g:r:hR", long_options, NULL)) != -1) {
 		switch (c) {
 #endif
 		case 'h':
 			usage(0, argv[0]);
 			ret = 0;
 			goto err;
-
+		case 'R':
+			recurse = 1;
+			break;
+		case 'g':
+			strncpy(target, optarg, FILENAME_MAX);
+			break;
 		case 'r':
 			if ((flags &  FL_COPY) != 0) {
 				usage(1, argv[0]);
@@ -222,6 +335,12 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
+	if (recurse && target[0] == '\0') {
+		fprintf(stderr, "%s: When using the -R flag, you must set a group, no Group specified with -g \n", argv[0]);
+		ret = -1;
+		goto err;
+	}
+
 	/* initialize libcgroup */
 	ret = cgroup_init();
 	if (ret) {
@@ -248,8 +367,22 @@ int main(int argc, char *argv[])
 	}
 
 	while (optind < argc) {
+		if (recurse)
+			strncpy(cgname, argv[optind], FILENAME_MAX);
+		else {
+			strncpy(cg_names[name_counter], argv[optind], FILENAME_MAX);
+			name_counter++;
+		}
+		optind++;
+	}
+
+	if (recurse)
+		/* Walk the cgroups hierachy and the names of all nested cgroups */
+		walk_cgroups(cg_names, &name_counter, target, cgname);
+
+	for (int i = 0; i <= name_counter-1; i++) {
 		/* create new cgroup */
-		cgroup = cgroup_new_cgroup(argv[optind]);
+		cgroup = cgroup_new_cgroup(cg_names[i]);
 		if (!cgroup) {
 			ret = ECGFAIL;
 			err("%s: can't add new cgroup: %s\n", argv[0], cgroup_strerror(ret));


### PR DESCRIPTION
Allow a user to specify the -R flag to recursivley change a targeted key:value under a given cgroup definition


```
# Current setting, prior to change
myhost [ ~/cg/libcgroup-2.0.1 ]$ cat /sys/fs/cgroup/memory/system.slice/system-getty.slice/memory.swappiness
50
myhost [ ~/cg/libcgroup-2.0.1 ]$ cat /sys/fs/cgroup/memory/system.slice/system getty.slice/getty@tty1.service/memory.swappiness
50

# Recursively make the change
myhost [ ~/cg/libcgroup-2.0.1 ]$ sudo  cgset -R  -g memory -r memory.swappiness=60 system.slice/system-getty.slice
myhost [ ~/cg/libcgroup-2.0.1 ]$ cat /sys/fs/cgroup/memory/system.slice/system-getty.slice/memory.swappiness
60
myhost [ ~/cg/libcgroup-2.0.1 ]$ cat /sys/fs/cgroup/memory/system.slice/system getty.slice/getty@tty1.service/memory.swappiness
60
```