### PR TITLE
tools: fix error msg in find_scope_pid()

### DIFF
--- a/src/tools/cgclassify.c
+++ b/src/tools/cgclassify.c
@@ -416,8 +416,8 @@ static pid_t find_scope_pid(pid_t pid, int capture)
 		}
 
 		if (_scope_pid != scope_pid) {
-			err("Failed to replace scope idle_thread, found two idle_thread\n");
-			err(" %u %u\n", scope_pid, _scope_pid);
+			err("Failed to replace scope idle_thread, found two idle_thread %u %u\n",
+			    scope_pid, _scope_pid);
 			scope_pid = -1;
 			goto out;
 		}

--- a/src/tools/cgexec.c
+++ b/src/tools/cgexec.c
@@ -354,8 +354,8 @@ static pid_t find_scope_pid(pid_t pid)
 		}
 
 		if (_scope_pid != scope_pid) {
-			err("Failed to replace scope idle_thread, found two idle_thread\n");
-			err(" %u %u\n", scope_pid, _scope_pid);
+			err("Failed to replace scope idle_thread, found two idle_thread %u %u\n",
+			    scope_pid, _scope_pid);
 			goto out;
 		}
 	}


### PR DESCRIPTION
This patchset fixes error messages in `cgclassify, cgexec` tools by
Un-split the error message by removing the newline character in the
`err()` in the `find_scope_pid()`.