### PR TITLE
tools/cgset: add -R option to recursively set variables

### DIFF
--- a/doc/man/cgset.1
+++ b/doc/man/cgset.1
@@ -7,9 +7,9 @@
 cgset \- set the parameters of given cgroup(s)
 
 .SH SYNOPSIS
-\fBcgset\fR [\fB-b\fR] [\fB-r\fR <\fIname=value\fR>] <\fBcgroup_path\fR> ...
+\fBcgset\fR [\fB-b\fR] [\fB-R\fR] [\fB-r\fR <\fIname=value\fR>] <\fBcgroup_path\fR> ...
 .br
-\fBcgset\fR [\fB-b\fR] \fB--copy-from\fR <\fIsource_cgroup_path\fR> <\fBcgroup_path\fR> ...
+\fBcgset\fR [\fB-b\fR] [\fB-R\fR] \fB--copy-from\fR <\fIsource_cgroup_path\fR> <\fBcgroup_path\fR> ...
 
 .SH DESCRIPTION
 Set the parameters of input cgroups.
@@ -30,6 +30,11 @@ cgroup root hierarchy.
 defines the name of the file to set and
 the value which should be written to that file.
 This parameter can be used multiple times.
+
+.TP
+.B -R
+recursively sets variable settings passed with -r option
+to cgroup_path and its descendant cgroups.
 
 .TP
 .B --copy-from <source_cgroup_path>

--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -30,6 +30,9 @@ int flags; /* used input method */
 
 static char *program_name;
 
+/* cgroup.subtree_control -r name, value */
+static struct control_value *cgrp_subtree_ctrl_val;
+
 static struct cgroup *copy_name_value_from_cgroup(char src_cg_path[FILENAME_MAX])
 {
 	struct cgroup *src_cgroup;
@@ -89,6 +92,10 @@ static int cgroup_set_cgroup_values(struct cgroup *src_cgrp, const char * const 
 	struct cgroup *cgrp;
 	int ret = ECGFAIL;
 
+	/* subtree_cgrp (src_cgrp) can be empty */
+	if (!src_cgrp)
+		return 0;
+
 	cgrp = create_and_copy_cgroup(src_cgrp, new_cgrp);
 	if (!cgrp)
 		return ret;
@@ -102,16 +109,44 @@ static int cgroup_set_cgroup_values(struct cgroup *src_cgrp, const char * const 
 	return ret;
 }
 
-static int _cgroup_set_cgroup_values_r(struct cgroup *src_cgrp, const char * const new_cgrp)
+static int is_leaf_node(void **handle)
 {
+	struct cgroup_tree_handle *entry;
+	FTSENT *ent;
+
+	entry = (struct  cgroup_tree_handle *)  *handle;
+	ent = fts_children(entry->fts, 0);
+	if (!ent)
+		return errno;
+
+	while (ent != NULL) {
+		/* return on the first child cgroup */
+		if (ent->fts_info == FTS_D)
+			return 0;
+
+		ent = ent->fts_link;
+	}
+
+	return 1;
+}
+
+static int _cgroup_set_cgroup_values_r(struct cgroup *src_cgrp, const char * const new_cgrp,
+		bool post_order_walk)
+{
+	struct cgroup_controller *ctrl = NULL;
+	bool subtree_control = false;
 	struct cgroup_file_info info;
 	int prefix_len;
 	void *handle;
 	int lvl, ret;
 
 
-	ret = cgroup_walk_tree_begin(src_cgrp->controller[0]->name, new_cgrp, 0, &handle, &info,
-			&lvl);
+	ctrl = src_cgrp->controller[0];
+
+	if (!strcmp(ctrl->values[0]->name, "cgroup.subtree_control"))
+		subtree_control = true;
+
+	ret = cgroup_walk_tree_begin(ctrl->name, new_cgrp, 0, &handle, &info, &lvl);
 	if (ret) {
 		err("%s: failed to walk the tree for cgroup %s controller %s\n",
 		    program_name, new_cgrp, src_cgrp->controller[0]->name);
@@ -119,18 +154,40 @@ static int _cgroup_set_cgroup_values_r(struct cgroup *src_cgrp, const char * con
 		return ret;
 	}
 
+	if (post_order_walk) {
+		ret = cgroup_walk_tree_set_flags(&handle, CGROUP_WALK_TYPE_POST_DIR);
+		if (ret) {
+			err("%s: failed to set CGROUP_WALK_TYPE_POST_DIR flag\n", program_name);
+			goto err;
+		}
+	}
+
 	prefix_len = strlen(info.full_path) - strlen(new_cgrp) - 1;
-	ret = cgroup_set_cgroup_values(src_cgrp, &info.full_path[prefix_len]);
-	if (ret)
-		goto err;
+
+	/* In post order cgroup tree walk, parent should be modify last */
+	if (!post_order_walk) {
+		ret = cgroup_set_cgroup_values(src_cgrp, &info.full_path[prefix_len]);
+		if (ret)
+			goto err;
+	}
 
 	while ((ret = cgroup_walk_tree_next(0, &handle, &info, lvl)) == 0) {
 		if (info.type == CGROUP_FILE_TYPE_DIR) {
+
+			/* skip modify subtree_control file for the leaf nodes */
+			if (subtree_control && is_leaf_node(&handle))
+				continue;
 
 			ret = cgroup_set_cgroup_values(src_cgrp, &info.full_path[prefix_len]);
 			if (ret)
 				goto err;
 		}
+	}
+
+	if (!post_order_walk) {
+		ret = cgroup_set_cgroup_values(src_cgrp, &info.full_path[prefix_len]);
+		if (ret)
+			goto err;
 	}
 
 err:
@@ -167,17 +224,86 @@ static int cgroup_copy_controller_idx(struct cgroup *dst_cgrp, struct cgroup *sr
 	return 0;
 }
 
+static int cgroup_populate_cgroup_ctrl(const char * const new_cgrp)
+{
+	char *ctrl, *ctrl_list = cgrp_subtree_ctrl_val->value;
+	struct cgroup_controller *cgc;
+	struct cgroup *cgrp;
+	int ret = ECGFAIL;
+
+	/* create new cgroup */
+	cgrp = cgroup_new_cgroup(new_cgrp);
+	if (!cgrp) {
+		err("%s: can't add new cgroup: %s\n", program_name, cgroup_strerror(ret));
+		return ret;
+	}
+
+	cgc =  cgroup_add_controller(cgrp, "cgroup");
+	if (!cgc)  {
+		err("%s: failed to add controller cgroup to %s\n", program_name, cgrp->name);
+		goto err;
+	}
+
+	/*
+	 * this is need for adding the controller setting, which
+	 * will be reset in the loop below.
+	 */
+	ret = cgroup_add_value_string(cgc, cgrp_subtree_ctrl_val->name,
+			cgrp_subtree_ctrl_val->value);
+	if (ret) {
+		err("%s: failed to add value %s to cgroup %s controller cgroup\n", program_name,
+				cgrp_subtree_ctrl_val->name, cgrp->name);
+		goto err;
+	}
+
+	while ((ctrl = strtok(ctrl_list, " ")) != NULL) {
+		ret = cgroup_set_value_string(cgc, cgrp_subtree_ctrl_val->name, ctrl);
+		if (ret) {
+			err("%s: failed to set value %s:%s to cgroup %s controller cgroup\n",
+			    program_name, cgrp_subtree_ctrl_val->name, ctrl, cgrp->name);
+			goto err;
+		}
+
+		if (ctrl[0] == '-')
+			ret = _cgroup_set_cgroup_values_r(cgrp, new_cgrp, true);
+		else if (ctrl[0] == '+')
+			ret = _cgroup_set_cgroup_values_r(cgrp, new_cgrp, false);
+		else
+			ret = ECGFAIL;
+
+		if (ret)
+			goto err;
+
+		ctrl_list = NULL;
+	}
+
+	ret = 0;
+
+err:
+	cgroup_free(&cgrp);
+	return ret;
+}
+
 static int cgroup_set_cgroup_values_r(struct cgroup *src_cgrp, const char * const new_cgrp)
 {
-	struct cgroup *cgrp;
+	struct cgroup *cgrp = NULL;
 	int i, ret = ECGFAIL;
 
+	if (cgrp_subtree_ctrl_val) {
+		ret = cgroup_populate_cgroup_ctrl(new_cgrp);
+		if (ret)
+			goto err;
+	}
+
 	if (is_cgroup_mode_unified()) {
+		if (!src_cgrp->index)
+			return 0;
+
 		cgrp = create_and_copy_cgroup(src_cgrp, new_cgrp);
 		if (!cgrp)
 			return ret;
 
-		ret = _cgroup_set_cgroup_values_r(cgrp, new_cgrp);
+		ret = _cgroup_set_cgroup_values_r(cgrp, new_cgrp, false);
 		goto err;
 	}
 
@@ -207,7 +333,7 @@ static int cgroup_set_cgroup_values_r(struct cgroup *src_cgrp, const char * cons
 		if (ret)
 			goto err;
 
-		ret = _cgroup_set_cgroup_values_r(cgrp, new_cgrp);
+		ret = _cgroup_set_cgroup_values_r(cgrp, new_cgrp, false);
 		if (ret)
 			goto err;
 	}
@@ -297,6 +423,25 @@ err:
 }
 
 #ifndef UNIT_TEST
+static int add_subtree_control_name_value(struct control_value *name_value)
+{
+	if (cgrp_subtree_ctrl_val) {
+		err("%s: duplicate -r %s option found\n", program_name, name_value->name);
+		return ECGFAIL;
+	}
+
+	cgrp_subtree_ctrl_val = calloc(1, sizeof(struct control_value));
+	if (!cgrp_subtree_ctrl_val) {
+		err("%s: not enough memory\n", program_name);
+		return ECGFAIL;
+	}
+
+	snprintf(cgrp_subtree_ctrl_val->name, FILENAME_MAX, "%s", name_value->name);
+	snprintf(cgrp_subtree_ctrl_val->value, CG_CONTROL_VALUE_MAX, "%s", name_value->value);
+
+	return 0;
+}
+
 int main(int argc, char *argv[])
 {
 	int ignore_default_systemd_delegate_slice = 0;
@@ -306,6 +451,7 @@ int main(int argc, char *argv[])
 	int nv_max = 0;
 
 	char src_cg_path[FILENAME_MAX] = "\0";
+	struct cgroup *subtree_cgrp = NULL;
 	struct cgroup *src_cgroup = NULL;
 
 	int ret = 0;
@@ -317,6 +463,14 @@ int main(int argc, char *argv[])
 	if (argc < 2) {
 		err("Usage is %s -r <name=value> relative path to cgroup>\n", program_name);
 		exit(EXIT_BADARGS);
+	}
+
+	/* initialize libcgroup */
+	ret = cgroup_init();
+	if (ret) {
+		err("%s: libcgroup initialization failed: %s\n", program_name,
+		    cgroup_strerror(ret));
+		goto err;
 	}
 
 	/* parse arguments */
@@ -359,7 +513,14 @@ int main(int argc, char *argv[])
 			if (ret)
 				goto err;
 
-			nv_number++;
+			if (!strcmp(name_value[nv_number].name, "cgroup.subtree_control")) {
+				ret = add_subtree_control_name_value(&name_value[nv_number]);
+				if (ret)
+					goto err;
+				memset(&name_value[nv_number], '\0', sizeof(struct control_value));
+			} else {
+				nv_number++;
+			}
 
 			break;
 		case COPY_FROM_OPTION:
@@ -412,6 +573,13 @@ int main(int argc, char *argv[])
 		src_cgroup = create_cgroup_from_name_value_pairs("tmp", name_value, nv_number);
 		if (src_cgroup == NULL)
 			goto err;
+
+		if (cgrp_subtree_ctrl_val && !recursive) {
+			subtree_cgrp = create_cgroup_from_name_value_pairs("tmp1",
+							cgrp_subtree_ctrl_val, 1);
+			if (!subtree_cgrp)
+				goto err;
+		}
 	}
 
 	/* copy the name-value from the given group */
@@ -422,10 +590,14 @@ int main(int argc, char *argv[])
 	}
 
 	while (optind < argc) {
-		if (recursive)
+		if (recursive) {
 			ret = cgroup_set_cgroup_values_r(src_cgroup, argv[optind]);
-		else
+		} else {
+			ret = cgroup_set_cgroup_values(subtree_cgrp, argv[optind]);
+			if (ret)
+				goto err;
 			ret = cgroup_set_cgroup_values(src_cgroup, argv[optind]);
+		}
 		if (ret)
 			goto err;
 
@@ -434,6 +606,7 @@ int main(int argc, char *argv[])
 
 err:
 	cgroup_free(&src_cgroup);
+	cgroup_free(&subtree_cgrp);
 	free(name_value);
 
 	return ret;

--- a/tests/ftests/089-cgset-recursive_flag.py
+++ b/tests/ftests/089-cgset-recursive_flag.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Advanced cgset functionality test - set values via the '-r' flag
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, CgroupVersion as Version
+from libcgroup import Mode
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLERS = ['cpu', 'cpuset', 'pids']
+
+PARENT = '089cgset'
+CHILD = os.path.join(PARENT, 'childcg')
+GRANDCHILD = os.path.join(CHILD, 'grandchildcg')
+
+SETTING_V1 = 'cpu.shares'
+SETTING_V2 = 'cpu.weight'
+SETTING_V1_V2 = 'cpuset.cpus'
+SETTING_V2_SUBTREE = 'cgroup.subtree_control'
+
+VALUE_V1 = '512'
+VALUE_V2 = '50'
+VALUE_V1_V2 = '0'
+VALUE_V2_SUBTREE = '+cpuset -pids'
+VALUE_V1_V2_SUBTREE = '+cpuset'
+
+DEFAULT_VALUE_V1 = '1024'
+DEFAULT_VALUE_V2 = '100'
+DEFAULT_VALUE_V1_V2 = '0-1'
+
+
+def prereqs(config):
+    pass
+
+
+def is_hybrid_with_ctrl(config):
+    if Cgroup.get_cgroup_mode(config) == Mode.CGROUP_MODE_HYBRID:
+        if (Version.get_version(CONTROLLERS[1]) == Version.CGROUP_V2):
+            return True
+
+    return False
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLERS[0], GRANDCHILD)
+
+    if (is_hybrid_with_ctrl(config)):
+        Cgroup.create(config, None, GRANDCHILD)
+
+
+def cgroup_settings_helper(config, SETTING, VALUE, DEF_VAL):
+
+    Cgroup.set(config, cgname=PARENT, setting=SETTING, value=VALUE,
+               recursive=True)
+
+    Cgroup.get_and_validate(config, PARENT, SETTING, VALUE)
+    Cgroup.get_and_validate(config, CHILD,  SETTING, VALUE)
+    Cgroup.get_and_validate(config, GRANDCHILD, SETTING, VALUE)
+
+    Cgroup.set(config, cgname=PARENT, setting=SETTING, value=DEF_VAL,
+               recursive=False)
+
+    Cgroup.get_and_validate(config, PARENT, SETTING, DEF_VAL)
+    Cgroup.get_and_validate(config, CHILD, SETTING,  VALUE)
+    Cgroup.get_and_validate(config, GRANDCHILD, SETTING, VALUE)
+
+
+def cgroup_subtree_helper(config, SUBTREE, SUBTREE_VAL):
+    result = consts.TEST_PASSED
+    cause = None
+
+    Cgroup.set(config, cgname=PARENT, setting=SUBTREE, value=SUBTREE_VAL,
+               recursive=True)
+
+    # checking if the controller is enabled in granchildcg, in turn will
+    # check its parent cgroup childcg's subtree_control file, if it's enabled
+    # in parent cgroup, it's also enabled in the grandparent too.
+    if not Cgroup.is_controller_enabled(config, GRANDCHILD, CONTROLLERS[1]):
+        result = consts.TEST_FAILED
+        cause = 'Controller {} is not enabled in the child cgroup'.format(CONTROLLERS[1])
+
+    # check if 'cpuset' controller is enabled
+    if not Cgroup.is_controller_enabled(config, GRANDCHILD, CONTROLLERS[1]):
+        result = consts.TEST_FAILED
+        tmp_cause = ('Controller {} is not enabled in the child cgroup'
+                     ''.format('cpuset'))
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # check if 'pids' controller is enabled
+    if Cgroup.get_cgroup_mode(config) == Mode.CGROUP_MODE_UNIFIED:
+        if Cgroup.is_controller_enabled(config, GRANDCHILD, CONTROLLERS[2]):
+            result = consts.TEST_FAILED
+            tmp_cause = ('Controller {} is enabled in the child cgroup'
+                         ''.format('pids'))
+            cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # for the grandchildcg read it's cgroup.subtree_control, is_controller_enabled
+    # will check its parent cgroup childcg's subtree_control
+    if Cgroup.get(config, None, GRANDCHILD, setting='cgroup.subtree_control',
+                  print_headers=False, values_only=True):
+        result = consts.TEST_FAILED
+        tmp_cause = 'Controller {} enabled in grandchild cgroup'.format(CONTROLLERS[1])
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def test_cgroup_legacy(config):
+    cgroup_settings_helper(config, SETTING_V1, VALUE_V1, DEFAULT_VALUE_V1)
+
+    return consts.TEST_PASSED, None
+
+
+def test_cgroup_hybrid(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cgroup_settings_helper(config, SETTING_V1, VALUE_V1, DEFAULT_VALUE_V1)
+
+    if (is_hybrid_with_ctrl(config)):
+        result, cause = cgroup_subtree_helper(config, SETTING_V2_SUBTREE,
+                                              VALUE_V1_V2_SUBTREE)
+
+        cgroup_settings_helper(config, SETTING_V1_V2, VALUE_V1_V2, DEFAULT_VALUE_V1_V2)
+
+    return result, cause
+
+
+def test_cgroup_unified(config):
+    cgroup_settings_helper(config, SETTING_V2, VALUE_V2, DEFAULT_VALUE_V2)
+    result, cause = cgroup_subtree_helper(config, SETTING_V2_SUBTREE, VALUE_V2_SUBTREE)
+
+    return result, cause
+
+
+def test(config):
+
+    if Cgroup.get_cgroup_mode(config) == Mode.CGROUP_MODE_UNIFIED:
+        result, cause = test_cgroup_unified(config)
+    elif Cgroup.get_cgroup_mode(config) == Mode.CGROUP_MODE_HYBRID:
+        result, cause = test_cgroup_hybrid(config)
+    else:
+        result, cause = test_cgroup_legacy(config)
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLERS[0], PARENT, recursive=True)
+    if (is_hybrid_with_ctrl(config)):
+        Cgroup.delete(config, None, PARENT, recursive=True)
+
+
+def main(config):
+    prereqs(config)
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -246,7 +246,7 @@ class Cgroup(object):
 
     @staticmethod
     def __set(config, cmd, cgname=None, setting=None, value=None,
-              copy_from=None, cghelp=False, ignore_systemd=False):
+              copy_from=None, cghelp=False, ignore_systemd=False, recursive=False):
         if setting is not None or value is not None:
             if isinstance(setting, str) and (isinstance(value, str) or isinstance(value, int)):
                 cmd.append('-r')
@@ -286,6 +286,9 @@ class Cgroup(object):
         if cghelp:
             cmd.append('-h')
 
+        if recursive:
+            cmd.append('-R')
+
         if config.args.container:
             return config.container.run(cmd)
         else:
@@ -293,7 +296,7 @@ class Cgroup(object):
 
     @staticmethod
     def set(config, cgname=None, setting=None, value=None, copy_from=None,
-            cghelp=False, ignore_systemd=False):
+            cghelp=False, ignore_systemd=False, recursive=False):
         """cgset equivalent method
 
         The following variants of cgset are being tested by the
@@ -315,7 +318,7 @@ class Cgroup(object):
         cmd.append(Cgroup.build_cmd_path('cgset'))
 
         return Cgroup.__set(config, cmd, cgname, setting, value, copy_from,
-                            cghelp, ignore_systemd)
+                            cghelp, ignore_systemd, recursive)
 
     @staticmethod
     def xset(config, cgname=None, setting=None, value=None, copy_from=None,


### PR DESCRIPTION
Add `-R` option to recursively set variable(s) passed to cgroups under `<cgroup_path>`. 
This will help users to set a controller setting for all the cgroups under a cgroup hierarchy,
instead of passing the cgroups multiple times on the command line.
```
example:
--------
./cgcreate -gcpu,memory:foo -gcpu:memory:foo/ch1 -gcpu,memory:foo/ch2 ./cgget -r cpu.shares foo foo/ch1 foo/ch2
foo:
cpu.shares: 1024

foo/ch1:
cpu.shares: 1024

foo/ch2:
cpu.shares: 1024

Without the patch
------------------
./cgset -r cpu.shares=256 foo
./cgget -r cpu.shares foo
foo/ch1 foo/ch2
foo:
cpu.shares: 256

foo/ch1:
cpu.shares: 1024

foo/ch2:
cpu.shares: 1024

With the patch
--------------
./cgset -R -r cpu.shares=512 foo
./cgget  -r cpu.shares foo foo/ch1 foo/ch2
foo:
cpu.shares: 512

foo/ch1:
cpu.shares: 512

foo/ch2:
cpu.shares: 512
```