### PR TITLE
api.c: enable controller in the root_cgroup.subtree_file

### DIFF
--- a/tests/ftests/091-cgcreate-non-default-controllers-v2.py
+++ b/tests/ftests/091-cgcreate-non-default-controllers-v2.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgcreate non default controller functionality test
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup, Mode
+import consts
+import ftests
+import sys
+import os
+
+CONTROLLERS = ['hugetlb', 'misc']
+
+CGNAME = '090cgcreate'
+CGNAME1 = os.path.join(CGNAME, 'childcg')
+CGNAME2 = os.path.join(CGNAME1, 'grandchildcg')
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if Cgroup.get_cgroup_mode(config) != Mode.CGROUP_MODE_UNIFIED:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires the unified cgroup v2 hierarchy'
+
+    return result, cause
+
+
+def setup(config):
+    Cgroup.create(config, CONTROLLERS, CGNAME2)
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    # checking if the controller is enabled in granchildcg, in turn will
+    # check its parent cgroup childcg's subtree_control file, if it's enabled
+    # in parent cgroup, it's also enabled in the grandparent too.
+    if not Cgroup.is_controller_enabled(config, CGNAME2, CONTROLLERS[0]):
+        result = consts.TEST_FAILED
+        cause = 'Controller {} is not enabled in the child cgroup'.format(CONTROLLERS[0])
+
+    if not Cgroup.is_controller_enabled(config, CGNAME2, CONTROLLERS[1]):
+        result = consts.TEST_FAILED
+        tmp_cause = 'Controller {} is not enabled in the child cgroup'.format(CONTROLLERS[1])
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    # for the grandchildcg read it cgroup.subtree_control, is_controller_enabled
+    # will check its parent cgroup childcg's subtree_control
+    if Cgroup.get(config, None, CGNAME2, setting='cgroup.subtree_control',
+                  print_headers=False, values_only=True):
+        result = consts.TEST_FAILED
+        tmp_cause = 'Controller {} enabled in grandchild cgroup'.format(CONTROLLERS[0])
+        cause = '\n'.join(filter(None, [cause, tmp_cause]))
+
+    return result, cause
+
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLERS, CGNAME, recursive=True)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/tests/gunit/012-cgroup_create_cgroup.cpp
+++ b/tests/gunit/012-cgroup_create_cgroup.cpp
@@ -82,6 +82,16 @@ class CgroupCreateCgroupTest : public ::testing::Test {
 				f = fopen(tmp_path, "w");
 				ASSERT_NE(f, nullptr);
 				fclose(f);
+
+				memset(tmp_path, 0, sizeof(tmp_path));
+				snprintf(tmp_path, FILENAME_MAX - 1,
+					 "%s/cgroup.controllers",
+					 PARENT_DIR);
+
+				f = fopen(tmp_path, "a");
+				ASSERT_NE(f, nullptr);
+				fprintf(f, "%s ",  CONTROLLERS[i]);
+				fclose(f);
 				break;
 			default:
 				/* we shouldn't get here.  fail the test */


### PR DESCRIPTION
`systemd` by default only enables `cpu, cpuset, io, memory`, and `pids`
controller the `root_cgroup.subtree_control`. Trying to enable other
controllers (`hugetlb` and `misc`) in a nested cgroups create scenario,
will fail because they are not, enabling the controller in the
`root_cgroup.subtree_control` file.
    
```
$ sudo cgcreate -ghugetlb:foo/bar
Error: Failed to delete foo/bar: No such file or directory
cgcreate: can't create cgroup foo/bar: No such file or directory
```
    
Fix this by enabling the controller in the `root_cgroup.subtree_control`
file unconditionally for all controllers, if not already enabled, while
calling `cgroupv2_subtree_control_recursive()` to enable the controller
in the given cgroup and its descendants. Checking and enabling every
controller unconditionally should work in the future, in case systemd
disables some other controllers too.

This patchset has two other patches, that update the `gunit/012` test
to adopt the new checks and add new `ftests` test cases that will recreate
the nested cgroups with `hugetlb` and `misc` controllers.

Fixes: #405 