### PR TITLE
Fix gunit test build warnings

### DIFF
--- a/tests/gunit/001-path.cpp
+++ b/tests/gunit/001-path.cpp
@@ -50,7 +50,7 @@ class BuildPathV1Test : public ::testing::Test {
 
 			ret = snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
 				 "/sys/fs/cgroup/%s", cg_mount_table[i].name);
-			ASSERT_LT(ret, sizeof(cg_mount_table[i].mount.path));
+			ASSERT_LT(ret, (int)sizeof(cg_mount_table[i].mount.path));
 
 			cg_mount_table[i].mount.next = NULL;
 		}

--- a/tests/gunit/006-cgroup_get_cgroup.cpp
+++ b/tests/gunit/006-cgroup_get_cgroup.cpp
@@ -94,7 +94,7 @@ class CgroupGetCgroupTest : public ::testing::Test {
 	void SetUp() override
 	{
 		char tmp_path[FILENAME_MAX];
-		int i, j, names_len, ret;
+		int i, ret;
 
 		ASSERT_EQ(NAMES_CNT, CONTROLLERS_CNT);
 		ASSERT_EQ(NAMES_CNT, VALUES_CNT);
@@ -165,7 +165,6 @@ class CgroupGetCgroupTest : public ::testing::Test {
 static void vectorize_cg(const struct cgroup * const cg,
 			 vector<string>& cg_vec)
 {
-	const char *cgname, *cgcname, *value;
 	int i, j;
 
 	for (i = 0; i < cg->index; i++) {

--- a/tests/gunit/008-cgroup_process_v2_mount.cpp
+++ b/tests/gunit/008-cgroup_process_v2_mount.cpp
@@ -55,10 +55,6 @@ class CgroupProcessV2MntTest : public ::testing::Test {
 
 	void SetUp() override
 	{
-		char tmp_path[FILENAME_MAX];
-		int i, ret;
-		FILE *f;
-
 		CreateHierarchy(PARENT_DIR);
 
 		/* make another directory to test the duplicate logic */

--- a/tests/gunit/009-cgroup_set_values_recursive.cpp
+++ b/tests/gunit/009-cgroup_set_values_recursive.cpp
@@ -93,9 +93,13 @@ TEST_F(SetValuesRecursiveTest, SuccessfulSetValues)
 					sizeof(struct control_value));
 		ASSERT_NE(ctrlr.values[i], nullptr);
 
-		strncpy(ctrlr.values[i]->name, NAMES[i], FILENAME_MAX);
+		strncpy(ctrlr.values[i]->name, NAMES[i], FILENAME_MAX - 1);
+		ctrlr.values[i]->name[FILENAME_MAX - 1] = '\0';
+
 		strncpy(ctrlr.values[i]->value, VALUES[i],
-			CG_CONTROL_VALUE_MAX);
+			CG_CONTROL_VALUE_MAX - 1);
+		ctrlr.values[i]->value[CG_CONTROL_VALUE_MAX - 1] = '\0';
+
 		if (i == 0)
 			ctrlr.values[i]->dirty = true;
 		else

--- a/tests/gunit/011-cgroupv2_subtree_control.cpp
+++ b/tests/gunit/011-cgroupv2_subtree_control.cpp
@@ -21,7 +21,7 @@ class SubtreeControlTest : public ::testing::Test {
 
 	void SetUp() override {
 		char tmp_path[FILENAME_MAX];
-		int ret, i;
+		int ret;
 		FILE *f;
 
 		ret = mkdir(PARENT_DIR, S_IRWXU | S_IRWXG | S_IRWXO);

--- a/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
+++ b/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
@@ -50,7 +50,7 @@ class BuildTasksProcPathTest : public ::testing::Test {
 
 			ret = snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
 				 "/sys/fs/cgroup/%s", cg_mount_table[i].name);
-			ASSERT_LT(ret, sizeof(cg_mount_table[i].mount.path));
+			ASSERT_LT(ret, (int)sizeof(cg_mount_table[i].mount.path));
 
 			cg_mount_table[i].mount.next = NULL;
 
@@ -109,7 +109,6 @@ TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1)
 TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2)
 {
 	char ctrlname[] = "controller3";
-	struct cgroup_controller ctrlr = {0};
 	char path[FILENAME_MAX];
 	char cgname[] = "tomcat";
 	int ret;
@@ -123,7 +122,6 @@ TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2)
 TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1WithNs)
 {
 	char ctrlname[] = "controller4";
-	struct cgroup_controller ctrlr = {0};
 	char path[FILENAME_MAX];
 	char cgname[] = "database12";
 	int ret;
@@ -137,7 +135,6 @@ TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV1WithNs)
 TEST_F(BuildTasksProcPathTest, BuildTasksProcPathTest_CgV2WithNs)
 {
 	char ctrlname[] = "controller1";
-	struct cgroup_controller ctrlr = {0};
 	char path[FILENAME_MAX];
 	char cgname[] = "server";
 	int ret;

--- a/tests/gunit/014-cgroupv2_get_subtree_control.cpp
+++ b/tests/gunit/014-cgroupv2_get_subtree_control.cpp
@@ -24,9 +24,7 @@ class GetSubtreeControlTest : public ::testing::Test {
 	protected:
 
 	void SetUp() override {
-		char tmp_path[FILENAME_MAX];
-		int ret, i;
-		FILE *f;
+		int ret;
 
 		ret = mkdir(PARENT_DIR, S_IRWXU | S_IRWXG | S_IRWXO);
 		ASSERT_EQ(ret, 0);

--- a/tests/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/tests/gunit/015-cgroupv2_controller_enabled.cpp
@@ -64,8 +64,8 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 	void InitMountTable(void)
 	{
 		char tmp_path[FILENAME_MAX] = {0};
-		int ret, i;
 		FILE *f;
+		int i;
 
 		ASSERT_EQ(VERSIONS_CNT, CONTROLLERS_CNT);
 

--- a/tests/gunit/017-API_fuzz_test.cpp
+++ b/tests/gunit/017-API_fuzz_test.cpp
@@ -187,7 +187,6 @@ TEST_F(APIArgsTest, API_cgroup_add_controller)
 	const char * const new_cg_ctrl = NULL;
 	struct cgroup_controller *cgc = NULL;
 	struct cgroup *cgroup = NULL;
-	int ret;
 
 	// case 1
 	// cgrp = NULL, name = NULL
@@ -477,7 +476,7 @@ TEST_F(APIArgsTest, API_cgroup_set_value_uint64)
 	// check if the value was set right
 	ret = cgroup_get_value_uint64(cgc, name, &value);
 	ASSERT_EQ(ret, 0);
-	ASSERT_EQ(value, 1024);
+	ASSERT_EQ((int)value, 1024);
 
 	free(name);
 }


### PR DESCRIPTION
This patchset fixes the build warnings across the gunit test cases,
it fixes warnings such as `unused variables`, `signed comparison`
and `string truncation` with no functional changes