### PR TITLE
[RFC] Add support to move all threads into a cgroup (v1)

### DIFF
--- a/include/libcgroup/tasks.h
+++ b/include/libcgroup/tasks.h
@@ -204,6 +204,13 @@ int cgroup_change_cgroup_uid_gid(uid_t uid, gid_t gid, pid_t pid);
 int cgroup_register_unchanged_process(pid_t pid, int flags);
 
 /**
+ * Move given threads (=thread) to given control group.
+ * @param cgroup Destination control group.
+ * @param tid The task to move.
+ */
+int cgroup_attach_thread_tid(struct cgroup *cgroup, pid_t tid);
+
+/**
  * @}
  * @}
  */

--- a/src/api.c
+++ b/src/api.c
@@ -2140,6 +2140,20 @@ int cgroup_attach_task(struct cgroup *cgroup)
 }
 
 /**
+ *  cgroup_attach_thread_tid is used to assign threads to a cgroup.
+ *  struct cgroup *cgroup: The cgroup to assign the thread to.
+ *  pid_t tid: The thread to be assigned to the cgroup.
+ *
+ *  returns 0 on success.
+ *  returns ECGROUPNOTOWNER if the caller does not have access to the cgroup.
+ *  returns ECGROUPNOTALLOWED for other causes of failure.
+ */
+int cgroup_attach_thread_tid(struct cgroup *cgroup, pid_t tid)
+{
+	return cgroup_attach_task_tid(cgroup, tid, 1);
+}
+
+/**
  * cg_mkdir_p, emulate the mkdir -p command (recursively creating paths)
  * @path: path to create
  */

--- a/src/api.c
+++ b/src/api.c
@@ -2012,16 +2012,7 @@ err:
 	return ret;
 }
 
-/**
- *  cgroup_attach_task_pid is used to assign tasks to a cgroup.
- *  struct cgroup *cgroup: The cgroup to assign the thread to.
- *  pid_t tid: The thread to be assigned to the cgroup.
- *
- *  returns 0 on success.
- *  returns ECGROUPNOTOWNER if the caller does not have access to the cgroup.
- *  returns ECGROUPNOTALLOWED for other causes of failure.
- */
-int cgroup_attach_task_pid(struct cgroup *cgroup, pid_t tid)
+static int cgroup_attach_task_tid(struct cgroup *cgroup, pid_t tid)
 {
 	char path[FILENAME_MAX] = {0};
 	char *controller_name;
@@ -2087,6 +2078,20 @@ int cgroup_attach_task_pid(struct cgroup *cgroup, pid_t tid)
 }
 
 /**
+ *  cgroup_attach_task_pid is used to assign tasks to a cgroup.
+ *  struct cgroup *cgroup: The cgroup to assign the thread to.
+ *  pid_t tid: The thread to be assigned to the cgroup.
+ *
+ *  returns 0 on success.
+ *  returns ECGROUPNOTOWNER if the caller does not have access to the cgroup.
+ *  returns ECGROUPNOTALLOWED for other causes of failure.
+ */
+int cgroup_attach_task_pid(struct cgroup *cgroup, pid_t tid)
+{
+	return cgroup_attach_task_tid(cgroup, tid);
+}
+
+/**
  * cgroup_attach_task is used to attach the current thread to a cgroup.
  * struct cgroup *cgroup: The cgroup to assign the current thread to.
  *
@@ -2095,11 +2100,8 @@ int cgroup_attach_task_pid(struct cgroup *cgroup, pid_t tid)
 int cgroup_attach_task(struct cgroup *cgroup)
 {
 	pid_t tid = cg_gettid();
-	int error;
 
-	error = cgroup_attach_task_pid(cgroup, tid);
-
-	return error;
+	return cgroup_attach_task_tid(cgroup, tid);
 }
 
 /**

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -162,4 +162,5 @@ CGROUP_3.0 {
 	is_cgroup_mode_hybrid;
 	is_cgroup_mode_unified;
 	cgroup_is_systemd_enabled;
+	cgroup_attach_thread_tid;
 } CGROUP_2.0;

--- a/src/python/cgroup.pxd.m4
+++ b/src/python/cgroup.pxd.m4
@@ -133,4 +133,6 @@ cdef extern from "libcgroup.h":
 
     bool cgroup_is_systemd_enabled()
 
+    int cgroup_attach_thread_tid(cgroup * cgroup, pid_t tid)
+
 # vim: set et ts=4 sw=4:

--- a/tests/ftests/092-sudo-cgroup_attach_thread_tid.py
+++ b/tests/ftests/092-sudo-cgroup_attach_thread_tid.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Attach a task to a cgroup via cgroup_attach_thread_tid()
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from cgroup import Cgroup as CgroupCli
+from libcgroup import Cgroup, Version
+from cgroup import CgroupVersion
+from process import Process
+import ftests
+import consts
+import sys
+import os
+
+CGNAME1 = '092cgattachcg1'
+CGNAME2 = '092cgattachcg2'
+CONTROLLER = 'cpu'
+THREADS = 3
+
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = 'This test requires cgroup v1'
+
+    return result, cause
+
+
+def setup(config):
+    cg = Cgroup(CGNAME1, Version.CGROUP_V1)
+    cg.add_controller(CONTROLLER)
+    cg.create()
+
+    cg = Cgroup(CGNAME2, Version.CGROUP_V1)
+    cg.add_controller(CONTROLLER)
+    cg.create()
+
+
+def read_cgroup_tasks_file(config, CONTROLLER, CGNAME):
+    mnt_path = CgroupCli.get_controller_mount_point(CONTROLLER)
+    path = os.path.join(mnt_path, CGNAME, "tasks")
+
+    cgrp_pids = [line.strip() for line in open(path, 'r')]
+    return cgrp_pids
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    config.process.create_threaded_process_in_cgroup(config, CONTROLLER, CGNAME1, THREADS)
+
+    threads_tid_cg1 = read_cgroup_tasks_file(config, CONTROLLER, CGNAME1)
+    if len(threads_tid_cg1) == 0:
+        result = consts.TEST_FAILED
+        cause = 'No threads found in cgroup {}'.format(CGNAME1)
+        return result, cause
+
+    cg = Cgroup(CGNAME2, Version.CGROUP_V1)
+    cg.add_controller(CONTROLLER)
+    cg.attach(int(threads_tid_cg1[0]), attach_threads=True)
+
+    threads_tid_cg2 = read_cgroup_tasks_file(config, CONTROLLER, CGNAME2)
+    if len(threads_tid_cg2) == 0:
+        result = consts.TEST_FAILED
+        cause = 'Thread attach from cgroup {} to {}, failed'.format(CGNAME1, CGNAME2)
+        return result, cause
+
+    threads_tid_cg1.sort()
+    threads_tid_cg2.sort()
+
+    if threads_tid_cg1 != threads_tid_cg2:
+        result = consts.TEST_FAILED
+        cause = 'Not all threads have moved from cgroup {} to {}'. format(CGNAME1, CGNAME2)
+        return result, cause
+
+    threads_tid_cg1 = read_cgroup_tasks_file(config, CONTROLLER, CGNAME1)
+    if len(threads_tid_cg1) != 0:
+        result = consts.TEST_FAILED
+        cause = 'Threads found in cgroup {} expected none'.format(CGNAME1)
+
+    return result, cause
+
+
+def teardown(config, result):
+    # Incase the migration fails, kill the process in CGNAME1
+    pids = CgroupCli.get_pids_in_cgroup(config, CGNAME1, CONTROLLER)
+    Process.kill(config, pids)
+
+    pids = CgroupCli.get_pids_in_cgroup(config, CGNAME2, CONTROLLER)
+    Process.kill(config, pids)
+
+    CgroupCli.delete(config, CONTROLLER, CGNAME1)
+    CgroupCli.delete(config, CONTROLLER, CGNAME2)
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        result = consts.TEST_FAILED
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config, result)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
This patchset, adds a new API `cgroup_attach_thread_tids()` that allows
the users to move all threads under a cgroup v1 controller hierarchy by
writing the `tid` of a thread into `cgroup.procs` file, which moves all the
sibling threads to the cgroup.  This patchset, also improves pybinding
`attach()` to be aware of moving threads and a test case to stress the
same.