### PR TITLE
systemd: fix non-systemd configuration support

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -2,8 +2,4 @@
 nobase_include_HEADERS = libcgroup.h libcgroup/error.h libcgroup/init.h \
 			 libcgroup/groups.h libcgroup/tasks.h \
 			 libcgroup/iterators.h libcgroup/config.h \
-			 libcgroup/log.h libcgroup/tools.h
-
-if WITH_SYSTEMD
-nobase_include_HEADERS += libcgroup/systemd.h
-endif
+			 libcgroup/log.h libcgroup/tools.h libcgroup/systemd.h

--- a/include/libcgroup/systemd.h
+++ b/include/libcgroup/systemd.h
@@ -133,6 +133,11 @@ void cgroup_cleanup_systemd_opts(void);
 int cgroup_write_systemd_default_cgroup(const char * const slice,
 					const char * const scope);
 
+/*
+ * Return true if systemd support is compiled into the libcgroup library
+ */
+bool cgroup_is_systemd_enabled(void);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,10 @@ SUBDIRS = . daemon pam tools
 if ENABLE_PYTHON
 SUBDIRS += python
 endif
+
+if WITH_SYSTEMD
 EXTRA_DIST = libcgroup_systemd_idle_thread
+endif
 
 # generate parse.h  from parse.y
 AM_YFLAGS = -d
@@ -28,10 +31,7 @@ lib_LTLIBRARIES = libcgroup.la
 libcgroup_la_SOURCES = parse.h parse.y lex.l api.c config.c libcgroup-internal.h libcgroup.map \
 		       wrapper.c log.c abstraction-common.c abstraction-common.h \
 		       abstraction-map.c abstraction-map.h abstraction-cpu.c abstraction-cpuset.c \
-		       tools/cgxget.c tools/cgxset.c
-if WITH_SYSTEMD
-libcgroup_la_SOURCES += systemd.c
-endif
+		       systemd.c tools/cgxget.c tools/cgxset.c
 
 libcgroup_la_LIBADD = -lpthread $(CODE_COVERAGE_LIBS)
 libcgroup_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC=static -DLIBCG_LIB -fPIC
@@ -47,10 +47,7 @@ noinst_LTLIBRARIES = libcgroupfortesting.la
 libcgroupfortesting_la_SOURCES = parse.h parse.y lex.l api.c config.c libcgroup-internal.h \
 				 libcgroup.map wrapper.c log.c abstraction-common.c \
 				 abstraction-common.h abstraction-map.c abstraction-map.h \
-				 abstraction-cpu.c abstraction-cpuset.c
-if WITH_SYSTEMD
-libcgroupfortesting_la_SOURCES += systemd.c
-endif
+				 abstraction-cpu.c abstraction-cpuset.c systemd.c
 
 libcgroupfortesting_la_LIBADD = -lpthread $(CODE_COVERAGE_LIBS)
 libcgroupfortesting_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC= -DUNIT_TEST

--- a/src/config.c
+++ b/src/config.c
@@ -19,7 +19,6 @@
 
 #include <libcgroup.h>
 #include <libcgroup-internal.h>
-#include <libcgroup/systemd.h>
 
 #include <pthread.h>
 #include <assert.h>
@@ -2284,18 +2283,28 @@ err:
 #else
 int cgroup_add_systemd_opts(const char * const config, const char * const value)
 {
-	return 1;
+	cgroup_err("Systemd support not compiled\n");
+	return 0;
 }
 
 int cgroup_alloc_systemd_opts(const char * const config, const char * const value)
 {
-	return 1;
+	cgroup_err("Systemd support not compiled\n");
+	return 0;
 }
 
 void cgroup_cleanup_systemd_opts(void) { }
 
 int cgroup_set_default_systemd_cgroup(void)
 {
+	cgroup_err("Systemd support not compiled\n");
+	return 0;
+}
+
+int cgroup_write_systemd_default_cgroup(const char * const slice,
+					const char * const scope)
+{
+	cgroup_err("Systemd support not compiled\n");
 	return 0;
 }
 #endif

--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -161,4 +161,5 @@ CGROUP_3.0 {
 	is_cgroup_mode_legacy;
 	is_cgroup_mode_hybrid;
 	is_cgroup_mode_unified;
+	cgroup_is_systemd_enabled;
 } CGROUP_2.0;

--- a/src/python/cgroup.pxd.m4
+++ b/src/python/cgroup.pxd.m4
@@ -35,8 +35,6 @@ cdef extern from "libcgroup.h":
         unsigned int minor
         unsigned int release
 
-ifdef(`WITH_SYSTEMD',
-    # comment to appease m4
     cdef enum cgroup_systemd_mode_t:
         CGROUP_SYSTEMD_MODE_FAIL
         CGROUP_SYSTEMD_MODE_REPLACE
@@ -48,7 +46,6 @@ ifdef(`WITH_SYSTEMD',
         int delegated
         cgroup_systemd_mode_t mode
         pid_t pid
-)
 
     cdef enum cgroup_log_level:
         CGROUP_LOG_CONT
@@ -88,11 +85,8 @@ ifdef(`WITH_SYSTEMD',
 
     cg_setup_mode_t cgroup_setup_mode()
 
-ifdef(`WITH_SYSTEMD',
-    # comment to appease m4
     int cgroup_create_scope(const char * const scope_name, const char * const slice_name,
                             const cgroup_systemd_scope_opts * const opts)
-)
 
     int cgroup_get_cgroup(cgroup *cg)
 
@@ -113,15 +107,12 @@ ifdef(`WITH_SYSTEMD',
     void cgroup_set_permissions(cgroup *cgroup, mode_t control_dperm, mode_t control_fperm,
                            mode_t task_fperm)
 
-ifdef(`WITH_SYSTEMD',
-    # comment to appease m4
     int cgroup_create_scope2(cgroup *cgroup, int ignore_ownership,
                              const cgroup_systemd_scope_opts * const opts)
 
     int cgroup_set_default_systemd_cgroup()
     int cgroup_write_systemd_default_cgroup(const char * const slice_name,
                                             const char * const scope_name)
-)
 
     int cgroup_compare_cgroup(cgroup *cgroup_a, cgroup *cgroup_b)
 

--- a/src/python/cgroup.pxd.m4
+++ b/src/python/cgroup.pxd.m4
@@ -130,4 +130,7 @@ cdef extern from "libcgroup.h":
     int cgroup_change_cgroup_path(const char *dest, pid_t pid, const char * const controllers[])
 
     void cgroup_set_default_logger(int log_level)
+
+    bool cgroup_is_systemd_enabled()
+
 # vim: set et ts=4 sw=4:

--- a/src/python/libcgroup.pyx.m4
+++ b/src/python/libcgroup.pyx.m4
@@ -33,14 +33,12 @@ cdef class Mode:
     CGROUP_MODE_HYBRID = cgroup.CGROUP_MODE_HYBRID
     CGROUP_MODE_UNIFIED = cgroup.CGROUP_MODE_UNIFIED
 
-ifdef(`WITH_SYSTEMD',
 cdef class SystemdMode:
     CGROUP_SYSTEMD_MODE_FAIL = cgroup.CGROUP_SYSTEMD_MODE_FAIL
     CGROUP_SYSTEMD_MODE_REPLACE = cgroup.CGROUP_SYSTEMD_MODE_REPLACE
     CGROUP_SYSTEMD_MODE_ISOLATE = cgroup.CGROUP_SYSTEMD_MODE_ISOLATE
     CGROUP_SYSTEMD_MODE_IGNORE_DEPS = cgroup.CGROUP_SYSTEMD_MODE_IGNORE_DEPS
     CGROUP_SYSTEMD_MODE_IGNORE_REQS = cgroup.CGROUP_SYSTEMD_MODE_IGNORE_REQS
-)
 
 cdef class LogLevel:
     CGROUP_LOG_CONT = cgroup.CGROUP_LOG_CONT
@@ -401,8 +399,6 @@ cdef class Cgroup:
         Cgroup.cgroup_init()
         return cgroup.cgroup_setup_mode()
 
-ifdef(`WITH_SYSTEMD',
-    # comment to appease m4
     @staticmethod
     def create_scope(scope_name='libcgroup.scope', slice_name='libcgroup.slice', delegated=True,
                      systemd_mode=SystemdMode.CGROUP_SYSTEMD_MODE_FAIL, pid=None):
@@ -439,8 +435,7 @@ ifdef(`WITH_SYSTEMD',
 
         ret = cgroup.cgroup_create_scope(c_str(scope_name), c_str(slice_name), &opts)
         if ret is not 0:
-            raise RuntimeError("cgroup_create_scope failed: {}".``format''(ret))
-)
+            raise RuntimeError("cgroup_create_scope failed: {}".`format'(ret))
 
     def get(self):
         """Get the cgroup information from the cgroup sysfs
@@ -539,8 +534,6 @@ ifdef(`WITH_SYSTEMD',
 
         cgroup.cgroup_set_permissions(self._cgp, dmode, cmode, tmode)
 
-ifdef(`WITH_SYSTEMD',
-    # comment to appease m4
     def create_scope2(self, ignore_ownership=True, delegated=True,
                       systemd_mode=SystemdMode.CGROUP_SYSTEMD_MODE_FAIL, pid=None):
         """Create a systemd scope using the cgroup instance
@@ -574,7 +567,7 @@ ifdef(`WITH_SYSTEMD',
 
         ret = cgroup.cgroup_create_scope2(self._cgp, ignore_ownership, &opts)
         if ret is not 0:
-            raise RuntimeError("cgroup_create_scope2 failed: {}".``format''(ret))
+            raise RuntimeError("cgroup_create_scope2 failed: {}".`format'(ret))
 
     @staticmethod
     def _set_default_systemd_cgroup():
@@ -646,7 +639,6 @@ ifdef(`WITH_SYSTEMD',
             Cgroup._set_default_systemd_cgroup()
         except RuntimeError:
             pass
-)
 
     cdef compare(self, Cgroup other):
         """Compare this cgroup instance with another cgroup instance

--- a/src/python/libcgroup.pyx.m4
+++ b/src/python/libcgroup.pyx.m4
@@ -815,6 +815,13 @@ cdef class Cgroup:
         """
         cgroup.cgroup_set_default_logger(log_level)
 
+    @staticmethod
+    def is_systemd_enabled():
+        """Returns true if libcgroup is compiled with systemd support
+        """
+
+        return cgroup.cgroup_is_systemd_enabled()
+
     def __dealloc__(self):
         cgroup.cgroup_free(&self._cgp)
 

--- a/src/systemd.c
+++ b/src/systemd.c
@@ -6,6 +6,8 @@
  */
 
 #include <libcgroup-internal.h>
+
+#ifdef WITH_SYSTEMD
 #include <systemd/sd-bus.h>
 #include <libcgroup.h>
 #include <unistd.h>
@@ -422,3 +424,24 @@ err:
 
 	return ret;
 }
+#else
+int cgroup_set_default_scope_opts(struct cgroup_systemd_scope_opts * const opts)
+{
+	cgroup_err("Systemd support not compiled\n");
+	return 1;
+}
+
+int cgroup_create_scope(const char * const scope_name, const char * const slice_name,
+			const struct cgroup_systemd_scope_opts * const opts)
+{
+	cgroup_err("Systemd support not compiled\n");
+	return 1;
+}
+
+int cgroup_create_scope2(struct cgroup *cgroup, int ignore_ownership,
+			 const struct cgroup_systemd_scope_opts * const opts)
+{
+	cgroup_err("Systemd support not compiled\n");
+	return 1;
+}
+#endif

--- a/src/systemd.c
+++ b/src/systemd.c
@@ -424,6 +424,11 @@ err:
 
 	return ret;
 }
+
+bool cgroup_is_systemd_enabled(void)
+{
+	return true;
+}
 #else
 int cgroup_set_default_scope_opts(struct cgroup_systemd_scope_opts * const opts)
 {
@@ -443,5 +448,10 @@ int cgroup_create_scope2(struct cgroup *cgroup, int ignore_ownership,
 {
 	cgroup_err("Systemd support not compiled\n");
 	return 1;
+}
+
+bool cgroup_is_systemd_enabled(void)
+{
+	return false;
 }
 #endif

--- a/src/tools/cgclassify.c
+++ b/src/tools/cgclassify.c
@@ -135,7 +135,9 @@ static struct option longopts[] = {
 int main(int argc, char *argv[])
 {
 	struct cgroup_group_spec *cgroup_list[CG_HIER_MAX];
+#ifdef WITH_SYSTEMD
 	int ignore_default_systemd_delegate_slice = 0;
+#endif
 	int ret = 0, i, exit_code = 0;
 	int skip_replace_idle = 0;
 	pid_t scope_pid = -1;
@@ -197,9 +199,10 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	/* this is false always for disable-systemd */
+#ifdef WITH_SYSTEMD
 	if (!ignore_default_systemd_delegate_slice)
 		cgroup_set_default_systemd_cgroup();
+#endif
 
 	for (i = optind; i < argc; i++) {
 		pid = (pid_t) strtol(argv[i], &endptr, 10);

--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -133,7 +133,9 @@ int main(int argc, char *argv[])
 	uid_t tuid = CGRULE_INVALID, auid = CGRULE_INVALID;
 	gid_t tgid = CGRULE_INVALID, agid = CGRULE_INVALID;
 
+#ifdef WITH_SYSTEMD
 	int ignore_default_systemd_delegate_slice = 0;
+#endif
 	int set_default_scope = 0;
 	int create_scope = 0;
 	pid_t scope_pid = -1;
@@ -276,9 +278,10 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	/* this will always be false if WITH_SYSTEMD is not defined */
+#ifdef WITH_SYSTEMD
 	if (!create_scope && !ignore_default_systemd_delegate_slice)
 		cgroup_set_default_systemd_cgroup();
+#endif
 
 	/* for each new cgroup */
 	for (i = 0; i < capacity; i++) {

--- a/src/tools/cgdelete.c
+++ b/src/tools/cgdelete.c
@@ -113,7 +113,9 @@ static int skip_add_controller(int counter, int *skip, struct ext_cgroup_record 
 
 int main(int argc, char *argv[])
 {
+#ifdef WITH_SYSTEMD
 	int ignore_default_systemd_delegate_slice = 0;
+#endif
 	struct cgroup_group_spec **cgroup_list = NULL;
 	struct ext_cgroup_record *ecg_list = NULL;
 	struct cgroup_controller *cgc;
@@ -186,9 +188,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	/* this is false always for disable-systemd */
+#ifdef WITH_SYSTEMD
 	if (!ignore_default_systemd_delegate_slice)
 		cgroup_set_default_systemd_cgroup();
+#endif
 
 	/* parse groups on command line */
 	for (i = optind; i < argc; i++) {

--- a/src/tools/cgexec.c
+++ b/src/tools/cgexec.c
@@ -70,7 +70,9 @@ static void usage(int status, const char *program_name)
 int main(int argc, char *argv[])
 {
 	struct cgroup_group_spec *cgroup_list[CG_HIER_MAX];
+#ifdef WITH_SYSTEMD
 	int ignore_default_systemd_delegate_slice = 0;
+#endif
 	pid_t scope_pid = -1;
 	int child_status = 0;
 	int replace_idle = 0;
@@ -129,9 +131,10 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	/* this is false always for disable-systemd */
+#ifdef WITH_SYSTEMD
 	if (!ignore_default_systemd_delegate_slice)
 		cgroup_set_default_systemd_cgroup();
+#endif
 
 	/* Just for debugging purposes. */
 	uid = geteuid();

--- a/src/tools/cgget.c
+++ b/src/tools/cgget.c
@@ -795,7 +795,7 @@ static void print_cgroups(struct cgroup *cg_list[], int cg_list_len, int mode)
 
 int main(int argc, char *argv[])
 {
-	int mode = MODE_SHOW_NAMES | MODE_SHOW_HEADERS | MODE_SYSTEMD_DELEGATE;
+	int mode = MODE_SHOW_NAMES | MODE_SHOW_HEADERS;
 	struct cgroup **cg_list = NULL;
 	int cg_list_len = 0;
 	int ret = 0, i;
@@ -811,6 +811,10 @@ int main(int argc, char *argv[])
 		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		goto err;
 	}
+
+#ifdef WITH_SYSTEMD
+	mode |= MODE_SYSTEMD_DELEGATE;
+#endif
 
 	ret = parse_opts(argc, argv, &cg_list, &cg_list_len, &mode);
 	if (ret)

--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -444,7 +444,9 @@ static int add_subtree_control_name_value(struct control_value *name_value)
 
 int main(int argc, char *argv[])
 {
+#ifdef WITH_SYSTEMD
 	int ignore_default_systemd_delegate_slice = 0;
+#endif
 	struct control_value *name_value = NULL;
 	int nv_number = 0;
 	int recursive = 0;
@@ -564,9 +566,10 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	/* this is false always for disable-systemd */
+#ifdef WITH_SYSTEMD
 	if (!ignore_default_systemd_delegate_slice)
 		cgroup_set_default_systemd_cgroup();
+#endif
 
 	/* copy the name-value pairs from -r options */
 	if ((flags & FL_RULES) != 0) {

--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -833,7 +833,7 @@ out:
 
 int main(int argc, char *argv[])
 {
-	int mode = MODE_SHOW_NAMES | MODE_SHOW_HEADERS | MODE_SYSTEMD_DELEGATE;
+	int mode = MODE_SHOW_NAMES | MODE_SHOW_HEADERS;
 	enum cg_version_t version = CGROUP_UNK;
 	struct cgroup **cg_list = NULL;
 	bool ignore_unmappable = false;
@@ -851,6 +851,10 @@ int main(int argc, char *argv[])
 		err("%s: libcgroup initialization failed: %s\n", argv[0], cgroup_strerror(ret));
 		goto err;
 	}
+
+#ifdef WITH_SYSTEMD
+	mode |= MODE_SYSTEMD_DELEGATE;
+#endif
 
 	ret = parse_opts(argc, argv, &cg_list, &cg_list_len, &mode, &version, &ignore_unmappable);
 	if (ret)

--- a/src/tools/cgxset.c
+++ b/src/tools/cgxset.c
@@ -146,7 +146,9 @@ err:
 #ifndef UNIT_TEST
 int main(int argc, char *argv[])
 {
+#ifdef WITH_SYSTEMD
 	int ignore_default_systemd_delegate_slice = 0;
+#endif
 	struct control_value *name_value = NULL;
 	int nv_number = 0;
 	int nv_max = 0;
@@ -255,9 +257,10 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	/* this is false always for disable-systemd */
+#ifdef WITH_SYSTEMD
 	if (!ignore_default_systemd_delegate_slice)
 		cgroup_set_default_systemd_cgroup();
+#endif
 
 	/* copy the name-value pairs from -r options */
 	if ((flags & FL_RULES) != 0) {

--- a/src/tools/lscgroup.c
+++ b/src/tools/lscgroup.c
@@ -246,7 +246,9 @@ int main(int argc, char *argv[])
 	};
 
 	struct cgroup_group_spec *cgroup_list[CG_HIER_MAX];
+#ifdef WITH_SYSTEMD
 	int ignore_default_systemd_delegate_slice = 0;
+#endif
 	int flags = 0;
 	int ret = 0;
 	int c;
@@ -291,9 +293,10 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	/* this is false always for disable-systemd */
+#ifdef WITH_SYSTEMD
 	if (!ignore_default_systemd_delegate_slice)
 		cgroup_set_default_systemd_cgroup();
+#endif
 
 	/* read the list of controllers */
 	while (optind < argc) {

--- a/tests/ftests/049-sudo-systemd_create_scope.py
+++ b/tests/ftests/049-sudo-systemd_create_scope.py
@@ -39,6 +39,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/050-sudo-systemd_create_scope_w_pid.py
+++ b/tests/ftests/050-sudo-systemd_create_scope_w_pid.py
@@ -40,6 +40,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/058-sudo-systemd_create_scope2.py
+++ b/tests/ftests/058-sudo-systemd_create_scope2.py
@@ -53,6 +53,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/059-sudo-invalid_systemd_create_scope2.py
+++ b/tests/ftests/059-sudo-invalid_systemd_create_scope2.py
@@ -9,6 +9,7 @@
 
 from cgroup import CgroupVersion as CgroupCliVersion
 from libcgroup import Cgroup, Version
+from systemd import Systemd
 import ftests
 import consts
 import sys
@@ -31,6 +32,10 @@ def prereqs(config):
     if CgroupCliVersion.get_version(CONTROLLER) != CgroupCliVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
         cause = 'This test requires cgroup v2'
+
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
 
     return result, cause
 

--- a/tests/ftests/060-sudo-cgconfigparser-systemd.py
+++ b/tests/ftests/060-sudo-cgconfigparser-systemd.py
@@ -74,6 +74,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/061-sudo-g_flag_controller_only_systemd-v1.py
+++ b/tests/ftests/061-sudo-g_flag_controller_only_systemd-v1.py
@@ -38,6 +38,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/062-sudo-g_flag_controller_only_systemd-v2.py
+++ b/tests/ftests/062-sudo-g_flag_controller_only_systemd-v2.py
@@ -38,6 +38,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/063-sudo-systemd_cgset-v1.py
+++ b/tests/ftests/063-sudo-systemd_cgset-v1.py
@@ -39,6 +39,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/064-sudo-systemd_cgset-v2.py
+++ b/tests/ftests/064-sudo-systemd_cgset-v2.py
@@ -38,6 +38,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/065-sudo-systemd_cgclassify-v1.py
+++ b/tests/ftests/065-sudo-systemd_cgclassify-v1.py
@@ -44,6 +44,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/066-sudo-systemd_cgclassify-v2.py
+++ b/tests/ftests/066-sudo-systemd_cgclassify-v2.py
@@ -44,6 +44,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/067-sudo-systemd_cgexec-v1.py
+++ b/tests/ftests/067-sudo-systemd_cgexec-v1.py
@@ -44,6 +44,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/068-sudo-systemd_cgexec-v2.py
+++ b/tests/ftests/068-sudo-systemd_cgexec-v2.py
@@ -44,6 +44,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
+++ b/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
@@ -75,6 +75,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
+++ b/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
@@ -75,6 +75,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/071-sudo-set_default_systemd_cgroup.py
+++ b/tests/ftests/071-sudo-set_default_systemd_cgroup.py
@@ -11,6 +11,7 @@
 from libcgroup import Version, Cgroup, Mode
 from cgroup import Cgroup as CgroupCli
 from process import Process
+from systemd import Systemd
 import consts
 import ftests
 import time
@@ -32,6 +33,10 @@ def prereqs(config):
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
+
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
 
     return result, cause
 

--- a/tests/ftests/078-sudo-cgcreate_systemd_scope.py
+++ b/tests/ftests/078-sudo-cgcreate_systemd_scope.py
@@ -7,9 +7,10 @@
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
-from cgroup import Cgroup
 from process import Process
+from systemd import Systemd
 from libcgroup import Mode
+from cgroup import Cgroup
 from run import RunError
 from log import Log
 import consts
@@ -37,6 +38,10 @@ def prereqs(config):
     if Cgroup.get_cgroup_mode(config) != Mode.CGROUP_MODE_UNIFIED:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the unified cgroup hierarchy'
+
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
 
     return result, cause
 

--- a/tests/ftests/079-sudo-cgcreate_default_systemd_scope.py
+++ b/tests/ftests/079-sudo-cgcreate_default_systemd_scope.py
@@ -7,9 +7,10 @@
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
-from cgroup import Cgroup
 from process import Process
+from systemd import Systemd
 from libcgroup import Mode
+from cgroup import Cgroup
 from run import RunError
 from log import Log
 import consts
@@ -35,6 +36,10 @@ def prereqs(config):
     if Cgroup.get_cgroup_mode(config) != Mode.CGROUP_MODE_UNIFIED:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the unified cgroup hierarchy'
+
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
 
     return result, cause
 

--- a/tests/ftests/084-sudo-cgcreate_systemd_scope_pid.py
+++ b/tests/ftests/084-sudo-cgcreate_systemd_scope_pid.py
@@ -7,9 +7,10 @@
 # Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
 #
 
-from cgroup import Cgroup
 from process import Process
+from systemd import Systemd
 from libcgroup import Mode
+from cgroup import Cgroup
 from run import RunError
 import consts
 import ftests
@@ -34,6 +35,10 @@ def prereqs(config):
     if Cgroup.get_cgroup_mode(config) != Mode.CGROUP_MODE_UNIFIED:
         result = consts.TEST_SKIPPED
         cause = 'This test requires the unified cgroup hierarchy'
+
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
 
     return result, cause
 

--- a/tests/ftests/085-sudo-cgexec_systemd_scope.py
+++ b/tests/ftests/085-sudo-cgexec_systemd_scope.py
@@ -9,6 +9,7 @@
 
 from multiprocessing import active_children
 from process import Process
+from systemd import Systemd
 from cgroup import Cgroup
 from run import RunError
 import consts
@@ -31,6 +32,10 @@ def prereqs(config):
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
+
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
 
     return result, cause
 

--- a/tests/ftests/086-sudo-systemd_cmdline_example.py
+++ b/tests/ftests/086-sudo-systemd_cmdline_example.py
@@ -44,6 +44,10 @@ def prereqs(config):
         result = consts.TEST_SKIPPED
         cause = 'This test requires the unified cgroup hierarchy'
 
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
+
     return result, cause
 
 

--- a/tests/ftests/088-sudo-cgclassify_systemd_scope.py
+++ b/tests/ftests/088-sudo-cgclassify_systemd_scope.py
@@ -8,6 +8,7 @@
 #
 
 from process import Process
+from systemd import Systemd
 from cgroup import Cgroup
 from run import RunError
 import consts
@@ -30,6 +31,10 @@ def prereqs(config):
     if config.args.container:
         result = consts.TEST_SKIPPED
         cause = 'This test cannot be run within a container'
+
+    if not Systemd.is_systemd_enabled():
+        result = consts.TEST_SKIPPED
+        cause = 'Systemd support not compiled in'
 
     return result, cause
 

--- a/tests/ftests/systemd.py
+++ b/tests/ftests/systemd.py
@@ -6,8 +6,9 @@
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
+from cgroup import Cgroup as CgroupCli
 from run import Run, RunError
-from cgroup import Cgroup
+from libcgroup import Cgroup
 import os
 
 
@@ -70,7 +71,12 @@ class Systemd(object):
         # In case the error occurs before the creation of slice/scope and
         # we may very well be on the teardown path, ignore the exception
         try:
-            Cgroup.delete(config, controller, cgname=_slice, ignore_systemd=True)
+            CgroupCli.delete(config, controller, cgname=_slice, ignore_systemd=True)
         except RunError as re:
             if 'No such file or directory' not in re.stderr:
                 raise re
+
+    # Check if libcgroup is compiled with --enable-systemd
+    @staticmethod
+    def is_systemd_enabled():
+        return Cgroup.is_systemd_enabled()


### PR DESCRIPTION
`systemd` support is configurable and is enabled by default, but can
be disabled too, by configuring with `--enable-systemd=no` option
and the programs linking `-lcgroup` complains about missing header
file `libcgroup/systemd.h`, in cases with `systemd` support disabled.
The reason is that `libcgroup/systemd.h` is included via `libcgroup.h`
independent of `systemd` configuration but only installed only if the
`systemd` support is enabled.

This patchset attempts to fix the warning by installing `libcgroup/systemd.h`
in both the `--enable-systemd=yes,no` configurations and also
introduce systemd function stubs, for the functions available to the
users, these versions of functions throw error about missing `systemd`
support, when gets called. It also fixes the `tools` to handle the
non-systemd stub function's return value.

Fixes: #413 
