### PR TITLE
Enable cgroup creation by non-root users

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -2625,7 +2625,7 @@ static int test_and_set_ctrl_mnt_path(const char * const mount_path, const char 
 STATIC int cgroupv2_subtree_control_recursive(char *path, const char *ctrl_name, bool enable)
 {
 	char *path_copy, *tmp_path, *stok_buff = NULL;
-	bool found_mount = false;
+	bool found_mount = false, controller_enabled = false;
 	size_t mount_len;
 	int i, error = 0;
 
@@ -2677,6 +2677,12 @@ STATIC int cgroupv2_subtree_control_recursive(char *path, const char *ctrl_name,
 
 		error = cg_create_control_group(path_copy);
 		if (error)
+			goto out;
+
+		error = cgroupv2_get_subtree_control(path_copy, ctrl_name, &controller_enabled);
+		if (controller_enabled)
+			continue;
+		if (error != ECGROUPNOTMOUNTED)
 			goto out;
 
 		error = cgroupv2_subtree_control(path_copy, ctrl_name, enable);


### PR DESCRIPTION
When using the SystemD options `Delegate` and `User`/`Group`, we can have processes running as non-root user, and file ownerships will be setup by SystemD such that we can modify cgroups "below" the scope managed by SystemD.

However, the current implementation of `cgroupv2_subtree_control_recursive()` (called during execution of `cgroup_create_cgroup`) unconditionally writes to `subtree_control` files that belong to root, even if such writes are unneccessary (because the desired controllers are already enabled). This adds a check, and also fixes a bug in `__cgroupv2_get_enabled()`, which would make the function return an error if a controller is not enabled, instead of simply reporting that fact.