### PR TITLE
ftests: support cpu, pids new controller values, interface file

### DIFF
--- a/tests/ftests/009-cgget-g_flag_controller_only.py
+++ b/tests/ftests/009-cgget-g_flag_controller_only.py
@@ -118,6 +118,26 @@ EXPECTED_OUT_V2 = [
     cpu.max.burst: 0
     cpu.max: max 100000
     cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time, force_idle
+    '''009cgget:
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            core_sched.force_idle_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
     cpu.uclamp.max: max'''
 ]
 

--- a/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -112,6 +112,25 @@ EXPECTED_OUT_V2 = [
     cpu.max: max 100000
     cpu.uclamp.min: 0.00
     cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time, force_idle
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            core_sched.force_idle_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
 ]
 
 

--- a/tests/ftests/013-cgget-multiple_g_flags.py
+++ b/tests/ftests/013-cgget-multiple_g_flags.py
@@ -61,8 +61,27 @@ EXPECTED_OUT_V1 = [
     cpu.idle: 0
     cpu.cfs_quota_us: -1
     cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with cfs_bandwidth, pids.peak with cpu.stat nr_busts, burst_time
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    pids.peak: 0
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
     cpu.uclamp.max: max'''
 ]
+
 
 EXPECTED_OUT_V2 = [
     '''013cgget:
@@ -146,6 +165,31 @@ EXPECTED_OUT_V2 = [
     pids.current: 0
     pids.events: max 0
     pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            core_sched.force_idle_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth, pids.peak
+    # with cpu.stat nr_busts, burst_time, force_idle
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    pids.peak: 0
     cpu.weight: 100
     cpu.stat: usage_usec 0
             user_usec 0

--- a/tests/ftests/013-cgget-multiple_g_flags.py
+++ b/tests/ftests/013-cgget-multiple_g_flags.py
@@ -140,6 +140,29 @@ EXPECTED_OUT_V2 = [
     cpu.max.burst: 0
     cpu.max: max 100000
     cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time, force_idle
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            core_sched.force_idle_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
     cpu.uclamp.max: max'''
 ]
 


### PR DESCRIPTION
This patchset adds support to teach ftests about the new values in
`cpu.stats` introduced in Linux Kernel >= 6.0 and the new interface file
`pid.peak` of pids controller introduced in Linux Kernel >= 6.1.