### PR TITLE
ftests/060: Add new systemd error message

### DIFF
--- a/tests/ftests/060-sudo-cgconfigparser-systemd.py
+++ b/tests/ftests/060-sudo-cgconfigparser-systemd.py
@@ -145,7 +145,10 @@ def test(config):
     try:
         Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
     except RunError as re:
-        if 'already exists' not in re.stdout:
+        if (
+                'already exists' not in re.stdout and
+                'was already loaded or has a fragment file' not in re.stdout
+           ):
             result = consts.TEST_FAILED
             cause = 'Unexpected error  {}'.format(re.stdout)
     else:


### PR DESCRIPTION
systemd >= 252 has changed the error message on creating duplicate
transient units, upstream commit 1f83244641f1 ("manager: allow transient
units to have drop-ins"). Adopt the newer systemd error message to avoid
expected failure.
```
-----------------------------------------------------------------
Test Results:
        Run Date:                          May 26 07:03:01
        Passed:                                  1 test(s)
        Skipped:                                 0 test(s)
        Failed:                                  0 test(s)
-----------------------------------------------------------------
Timing Results:
        Test                                   Time (sec)
        -------------------------------------------------
        setup                                        0.00
        060-sudo-cgconfigparser-systemd.py           3.62
        teardown                                     0.00
        -------------------------------------------------
        Total Run Time                               3.62