### PR TITLE
Introduce Kernel Version based ftests controller output map

### DIFF
--- a/tests/ftests/061-sudo-g_flag_controller_only_systemd-v1.py
+++ b/tests/ftests/061-sudo-g_flag_controller_only_systemd-v1.py
@@ -77,8 +77,13 @@ def test(config):
     result = consts.TEST_PASSED
     cause = None
 
+    expected_out_len = 10
+    kernel_ver = CgroupVersion.get_kernel_version(config)
+    if int(kernel_ver[0]) <= 5 and int(kernel_ver[1]) <= 4:
+        expected_out_len = 8
+
     out = Cgroup.get(config, controller=CONTROLLER, cgname=SYSTEMD_CGNAME)
-    if len(out.splitlines()) < 10:
+    if len(out.splitlines()) < expected_out_len:
         # This cgget command gets all of the settings/values within the cgroup.
         # We don't care about the exact data, but there should be at least 10
         # lines of settings/values
@@ -89,7 +94,7 @@ def test(config):
                 )
 
     out = Cgroup.get(config, controller=CONTROLLER, cgname=OTHER_CGNAME, ignore_systemd=True)
-    if len(out.splitlines()) < 10:
+    if len(out.splitlines()) < expected_out_len:
         result = consts.TEST_FAILED
         tmp_cause = (
                         'cgget failed to read at least 10 lines from '

--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -12,6 +12,7 @@ from run import Run, RunError
 import multiprocessing as mp
 from libcgroup import Mode
 from enum import Enum
+import platform
 import consts
 import utils
 import time
@@ -82,6 +83,13 @@ class CgroupVersion(Enum):
                             'Unknown version for controller {}'
                             ''.format(controller)
                         )
+
+    # get the current kernel version
+    @staticmethod
+    def get_kernel_version(config):
+        kernel_version_str = str(platform.release())
+        kernel_version = kernel_version_str.split('.')[0:3]
+        return kernel_version
 
 
 class Cgroup(object):


### PR DESCRIPTION
This patchset introduces Kernel version-based ftests controller
output mapping.  The first patch introduces `get_kernel_version()`
that returns the `Major.Minor.Patch Level` and the second patch
calculates the CPU controllers' expected output lines based on the
Kernel version.
