### PR TITLE
ftests/cgroup: Fix flake8 warning

### DIFF
--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -627,7 +627,7 @@ class Cgroup(object):
             elif re.ret == 0 and 'ERROR: can\'t get' in re.stderr:
                 res = re.stdout
             else:
-                raise(re)
+                raise (re)
 
         # convert the cgsnapshot stdout to a dict of cgroup objects
         return Cgroup.snapshot_to_dict(res)


### PR DESCRIPTION
Fix pythonlint (flake8) warning:
`tests/ftests/cgroup.py:630:22: E275 missing whitespace after keyword`