### PR TITLE
ftests/cgroup: Add support for favordynmods

### DIFF
--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -39,6 +39,12 @@ class CgroupMount(object):
             if self.version == CgroupVersion.CGROUP_V1:
                 self.controller = entries[3].split(',')[-1]
 
+                # kernel's compiled with CONFIG_CGROUP_FAVOR_DYNMODS on
+                # cgroup v1 will append mount points with favordynmods,
+                # remove it.
+                if self.controller == 'favordynmods':
+                    self.controller == entries[3].split(',')[-2]
+
                 if self.controller == 'clone_children':
                     # the cpuset controller may append this option to the end
                     # rather than the controller name like all other controllers


### PR DESCRIPTION
Upstream Linux Kernel commit 81d3a5be05d3 ("cgroup: add cgroup_favordynmods=
command-line option") introduced CONFIG_CGROUP_FAVOR_DYNMODS, that would
append `favordynmods` to the mount options on cgroup v1. This patch strips that option.