### PR TITLE
ftests/consts: Add cpu controller throttled_usec (v1/v2)

### DIFF
--- a/tests/ftests/013-cgget-multiple_g_flags.py
+++ b/tests/ftests/013-cgget-multiple_g_flags.py
@@ -32,19 +32,19 @@ def test(config):
     result = consts.TEST_PASSED
     cause = None
 
-    # Append pid controller [0] and cpu controller [N - 1]
+    # Append pid controller [0] and cpu controller [N - 2]
     EXPECTED_OUT_V1 = [OUT_PREFIX + consts.EXPECTED_PIDS_OUT[0] + expected_out
-                       for expected_out in consts.EXPECTED_CPU_OUT_V1[:-1]]
-    # Append pid controller [1] and cpu controller [N]
-    EXPECTED_OUT_V1.append(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[1] +
-                           consts.EXPECTED_CPU_OUT_V1[-1])
+                       for expected_out in consts.EXPECTED_CPU_OUT_V1[:-2]]
+    # Append pid controller [1] and cpu controller [N, N - 1]
+    EXPECTED_OUT_V1.extend(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[1] + expected_out
+                           for expected_out in consts.EXPECTED_CPU_OUT_V1[-2:])
 
-    # Append pid controller [0] and cpu controller [N - 1]
+    # Append pid controller [0] and cpu controller [N - 2]
     EXPECTED_OUT_V2 = [OUT_PREFIX + consts.EXPECTED_PIDS_OUT[0] + expected_out
-                       for expected_out in consts.EXPECTED_CPU_OUT_V2[:-1]]
-    # Append pid controller [1] and cpu controller [N]
-    EXPECTED_OUT_V2.append(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[1] +
-                           consts.EXPECTED_CPU_OUT_V2[-1])
+                       for expected_out in consts.EXPECTED_CPU_OUT_V2[:-2]]
+    # Append pid controller [1] and cpu controller [N, N - 1]
+    EXPECTED_OUT_V2.extend(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[1] + expected_out
+                           for expected_out in consts.EXPECTED_CPU_OUT_V2[-2:])
 
     out = Cgroup.get(config, controller=[CONTROLLER1, CONTROLLER2],
                      cgname=CGNAME)

--- a/tests/ftests/consts.py
+++ b/tests/ftests/consts.py
@@ -161,6 +161,27 @@ EXPECTED_CPU_OUT_V2 = [
     cpu.max.burst: 0
     cpu.max: max 100000
     cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time, force_idle
+    # cpu.stat.local
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            core_sched.force_idle_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.stat.local: throttled_usec 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
     cpu.uclamp.max: max'''
 ]
 

--- a/tests/ftests/consts.py
+++ b/tests/ftests/consts.py
@@ -65,6 +65,20 @@ EXPECTED_CPU_OUT_V1 = [
     cpu.idle: 0
     cpu.cfs_quota_us: -1
     cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.stat.local: throttled_time 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
     cpu.uclamp.max: max'''
 ]
 


### PR DESCRIPTION
Add cpu controller (v1/v2) stat output throttled_usec, introduced by
677ea015f231 ("sched: add throttled time stat for throttled children")