### PR TITLE
ftests/071: Introduce delay before killing cgroup

### DIFF
--- a/tests/ftests/071-sudo-set_default_systemd_cgroup.py
+++ b/tests/ftests/071-sudo-set_default_systemd_cgroup.py
@@ -94,6 +94,10 @@ def test(config):
         cause = '\n'.join(filter(None, [cause, tmp_cause]))
 
     Process.kill(config, pid)
+
+    # Allow the cgroup sync, on killed pid
+    time.sleep(0.5)
+
     cg.delete()
 
     #


### PR DESCRIPTION
Fix the following issue:
`071-sudo-set_default_systemd_cgroup.py - cgroup_delete_cgroup failed: 50016`

Some older version of Kernel/Python combination, requires few jiffies to sync the
`cgroup.procs` list of process. Fix it by introducing 0.5 second delay, before removing
the cgroup.