### PR TITLE
ftests: Refactor expected output iterator

### DIFF
--- a/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -10,6 +10,7 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
+import utils
 import sys
 import os
 
@@ -35,41 +36,22 @@ def test(config):
     version = CgroupVersion.get_version(CONTROLLER)
 
     if version == CgroupVersion.CGROUP_V1:
-        for expected_out in consts.EXPECTED_CPU_OUT_V1:
-            if len(out.splitlines()) == len(expected_out.splitlines()):
+        EXPECTED_OUT = consts.EXPECTED_CPU_OUT_V1
+    else:
+        EXPECTED_OUT = consts.EXPECTED_CPU_OUT_V2
+
+    for expected_out in EXPECTED_OUT:
+        if len(out.splitlines()) == len(expected_out.splitlines()):
+            result_, tmp_cause = utils.is_output_same(config, out, expected_out)
+            if result_ is True:
+                result = consts.TEST_PASSED
+                cause = None
                 break
-    elif version == CgroupVersion.CGROUP_V2:
-        for expected_out in consts.EXPECTED_CPU_OUT_V2:
-            if len(out.splitlines()) == len(expected_out.splitlines()):
-                break
+            else:
+                if cause is None:
+                    cause = "Tried Matching:\n==============="
 
-    if len(out.splitlines()) != len(expected_out.splitlines()):
-        result = consts.TEST_FAILED
-        cause = (
-                    'Expected line count: {}, but received line count: {}'
-                    ''.format(len(expected_out.splitlines()),
-                              len(out.splitlines()))
-                )
-        return result, cause
-
-    if len(out.splitlines()) != len(expected_out.splitlines()):
-        result = consts.TEST_FAILED
-        cause = (
-                    'Expected {} lines but received {} lines'
-                    ''.format(len(expected_out.splitlines()),
-                              len(out.splitlines()))
-                )
-        return result, cause
-
-    for line_num, line in enumerate(out.splitlines()):
-        if line.strip() != expected_out.splitlines()[line_num].strip():
-            result = consts.TEST_FAILED
-            cause = (
-                        'Expected line:\n\t{}\nbut received line:\n\t{}'
-                        ''.format(expected_out.splitlines()[line_num].strip(),
-                                  line.strip())
-                    )
-            return result, cause
+                cause = '\n'.join(filter(None, [cause, expected_out]))
 
     return result, cause
 

--- a/tests/ftests/013-cgget-multiple_g_flags.py
+++ b/tests/ftests/013-cgget-multiple_g_flags.py
@@ -10,6 +10,7 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
+import utils
 import sys
 import os
 
@@ -32,51 +33,37 @@ def test(config):
     result = consts.TEST_PASSED
     cause = None
 
-    # Append pid controller [0] and cpu controller [N - 2]
-    EXPECTED_OUT_V1 = [OUT_PREFIX + consts.EXPECTED_PIDS_OUT[0] + expected_out
-                       for expected_out in consts.EXPECTED_CPU_OUT_V1[:-2]]
-    # Append pid controller [1] and cpu controller [N, N - 1]
-    EXPECTED_OUT_V1.extend(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[1] + expected_out
-                           for expected_out in consts.EXPECTED_CPU_OUT_V1[-2:])
-
-    # Append pid controller [0] and cpu controller [N - 2]
-    EXPECTED_OUT_V2 = [OUT_PREFIX + consts.EXPECTED_PIDS_OUT[0] + expected_out
-                       for expected_out in consts.EXPECTED_CPU_OUT_V2[:-2]]
-    # Append pid controller [1] and cpu controller [N, N - 1]
-    EXPECTED_OUT_V2.extend(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[1] + expected_out
-                           for expected_out in consts.EXPECTED_CPU_OUT_V2[-2:])
-
     out = Cgroup.get(config, controller=[CONTROLLER1, CONTROLLER2],
                      cgname=CGNAME)
     version = CgroupVersion.get_version(CONTROLLER1)
 
     if version == CgroupVersion.CGROUP_V1:
-        for expected_out in EXPECTED_OUT_V1:
-            if len(out.splitlines()) == len(expected_out.splitlines()):
-                break
-    elif version == CgroupVersion.CGROUP_V2:
-        for expected_out in EXPECTED_OUT_V2:
-            if len(out.splitlines()) == len(expected_out.splitlines()):
-                break
+        # Append pid controller [0] and cpu controller [N - 2]
+        EXPECTED_OUT = [OUT_PREFIX + consts.EXPECTED_PIDS_OUT[0] + expected_out
+                        for expected_out in consts.EXPECTED_CPU_OUT_V1[:-2]]
+        # Append pid controller [1] and cpu controller [N, N - 1]
+        EXPECTED_OUT.extend(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[1] + expected_out
+                            for expected_out in consts.EXPECTED_CPU_OUT_V1[-2:])
+    else:
+        # Append pid controller [0] and cpu controller [N - 2]
+        EXPECTED_OUT = [OUT_PREFIX + consts.EXPECTED_PIDS_OUT[0] + expected_out
+                        for expected_out in consts.EXPECTED_CPU_OUT_V2[:-2]]
+        # Append pid controller [1] and cpu controller [N, N - 1]
+        EXPECTED_OUT.extend(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[1] + expected_out
+                            for expected_out in consts.EXPECTED_CPU_OUT_V2[-2:])
 
-    if len(out.splitlines()) != len(expected_out.splitlines()):
-        result = consts.TEST_FAILED
-        cause = (
-                    'Expected {} lines but received {} lines'
-                    ''.format(len(expected_out.splitlines()),
-                              len(out.splitlines()))
-                )
-        return result, cause
+    for expected_out in EXPECTED_OUT:
+        if len(out.splitlines()) == len(expected_out.splitlines()):
+            result_, tmp_cause = utils.is_output_same(config, out, expected_out)
+            if result_ is True:
+                result = consts.TEST_PASSED
+                cause = None
+                break
+            else:
+                if cause is None:
+                    cause = "Tried Matching:\n==============="
 
-    for line_num, line in enumerate(out.splitlines()):
-        if line.strip() != expected_out.splitlines()[line_num].strip():
-            result = consts.TEST_FAILED
-            cause = (
-                        'Expected line:\n\t{}\nbut received line:\n\t{}'
-                        ''.format(expected_out.splitlines()[line_num].strip(),
-                                  line.strip())
-                    )
-            return result, cause
+                cause = '\n'.join(filter(None, [cause, expected_out]))
 
     return result, cause
 

--- a/tests/ftests/utils.py
+++ b/tests/ftests/utils.py
@@ -86,4 +86,21 @@ def get_kernel_version(config):
     kernel_version = kernel_version_str.split('.')[0:3]
     return kernel_version
 
+
+# match if both outputs are same
+def is_output_same(config, out, expected_out):
+    result = True
+    cause = None
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != expected_out.splitlines()[line_num].strip():
+            cause = (
+                    'Expected line:\n\t{}\nbut received line:\n\t{}'
+                    ''.format(expected_out.splitlines()[line_num].strip(), line.strip())
+                    )
+            result = False
+
+    return result, cause
+
+
 # vim: set et ts=4 sw=4:


### PR DESCRIPTION
This patchset introduces a helper function to check if the expected output
of the controller(s) and actual output match.  Using this helper function
the test cases 009, 010, 013 are refactored to look clean and minimal.
