### PR TITLE
ftests/utils: Fix flake8 warning

### DIFF
--- a/tests/ftests/utils.py
+++ b/tests/ftests/utils.py
@@ -80,6 +80,7 @@ def get_file_permissions(config, filename):
     else:
         return Run.run(cmd, shell_bool=True)
 
+
 # get the current kernel version
 def get_kernel_version(config):
     kernel_version_str = str(platform.release())


### PR DESCRIPTION
Fix flake8 warning:
tests/ftests/utils.py:84:1: E302 expected 2 blank lines, found 1