### PR TITLE
Fix CodeQL warnings across code

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -5019,6 +5019,12 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller, char *
 					ret = fscanf(pid_cgroup_fd, "%*[^\n]\n");
 					if (ret == 0)
 						continue;
+
+					if (ret == EOF) {
+						last_errno = errno;
+						ret = ECGEOF;
+						goto done;
+					}
 				}
 
 				cgroup_warn("read failed for pid_cgroup_fd ret %d\n", ret);

--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -106,6 +106,11 @@ int load_list(char *filename, struct deny_list_type **p_list)
 		if (ret == 0)
 			continue;
 
+		if (ret == EOF) {
+			ret = ECGEOF;
+			goto err;
+		}
+
 		new = (struct deny_list_type *) malloc(sizeof(struct deny_list_type));
 		if (new == NULL) {
 			err("ERROR: Memory allocation problem (%s)\n", strerror(errno));


### PR DESCRIPTION
This patchset fixes two warnings reported by CodeQL about:
`Incorrect return-value check for a 'scanf'-like function`. 
The first patch fixes the warning in `tools/cgsnapshot.c` and the
second one is `src/api.c`