### PR TITLE
ftests/030: teach parsing of cgroup v1/v2 code isolation

### DIFF
--- a/tests/ftests/030-lssubsys-lssubsys_all.py
+++ b/tests/ftests/030-lssubsys-lssubsys_all.py
@@ -10,6 +10,7 @@
 from cgroup import Cgroup
 import consts
 import ftests
+import utils
 import sys
 import os
 
@@ -50,6 +51,13 @@ def test(config):
             if lsmount == 'blkio' and mount.controller == 'io':
                 found = True
                 break
+
+        if not found and mount.controller == 'cpuset':
+            kernel_ver = utils.get_kernel_version(config)
+            if int(kernel_ver[0]) >= 6 and int(kernel_ver[1]) >= 12:
+                # Starting 6.12 cpuset is split into v1 and v2, where
+                # v1 is compiled only when CONFIG_CPUSET_V1 is enabled
+                found = True
 
         if not found:
             result = consts.TEST_FAILED

--- a/tests/ftests/030-lssubsys-lssubsys_all.py
+++ b/tests/ftests/030-lssubsys-lssubsys_all.py
@@ -52,11 +52,13 @@ def test(config):
                 found = True
                 break
 
-        if not found and mount.controller == 'cpuset':
+        if not found and (mount.controller == 'cpuset' or
+                          mount.controller == 'memory'):
             kernel_ver = utils.get_kernel_version(config)
             if int(kernel_ver[0]) >= 6 and int(kernel_ver[1]) >= 12:
-                # Starting 6.12 cpuset is split into v1 and v2, where
-                # v1 is compiled only when CONFIG_CPUSET_V1 is enabled
+                # Starting 6.12 cpuset and memory split into v1 and v2,
+                # where v1 is compiled only when CONFIG_CPUSET_V1 and
+                # CONFIG_MEMCG_v1 is enabled respectively.
                 found = True
 
         if not found:


### PR DESCRIPTION
Starting `v6.12` cpuset and memory controllers code is split into v1 and v2 code,
where v1 code is only compiled when COFIG_CPUSET_V1 and CONFIG_MEMCG_V1
is set. Which defaults to disabled, teach the test case to ignore failures, when
the cpuset or memory controller is missing from `/proc/cgroups` on cgroup v2
booted system.