### PR TITLE
 api.c: constify cgroup_get_procs() and cgroup_get_threads() arguments

### DIFF
--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -586,7 +586,7 @@ char *cgroup_get_value_name(struct cgroup_controller *controller, int index);
  * to the API. Should be freed by the caller using free.
  * @param size The size of the pids array returned by the API.
  */
-int cgroup_get_procs(char *name, char *controller, pid_t **pids, int *size);
+int cgroup_get_procs(const char *name, const char *controller, pid_t **pids, int *size);
 
 /**
  * Get the list of threads in a cgroup. This list is guaranteed to

--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -597,7 +597,7 @@ int cgroup_get_procs(const char *name, const char *controller, pid_t **pids, int
  * to the API. Should be freed by the caller using free.
  * @param size The size of the pids array returned by the API.
  */
-int cgroup_get_threads(char *name, char *controller, pid_t **pids, int *size);
+int cgroup_get_threads(const char *name, const char *controller, pid_t **pids, int *size);
 
 /**
  * Change permission of files and directories of given group

--- a/src/api.c
+++ b/src/api.c
@@ -6213,7 +6213,7 @@ static int read_pids(char *path, pid_t **pids, int *size)
 	return 0;
 }
 
-int cgroup_get_procs(char *name, char *controller, pid_t **pids, int *size)
+int cgroup_get_procs(const char *name, const char *controller, pid_t **pids, int *size)
 {
 	char cgroup_path[FILENAME_MAX];
 

--- a/src/api.c
+++ b/src/api.c
@@ -6223,7 +6223,7 @@ int cgroup_get_procs(const char *name, const char *controller, pid_t **pids, int
 	return read_pids(cgroup_path, pids, size);
 }
 
-int cgroup_get_threads(char *name, char *controller, pid_t **pids, int *size)
+int cgroup_get_threads(const char *name, const char *controller, pid_t **pids, int *size)
 {
 	char cgroup_path[FILENAME_MAX];
 


### PR DESCRIPTION
This patchset constifies the char* functional arguments of
`cgroup_get_procs()` and `cgroup_get_threads()`. These
parameters are not supposed to change.