### PR TITLE
tools/cgset: Fix -R switch indentation in help menu

### DIFF
--- a/src/tools/cgset.c
+++ b/src/tools/cgset.c
@@ -363,7 +363,7 @@ static void usage(int status)
 	info("  -b					Ignore default systemd ");
 	info("delegate hierarchy\n");
 #endif
-	info("  -R                                      Recursively set variable(s)");
+	info("  -R					Recursively set variable(s)");
 	info(" for cgroups under <cgroup_path>\n");
 }
 #endif /* !UNIT_TEST */


### PR DESCRIPTION
Fix the indentation of '-R' switch description of cgset help menu.

Before:

```$ cgset --help
Usage: cgset [-r <name=value>] <cgroup_path> ...
   or: cgset --copy-from <source_cgroup_path> <cgroup_path> ...
Set the parameters of given cgroup(s)
  -r, --variable <name>                 Define parameter to set
  --copy-from <source_cgroup_path>      Control group whose parameters will be copied
  -b                                    Ignore default systemd delegate hierarchy
  -R                                      Recursively set variable(s) for cgroups under <cgroup_path>
```

After:

```$ cgset --help
Usage: cgset [-r <name=value>] <cgroup_path> ...
   or: cgset --copy-from <source_cgroup_path> <cgroup_path> ...
Set the parameters of given cgroup(s)
  -r, --variable <name>                 Define parameter to set
  --copy-from <source_cgroup_path>      Control group whose parameters will be copied
  -b                                    Ignore default systemd delegate hierarchy
  -R                                    Recursively set variable(s) for cgroups under <cgroup_path>
```