### PR TITLE
api.c: fix memory leak on non-writable settings

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -2427,8 +2427,11 @@ STATIC int cgroup_set_values_recursive(const char * const base,
 		}
 
 		/* 0200 == S_IWUSR */
-		if (!(path_stat.st_mode & 0200))
+		if (!(path_stat.st_mode & 0200)) {
+			free(path);
+			path = NULL;
 			continue;
+		}
 
 		cgroup_dbg("setting %s to \"%s\", pathlen %d\n", path, cv->value, ret);
 


### PR DESCRIPTION
When hitting the path st_mode check, we might already have allocated a path. In this case, the continue re-enters the loop without freeing the path:

 653 bytes in 8 blocks are definitely lost in loss record
    at 0x484582F: realloc (vg_replace_malloc.c:1437)
    by 0x49023E1: __vasprintf_internal (vasprintf.c:79)
    by 0x48D5BD5: asprintf (asprintf.c:31)
    by 0x4B41722: cgroup_set_values_recursive (api.c:2414)
    by 0x4B4688A: _cgroup_create_cgroup (api.c:2999)
    by 0x4B47067: cgroup_create_cgroup (api.c:3062)
    by 0x4B47067: cgroup_create_cgroup (api.c:3028)

Fixes: 0e50142a1fe0 ("api.c: Don't fail a recursive write if value isn't dirty")