### PR TITLE
ftests/cgroup: Fix typo in CgroupMount::__init__

### DIFF
--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -43,7 +43,7 @@ class CgroupMount(object):
                 # cgroup v1 will append mount points with favordynmods,
                 # remove it.
                 if self.controller == 'favordynmods':
-                    self.controller == entries[3].split(',')[-2]
+                    self.controller = entries[3].split(',')[-2]
 
                 if self.controller == 'clone_children':
                     # the cpuset controller may append this option to the end


### PR DESCRIPTION
Fix the typo of '==' (comparison) to '=' assignment in CgroupMount::__init__.

Fixes: 52b196c2f4f3c ("ftests/cgroup: Add support for favordynmods")