### PR TITLE
ftests/consts.py: Add more cpu controller output (v2)

### DIFF
--- a/tests/ftests/consts.py
+++ b/tests/ftests/consts.py
@@ -182,6 +182,28 @@ EXPECTED_CPU_OUT_V2 = [
     cpu.max.burst: 0
     cpu.max: max 100000
     cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max""",
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time, force_idle
+    # cpu.stat.local, cgroup bstat with nice_usec
+    """cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nice_usec 0
+            core_sched.force_idle_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.stat.local: throttled_usec 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
     cpu.uclamp.max: max"""
 ]
 


### PR DESCRIPTION
Upstream v6.13 kernel commit aefa398d93d5 ("cgroup/rstat: Tracking
cgroup-level niced CPU time") added "nice_usec" to the cgroup base
stats cputime, add it to the list of cpu controller (v2) expected output.