### PR TITLE
api: Show all members of a given group

### DIFF
--- a/include/libcgroup/log.h
+++ b/include/libcgroup/log.h
@@ -133,6 +133,13 @@ extern void cgroup_set_default_logger(int loglevel);
 extern void cgroup_set_loglevel(int loglevel);
 
 /**
+ * Test the current loglevel.
+ * Verify if the specified loglevel matches the current loglevel.
+ * @param loglevel The log level.
+ */
+extern bool cgroup_test_loglevel(int loglevel);
+
+/**
  * Libcgroup log function. This is for applications which are too lazy to set
  * up their own complex logging and miss-use libcgroup for that purpose.
  * I.e. this function should be used only by simple command-line tools.

--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -87,6 +87,8 @@ extern "C" {
 #define cgroup_dbg(x...)	cgroup_log(CGROUP_LOG_DEBUG, x)
 #define cgroup_cont(x...)	cgroup_log(CGROUP_LOG_CONT, x)
 
+#define cgrp_is_loglvl_dbg	cgroup_test_loglevel(CGROUP_LOG_DEBUG)
+
 #define CGRP_DEFAULT_LOGLEVEL	CGROUP_LOG_ERROR
 
 #define max(x, y) ((y) < (x)?(x):(y))

--- a/src/log.c
+++ b/src/log.c
@@ -24,6 +24,11 @@ static void cgroup_default_logger(void *userdata, int level, const char *fmt,
 	vfprintf(stdout, fmt, ap);
 }
 
+bool cgroup_test_loglevel(int loglevel)
+{
+	return cgroup_logger && loglevel == cgroup_loglevel;
+}
+
 void cgroup_log(int level, const char *fmt, ...)
 {
 	va_list ap;


### PR DESCRIPTION
In the context of a group rule (i.e. indicated by '@' used to prefix the actual group name), getgrnam(3) is used to provide a pointer to a group file entry that may contain a NULL-terminated array of pointers to group members. A user can belong to multiple groups. With this information, we then check the username that corresponds to the specified UID against each group member for a match. This patch makes it possible to see this information if debug level logging is enabled.

For example, this can be useful when troubleshooting the Cgroup rules engine daemon.

Signed-off-by: Aaron Tomlin <atomlin@atomlin.com>