### PR TITLE
libcgroup.map: include cgroup_get_cgroup_name

### DIFF
--- a/src/libcgroup.map
+++ b/src/libcgroup.map
@@ -124,6 +124,7 @@ CGROUP_0.40 {
 } CGROUP_0.39;
 
 CGROUP_0.41 {
+	cgroup_get_cgroup_name;
 } CGROUP_0.40;
 
 CGROUP_0.42 {


### PR DESCRIPTION
Using cgroup_get_cgroup_name() API, fails with:
```
gcc -o cgrp_get_cgrp_name cgrp_get_cgrp_name.c -lcgroup /usr/bin/ld: /tmp/ccIyBv5c.o: in function `main':
cgrp_get_cgrp_name.c:(.text+0xaa): undefined reference to `cgroup_get_cgroup_name'
collect2: error: ld returned 1 exit status
```
The API was introduced by commit ca32d88ef56b1 ("wrappers: Add a cgroup_get_cgroup_name API") but missed adding it to libcgroup.map file, causing the linkage issue. Fix the issue by adding the API at the libcgroup.map under version it was introduced.