### PR TITLE
src/config: Fix data race reported by Coverity

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -599,10 +599,12 @@ int cgroup_config_insert_into_namespace_table(char *name, char *nspath)
 {
 	char *ns_tbl_name, *ns_tbl_path;
 
-	if (namespace_table_index >= CG_CONTROLLER_MAX)
-		return 0;
-
 	pthread_rwlock_wrlock(&namespace_table_lock);
+
+	if (namespace_table_index >= CG_CONTROLLER_MAX) {
+		pthread_rwlock_unlock(&namespace_table_lock);
+		return 0;
+	}
 
 	ns_tbl_name = config_namespace_table[namespace_table_index].name;
 	strncpy(ns_tbl_name, name, CONTROL_NAMELEN_MAX - 1);


### PR DESCRIPTION
Fix the following data race issue reported by Coverity:

CID 465888:Check of thread-shared field evades lock acquisition
(LOCK_EVASION):

```
The data guarded by this critical section may be read while in an
inconsistent state or modified by multiple racing threads.

In cgroup_config_insert_into_namespace_table: Checking the value
of a thread-shared field outside of a locked region to determine if a
locked operation involving that thread shared field has completed.
```

Fix it by moving the `namespace_table_index` value check too under the 
`namespace_table_lock`