### PR TITLE
config: Fix data race reported in cgroup_config_insert_into_mount_table

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -551,10 +551,12 @@ int cgroup_config_insert_into_mount_table(char *name, char *mount_point)
 {
 	int i;
 
-	if (config_table_index >= CG_CONTROLLER_MAX)
-		return 0;
-
 	pthread_rwlock_wrlock(&config_table_lock);
+
+	if (config_table_index >= CG_CONTROLLER_MAX) {
+		pthread_rwlock_unlock(&config_table_lock);
+		return 0;
+	}
 
 	/* Merge controller names with the same mount point */
 	for (i = 0; i < config_table_index; i++) {


### PR DESCRIPTION
Fix the following data race issue reported by Coverity:

CID 465888: (#1 of 1): Check of thread-shared field evades lock acquisition
(LOCK_EVASION):

```
The data guarded by this critical section may be read while in an inconsistent
state or modified by multiple racing threads.

In cgroup_config_insert_into_mount_table: Checking the value of a thread-shared
field outside of a locked region to determine if a locked operation involving that
thread shared field has completed.
```

Fix it by moving the `config_table_index` value check too under the `config_table_lock`.