### PR TITLE
tools-common.c: Fix resource leak in cgroup_string_list_add_directory()

### DIFF
--- a/src/tools/tools-common.c
+++ b/src/tools/tools-common.c
@@ -238,11 +238,15 @@ int cgroup_string_list_add_directory(struct cgroup_string_list *list, char *dirn
 
 				/* we are interested in .conf files, skip others */
 				file_ext = strstr(item->d_name, ".conf");
-				if (!file_ext)
+				if (!file_ext) {
+					free(fullpath);
 					continue;
+				}
 
-				if (strcmp(file_ext, ".conf") || strlen(item->d_name) == 5)
+				if (strcmp(file_ext, ".conf") || strlen(item->d_name) == 5) {
+					free(fullpath);
 					continue;
+				}
 
 				ret = cgroup_string_list_add_item(list, fullpath);
 				count++;


### PR DESCRIPTION
Fix a Coverity warning about resource leak:

```
CID 465889: (#4 of 4): Resource leak (RESOURCE_LEAK)
32. leaked_storage: Variable fullpath going out of scope
leaks the storage it points to.
```

Fix it by releasing the 'fullpath', when file name does not
matches '*.conf' code path(s).