### PR TITLE
Update libcgroup.h to make systemd optional.

### DIFF
--- a/include/libcgroup.h
+++ b/include/libcgroup.h
@@ -18,7 +18,10 @@
 #include <libcgroup/config.h>
 #include <libcgroup/log.h>
 #include <libcgroup/tools.h>
+
+#ifdef WITH_SYSTEMD
 #include <libcgroup/systemd.h>
+#endif
 
 #undef _LIBCGROUP_H_INSIDE
 


### PR DESCRIPTION
To allow for systemd to be optional in libcgroup.h