### PR TITLE
tools/cgsnapshot: Fix Coverity uninitialized variable warning

### DIFF
--- a/src/tools/cgsnapshot.c
+++ b/src/tools/cgsnapshot.c
@@ -743,8 +743,8 @@ int main(int argc, char *argv[])
 	};
 
 	cont_name_t wanted_cont[CG_CONTROLLER_MAX];
-	char bl_file[FILENAME_MAX];  /* denylist file name */
-	char wl_file[FILENAME_MAX];  /* allowlist file name */
+	char bl_file[FILENAME_MAX] = { "\0" };  /* denylist file name */
+	char wl_file[FILENAME_MAX] = { "\0" };  /* allowlist file name */
 	int ret = 0, err;
 	int c_number = 0;
 	int c, i;


### PR DESCRIPTION
Coverity reported the following uninitialized variable warning:

CID 465887: (#1 of 1): Uninitialized scalar variable (UNINIT)
32. uninit_use_in_call: Using uninitialized value *wl_file when calling load_list.

Fix the issue by initializing the `char[] wl_file` with '\0', and also initialize `dl_file`
similarly as a best practice.