### PR TITLE
Pass -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to CMake

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -217,7 +217,7 @@ jobs:
         git submodule update --init --recursive
         pushd googletest/googletest
         git checkout release-1.8.0
-        cmake -DBUILD_SHARED_LIBS=ON .
+        cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .
         make
         popd
     - name: Automake

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,7 +15,7 @@ git submodule update --init --recursive
 # configure googletest
 pushd googletest/googletest
 git checkout release-1.8.0
-cmake -DBUILD_SHARED_LIBS=ON .
+cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .
 make
 popd
 


### PR DESCRIPTION
Googletest is broken across the Ubuntu images provided by GitHub,
and it complains about incompatibility with CMake versions < 3.5.
Since we use googletest as a third-party submodule, which we do
not have control over, lets pass `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`
to keep CMake compatible as a workaround.