### PR TITLE
Various continuous integration fixes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -215,9 +215,11 @@ jobs:
     - name: Initialize submodules
       run: |
         git submodule update --init --recursive
-        pushd googletest/googletest
-        git checkout release-1.8.0
-        cmake -DBUILD_SHARED_LIBS=ON .
+        pushd googletest
+        git checkout v1.12.0
+        mkdir -p build
+        cd build
+        cmake .. -DBUILD_GMOCK=OFF
         make
         popd
     - name: Automake

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,9 +13,11 @@ fi
 git submodule update --init --recursive
 
 # configure googletest
-pushd googletest/googletest
-git checkout release-1.8.0
-cmake -DBUILD_SHARED_LIBS=ON .
+pushd googletest
+git checkout v1.12.0
+mkdir -p build
+cd build
+cmake .. -DBUILD_GMOCK=OFF
 make
 popd
 

--- a/tests/ftests/089-cgset-recursive_flag.py
+++ b/tests/ftests/089-cgset-recursive_flag.py
@@ -37,7 +37,14 @@ DEFAULT_VALUE_V1_V2 = '0-1'
 
 
 def prereqs(config):
-    pass
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+
+    return result, cause
 
 
 def is_hybrid_with_ctrl(config):
@@ -160,7 +167,9 @@ def teardown(config):
 
 
 def main(config):
-    prereqs(config)
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
 
     setup(config)
     [result, cause] = test(config)

--- a/tests/gunit/001-path.cpp
+++ b/tests/gunit/001-path.cpp
@@ -10,6 +10,9 @@
 
 #include "libcgroup-internal.h"
 
+char * const NAMESPACE1 = "ns1";
+char * const NAMESPACE5 = "ns5";
+
 class BuildPathV1Test : public ::testing::Test {
 	protected:
 
@@ -33,8 +36,6 @@ class BuildPathV1Test : public ::testing::Test {
 	 * Note that controllers 1 and 5 are also given namespaces
 	 */
 	void SetUp() override {
-		char NAMESPACE1[] = "ns1";
-		char NAMESPACE5[] = "ns5";
 		const int ENTRY_CNT = 6;
 		int i, ret;
 

--- a/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
+++ b/tests/gunit/013-cgroup_build_tasks_procs_path.cpp
@@ -10,6 +10,9 @@
 
 #include "libcgroup-internal.h"
 
+char * const NAMESPACE1 = "ns1";
+char * const NAMESPACE4 = "ns4";
+
 class BuildTasksProcPathTest : public ::testing::Test {
 	protected:
 
@@ -33,8 +36,6 @@ class BuildTasksProcPathTest : public ::testing::Test {
 	 * Note that controllers 1 and 4 are also given namespaces
 	 */
 	void SetUp() override {
-		char NAMESPACE1[] = "ns1";
-		char NAMESPACE4[] = "ns4";
 		const int ENTRY_CNT = 6;
 		int i, ret;
 

--- a/tests/gunit/Makefile.am
+++ b/tests/gunit/Makefile.am
@@ -18,8 +18,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/include \
 LDADD = $(top_builddir)/src/.libs/libcgroupfortesting.la \
 	$(top_builddir)/src/tools/.libs/libcgset.la
 
-EXTRA_DIST = $(top_srcdir)/googletest/googletest/libgtest.so \
-	     $(top_srcdir)/googletest/googletest/libgtest_main.so \
+EXTRA_DIST = $(top_srcdir)/googletest/build/lib/libgtest.a \
+	     $(top_srcdir)/googletest/build/lib/libgtest_main.a \
 	     $(top_srcdir)/googletest/googletest/include \
 	     libcgroup_unittest.map
 
@@ -46,7 +46,7 @@ gtest_SOURCES = gtest.cpp \
 		017-API_fuzz_test.cpp \
 		018-get_next_rule_field.cpp
 
-gtest_LDFLAGS = -L$(top_srcdir)/googletest/googletest -l:libgtest.so \
+gtest_LDFLAGS = -L$(top_srcdir)/googletest/build/lib -l:libgtest.a \
 		-rpath $(abs_top_srcdir)/googletest/googletest
 
 clean-local:


### PR DESCRIPTION
* update to a newer version of googletest
* fix erroneous string usage in two unit tests
* test 089 fails on some containers - skip it
* retry getting the sleep pid in ftests.  it sometimes fails