### PR TITLE
src/daemon/cgrulesengd: Correctly check for ENOBUFS when doing recvfr…

### DIFF
--- a/src/daemon/cgrulesengd.c
+++ b/src/daemon/cgrulesengd.c
@@ -567,7 +567,7 @@ static int cgre_receive_netlink_msg(int sk_nl)
 	from_nla_len = sizeof(from_nla);
 	recv_len = recvfrom(sk_nl, buff, sizeof(buff), 0, (struct sockaddr *)&from_nla,
 			    &from_nla_len);
-	if (recv_len == ENOBUFS) {
+	if (recv_len == -1 && errno == ENOBUFS) {
 		flog(LOG_ERR, "ERROR: NETLINK BUFFER FULL, MESSAGE DROPPED!\n");
 		return 0;
 	}


### PR DESCRIPTION
…om()

Currently, code checks if recvfrom() returns ENOBUFS, however, it can never return errno type error code, but -1 on error

Fix that by checking errno in case of an error instead