### PR TITLE
doc/release: add step to push to release branch

### DIFF
--- a/doc/internal/release-github.md
+++ b/doc/internal/release-github.md
@@ -74,14 +74,18 @@ release.
 
 	# git push <repo> vX.Y.Z
 
-#### 16. Create a new GitHub release using the associated tag and upload the following files
+#### 16. Push the release branch to the main GitHub repository
+
+    # git push <repo> release-X.Y
+
+#### 17. Create a new GitHub release using the associated tag and upload the following files
 
   * libcgroup-X.Y.Z.tar.gz
   * libcgroup-X.Y.Z.tar.gz.asc
   * libcgroup-X.Y.Z.tar.gz.SHA256SUM
   * libcgroup-X.Y.Z.tar.gz.SHA256SUM.asc
 
-#### 17. Update the GitHub release notes for older releases which are now unsupported
+#### 18. Update the GitHub release notes for older releases which are now unsupported
 
 The following Markdown text is suggested at the top of the release note, see old GitHub releases for examples.
 


### PR DESCRIPTION
Update the release process documentation to include the missing step for
pushing to the newly created release branch. Renumber subsequent steps
to reflect the correct order.
