### PR TITLE
src: handle NULL options in cgroup_parse_rules_options

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -526,6 +526,10 @@ STATIC int cgroup_parse_rules_options(char *options, struct cgroup_rule * const 
 	size_t cmp_len;
 	int ret = 0;
 
+	if (!options) {
+		cgroup_err("failed to parse options (NULL)\n");
+		return -EINVAL;
+	}
 	stok_buff = strtok(options, ",");
 	if (!stok_buff) {
 		cgroup_err("failed to parse options: %s\n", options);


### PR DESCRIPTION
We don't want to pass NULL to strtok:
```
[ RUN      ] ParseRulesOptionsTest.RulesOptions_NullOptions
==2006496== Conditional jump or move depends on uninitialised value(s)
==2006496==    at 0x520D156: strtok_r (strtok_r.c:49)
==2006496==    by 0x403FB7E: cgroup_parse_rules_options (api.c:529)
==2006496==    by 0x4005F41: ParseRulesOptionsTest_RulesOptions_NullOptions_Test::TestBody() (002-cgroup_parse_rules_options.cpp:89)
==2006496==    by 0x4ABA45D: ??? (in /usr/lib64/libgtest.so.1.15.2)
==2006496==    by 0x4ABE5AB: ??? (in /usr/lib64/libgtest.so.1.15.2)
==2006496==    by 0x4A9D949: testing::TestInfo::Run() (in /usr/lib64/libgtest.so.1.15.2)
==2006496==    by 0x4ABF18A: ??? (in /usr/lib64/libgtest.so.1.15.2)
==2006496==    by 0x4AB7467: testing::internal::UnitTestImpl::RunAllTests() (in /usr/lib64/libgtest.so.1.15.2)
==2006496==    by 0x4AACC46: testing::UnitTest::Run() (in /usr/lib64/libgtest.so.1.15.2)
==2006496==    by 0x4002345: UnknownInlinedFun (gtest.h:2334)
==2006496==    by 0x4002345: main (gtest.cpp:15)
==2006496==
Error: failed to parse options: (null)
```