### PR TITLE
tests/gunit: disable execution with --gtest_shuffle

### DIFF
--- a/tests/gunit/gtest.cpp
+++ b/tests/gunit/gtest.cpp
@@ -12,5 +12,9 @@ int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
 
+    if (testing::GTEST_FLAG(shuffle)) {
+	    std::cout << "--gtest_shuffle option is not supported!" <<std::endl;
+	    return 0;
+    }
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Some Google tests rely on being run in a specific order, with certain tests depending on the successful completion of previous ones. Passing the `--gtest_shuffle` option can break this sequence, potentially leading to test failures or inconsistent results.

Until the test suite is updated to support randomized execution, skip running tests when `--gtest_shuffle` is used.