### PR TITLE
ftests/run.py: terminate processes that exceed timeout

### DIFF
--- a/tests/ftests/run.py
+++ b/tests/ftests/run.py
@@ -49,6 +49,9 @@ class Run(object):
                     ret = -1
                 else:
                     ret = 0
+
+                # kill the process, that has exceeded the timeout
+                subproc.kill()
         else:
             out, err = subproc.communicate()
             ret = subproc.returncode


### PR DESCRIPTION
Some commands, like 'cgrulesengd' in non-daemon mode, continue running
until explicitly terminated. Currently, we catch exceptions for timeouts but do
not terminate the lingering process. This patch ensures that such processes
are properly killed after the timeout.