### PR TITLE
ftests/utils: add get_distro() to detect Linux distribution

### DIFF
--- a/tests/ftests/utils.py
+++ b/tests/ftests/utils.py
@@ -104,4 +104,13 @@ def is_output_same(config, out, expected_out):
     return result, cause
 
 
+# get the current linux flavour
+def get_distro(config):
+    with open('/etc/os-release', 'r') as relfile:
+        buf = relfile.read()
+        if "Oracle Linux" in buf:
+            return "oracle"
+        elif "Ubuntu" in buf:
+            return "ubuntu"
+
 # vim: set et ts=4 sw=4:


### PR DESCRIPTION
Introduce helper function get_distro() to identify the current Linux
distribution. Currently checks for 'Ubuntu' and 'Oracle Linux', which
are the only distros used for testing. Can be extended to support
others in the future.