### PR TITLE
Avoid cgrules controllers out of bounds access

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -974,7 +974,7 @@ static int cgroup_parse_rules_file(char *filename, bool cache, uid_t muid, gid_t
 			   lst->tail->username, lst->tail->uid, lst->tail->gid,
 			   lst->tail->destination);
 
-		for (i = 0; lst->tail->controllers[i]; i++)
+		for (i = 0; i < MAX_MNT_ELEMENTS && lst->tail->controllers[i]; i++)
 			cgroup_dbg(" %s", lst->tail->controllers[i]);
 		cgroup_dbg("\n");
 	}


### PR DESCRIPTION
Hello!

<h3>1) Potential out-of-bounds access in cgroup_create_template_group</h3>  

In the function src/api.c/cgroup_create_template_group, the loop condition:

```
		while (tmp->controllers[i] != NULL) {
			exist = cgroup_exist_in_subsystem(tmp->controllers[i], group_name);

			if (exist != 0) {
				/* The cgroup does not exist */
				ret = add_controller(&template_group, group_name,
						     tmp->controllers[i]);
				if  (ret != 0)
					goto while_end;
			}
			i++;
		}
```

potentially allows accessing ``tmp->controllers[MAX_MNT_ELEMENTS]`` if tmp->controllers is full and lacks a terminating NULL. I tested this empirically.

First, I checked v0.41 (the version available in my package repository), where ``MAX_MNT_ELEMENTS=8``. I configured cgrules.conf as follows:

```
*:sha1sum    freezer,cpu,misc,memory,devices,rdma,hugetlb,cpuset        /my_limit/%u
*:stress     cpu                                                        /my_limit/%u
```

When I started a sha1sum process and launched cgrulesengd, I encountered a segfault:

```
Found matching rule * for PID: 10116, UID: 0, GID: 0
Executing rule * for PID 10116... control group /my_limit/root is template

Program received signal SIGSEGV, Segmentation fault.
__strcmp_avx2 () at ../sysdeps/x86_64/multiarch/strcmp-avx2.S:287
287    CMP_R1_S2_ymm (%ymm0, (%rsi), %ymm2, %ymm1)
(gdb) bt full
#0  __strcmp_avx2 () at ../sysdeps/x86_64/multiarch/strcmp-avx2.S:287
No locals.
#1  0x00007ffff7c0a11c in cg_build_path_locked (name=0x55555555e070 "", 
    path=0x7fffffffa790 "/sys/fs/cgroup/cpuset/", 
    type=0x1161 <error: Cannot access memory at address 0x1161>) at api.c:1142
        i = 0
#2  0x00007ffff7c0d81c in cgroup_exist_in_subsystem (
    controller_name=0x1161 <error: Cannot access memory at address 0x1161>, 
    prefix=0x55555555e070 "") at api.c:2682
        dir = 0x55555556f490
        path = "/sys/fs/cgroup/cpuset/\000\000ct/\000\377\177\000\000\020\320UUUU\000\000\a\000\000\000\000\000\000\000\000\250\377\377\377\177\000\000\256݊\367\377\177\000\000\000\250\377\377\377\177\000\000\257\031\211\367\377\177\000\000@\326UUUU\000\000X\373\377\377\377\377\377\377\002\000\000\000\000\000\000\000\020\340UUUU\000\000@\250\377\377\377\177\000\000\021\000\000\000\000\000\000\000\200\270\377\377\377\177\000\000@\235UUUU\000\000@\250\377\377\377\177\000\000_C\213\367\377\177\000\000P\314\377\377\377\177\000\000\360\314\377\377\377\177\000\000\240\310\377\377\377\177\000\0004\t\301\367\377\177\000\000\310\310\377\377\377\177\000\000\000"...
        ret_path = 0x0
        ret = 1
#3  0x00007ffff7c0db47 in cgroup_create_template_group (
    orig_group_name=0x7fffffffb880 "/my_limit/root", tmp=0x55555555f8b0, 
--Type <RET> for more, q to quit, c to continue without paging--
    flags=1) at api.c:2809
        template_name = 0x55555555e090 ""
        group_name = 0x55555555e070 ""
        template_position = 0x55555555e090 ""
        group_position = 0x55555555e070 ""
        template_group = 0x55555556f490
        ret = 0
        i = 9
        exist = 1
...
```

I suspect this segfault occurred due to accessing ``tmp->controllers[8]``.

Next, I checked v3.2.0, where ``MAX_MNT_ELEMENTS=16``. While it's unlikely that real-world systems would have 16 controllers, nothing prevents specifying exactly 16 values in the controllers column of cgrules.conf:

```
*:sha1sum    cpu,cpuset,memory,pids,cpu,cpu,cpu,cpu,cpu,cpu,cpu,cpu,cpu,cpu,cpu  /my_limit/%u
*:stress     cpu                                                                 /my_limit/%u
```

Here, no segfault occurred, but an out-of-bounds access likely happened:

```
Found matching rule * for PID: 10587, UID: 1000, GID: 1000
Executing rule * for PID 10587... control group /my_limit/vboxuser is template
failed to get cgroup version for controller ��������
```

<h3>2) Similar concern in cgroup_parse_rules_file (v3.2.0)</h3>

In src/api.c/cgroup_parse_rules_file, there's a loop:

```
		for (i = 0; lst->tail->controllers[i]; i++)
			cgroup_dbg(" %s", lst->tail->controllers[i]);
```

Again, the loop condition relies on ``lst->tail->controllers[i]`` being ``NULL`` to terminate. While this works in practice (since ``lst->tail->next`` is NULL and thus ``lst->tail->controllers[MAX_MNT_ELEMENTS]`` is effectively ``NULL``), this seems to depend on undefined behavior.
\
\
Fixes: #490 
\
Found by Linux Verification Center (linuxtesting.org) with SVACE. \
\
Signed-off-by: Mikhail Dmitrichenko <m.dmitrichenko222@gmail.com>