### PR TITLE
src/config: Fix segfault while using templates

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1946,7 +1946,7 @@ int cgroup_config_create_template_group(struct cgroup *cgroup, char *template_na
 			}
 
 			/* template name match */
-			for (k = 0; t_cgroup->controller[k] != NULL; k++) {
+			for (k = 0; k < t_cgroup->index; k++) {
 				if (strcmp((cgroup->controller[i])->name,
 					(t_cgroup->controller[k])->name) != 0) {
 					/* controller name does not match */


### PR DESCRIPTION
An intermittent segmentation fault occurs when classifying tasks using cgrulesengd in combination with a template defined in cgconfig.conf. Backtrace:
```
(gdb) bt
 #0  __strcmp_evex () at ../sysdeps/x86_64/multiarch/strcmp-evex.S:295
 #1  0x00007079d2e69645 in cgroup_config_create_template_group (cgroup=0x18844f834600,
     template_name=0x18844f710cd0 "system/hosting-users/%g/mail-delivery", flags=1) at config.c:1950
 #2  0x00007079d2e61458 in cgroup_create_template_group (orig_group_name=0x79905b6ebb70 "system/hosting-users/ryleeisitt/mail-delivery",
     tmp=0x18844f69cce0, flags=1) at api.c:4609
 #3  0x00007079d2e61bcd in cgroup_change_cgroup_flags (uid=0, gid=674, procname=0x18844f79c310 "/var/qmail/bin/qmail-queue-wrapper", pid=1048, flags=1)
     at api.c:4811
 #4  0x000018844cc0f29d in cgre_process_event (ev=0x79905b6ecc74, type=4) at cgrulesengd.c:485
 #5  0x000018844cc0f441 in cgre_handle_msg (cn_hdr=0x79905b6ecc60) at cgrulesengd.c:531
 #6  0x000018844cc0f678 in cgre_receive_netlink_msg (sk_nl=0) at cgrulesengd.c:596
 #7  0x000018844cc0ffe1 in cgre_create_netlink_socket_process_msg () at cgrulesengd.c:786
 #8  0x000018844cc10e4e in main (argc=3, argv=0x79905b6eda58) at cgrulesengd.c:1282
```
Fix the issue using cgroup->index that holds the count of controllers, populated for the cgroup instead of checking for
cgroup->controller[index] is NULL.

Fixes: https://github.com/libcgroup/libcgroup/issues/483