### PR TITLE
ftests: Fix false positive in 010 testcase

### DIFF
--- a/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/tests/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -27,7 +27,7 @@ def setup(config):
 
 
 def test(config):
-    result = consts.TEST_PASSED
+    result = consts.TEST_FAILED
     cause = None
 
     out = Cgroup.get(config, controller='{}:{}'.format(CONTROLLER, CGNAME),


### PR DESCRIPTION
Fix the false positive in the testcase number 010, the return value should
be by default `TEST_FAILED`, instead of `TEST_PASSED`. The flow of the
testcase is designed to set the return value to `TEST_PASSED` only if the
current kernel's cpu controller settings matches any of the expected
cpu controller output list.