### PR TITLE
ftests: Fix false positive in 013 testcase

### DIFF
--- a/tests/ftests/013-cgget-multiple_g_flags.py
+++ b/tests/ftests/013-cgget-multiple_g_flags.py
@@ -30,7 +30,7 @@ def setup(config):
 
 
 def test(config):
-    result = consts.TEST_PASSED
+    result = consts.TEST_FAILED
     cause = None
 
     out = Cgroup.get(config, controller=[CONTROLLER1, CONTROLLER2],


### PR DESCRIPTION
Fix the false positive in the testcase number 013, the return value should
be by default `TEST_FAILED`, instead of `TEST_PASSED`. The flow of the
testcase is designed to set the return value to `TEST_PASSED` only if the
current kernel's cpu controller settings matches any of the expected
cpu controller output list.