### PR TITLE
Miscellaneous ftest fixes

### DIFF
--- a/tests/ftests/013-cgget-multiple_g_flags.py
+++ b/tests/ftests/013-cgget-multiple_g_flags.py
@@ -51,6 +51,9 @@ def test(config):
         # Append pid controller [1] and cpu controller [N, N - 1]
         EXPECTED_OUT.extend(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[1] + expected_out
                             for expected_out in consts.EXPECTED_CPU_OUT_V2[-2:])
+        # Append pid controller [2] and cpu controller [N, N - 1]
+        EXPECTED_OUT.extend(OUT_PREFIX + consts.EXPECTED_PIDS_OUT[2] + expected_out
+                            for expected_out in consts.EXPECTED_CPU_OUT_V2[-2:])
 
     for expected_out in EXPECTED_OUT:
         if len(out.splitlines()) == len(expected_out.splitlines()):

--- a/tests/ftests/090-cgxset-recursive_flag.py
+++ b/tests/ftests/090-cgxset-recursive_flag.py
@@ -147,6 +147,8 @@ def test_cgroup_hybrid(config):
 
 
 def test_cgroup_unified(config):
+    Cgroup.xset(config, cgname=PARENT + "/../", setting=SETTING_V2_SUBTREE,
+                value=VALUE_V1_V2_SUBTREE, version=CGRP_VER_V2, recursive=False)
     cgroup_settings_helper(config, SETTING_V1, VALUE_V1, DEFAULT_VALUE_V1, CGRP_VER_V1)
     result, cause = cgroup_subtree_helper(config, SETTING_V2_SUBTREE, VALUE_V2_SUBTREE, CGRP_VER_V2)
 

--- a/tests/ftests/consts.py
+++ b/tests/ftests/consts.py
@@ -216,6 +216,13 @@ EXPECTED_PIDS_OUT = [
         pids.events: max 0
         pids.max: max
         pids.peak: 0
+        """,
+        # pids.events.local
+        """pids.current: 0
+        pids.events: max 0
+        pids.max: max
+        pids.events.local: max 0
+        pids.peak: 0
         """
 ]
 


### PR DESCRIPTION
This patch series has two fixes:
- The patches 0001 and 0002, adds a new pids controller setting consts to the pid list
   and extend the test case 013 to stress the new pids controller setting
- The patch 0003, modifies the test case 090 to write `cpuset` controller into default
  hirerachy (root cgroup) without it, children cgroups can not enable `cpuset` controllers.