### PR TITLE
ftests/cgroup: Add timeout to cgrulesengd

### DIFF
--- a/tests/ftests/cgroup.py
+++ b/tests/ftests/cgroup.py
@@ -705,7 +705,7 @@ class Cgroup(object):
                                 'supported'
                             )
         else:
-            Run.run(cmd, shell_bool=True)
+            Run.run(cmd, shell_bool=True, timeout=20)
 
     def start_cgrules(self, config):
         Cgroup.init_cgrules(config)


### PR DESCRIPTION
`cgrulesengd -n` (nodaemon mode) runs indefinitely until it is terminated
with `SIGKILL`. To handle this, introduce a 20-second timeout that is passed
to `__run()`, which in turn calls `subproc.kill()` to terminate `cgrulesengd`
once the timer expires.