### PR TITLE
Fix Issue #505

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -39,7 +39,15 @@ jmp_buf parser_error_env;
 "systemd"     	{return SYSTEMD;}
 "default"	{yylval.name = strdup(yytext); return DEFAULT;}
 [a-zA-Z0-9_\-\/\.\,\%\@\\]+ {yylval.name = strdup(yytext); return ID;}
-\"[^"]*\" {yylval.name = strdup(yytext+1); yylval.name[strlen(yylval.name)-1] = '\0'; return ID; }
+\"[^"]*\"	{
+	if (yytext[0] != '\0' && yytext[1] != '\0') {
+		yylval.name = strdup(yytext+1); 
+		yylval.name[strlen(yylval.name)-1] = '\0';
+	} else {
+		yylval.name = strdup("");
+	} 
+	return ID;
+	} 
 .	{return yytext[0];}
 %%
 


### PR DESCRIPTION
The error is related to overflow when adding an unsigned offset when processing quoted strings.

    43     \"namespace\"\t{return NAMESPACE;}
    44     \"template\"\t{return TEMPLATE;}
    45     \"default\"\t{yylval.name = strdup(yytext); return DEFAULT;}
    46     [a-zA-Z0-9_\\-\\/\\.\\,\\%\\@\\\\]+ {yylval.name = strdup(yytext); return ID;}
--->47     \\\"[^\"]*\\\" {yylval.name = strdup(yytext+1); yylval.name[strlen(yylval.name)-1] = '\\0'; return ID; }
    48     .\t{return yytext[0];}
    49     %%
    50     
If the string is empty (""), then strlen(yylval.name -1 can give a negative value converted to a very large unsigned number.