### PR TITLE
Add a Github Actions job to build libcgroup using clang

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -94,6 +94,35 @@ jobs:
         publish_dir: ./doc/html
         publish_branch: doxygen/${{ github.ref_name }}
 
+  build-with-clang:
+    name: Build with Clang
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: false
+    - name: Install dependencies
+      run: |
+        while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do sleep 3; done
+        sudo apt-get update
+        sudo apt-get install libpam-dev python3-pip python3-dev cmake bison flex byacc g++ autoconf automake libtool libsystemd-dev clang -y
+    - name: Install cython
+      run: sudo pip install cython
+    - name: Bootstrap
+      run: ./bootstrap.sh
+    - name: Reconfigure libcgroup with unit tests enabled
+      run: CFLAGS="$CFLAGS -Werror" ./configure --sysconfdir=/etc --localstatedir=/var --enable-opaque-hierarchy="name=systemd" --enable-python --enable-unittests
+    - name: Build libcgroup
+      run: make
+    - name: Run unit tests
+      run: |
+        pushd tests/gunit
+        make check
+        popd
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/src/api.c
+++ b/src/api.c
@@ -2381,7 +2381,6 @@ static int cg_set_control_value(char *path, const char *val)
 			path_dir_end = strrchr(path, '/');
 			if (path_dir_end == NULL)
 				return ECGROUPVALUENOTEXIST;
-			path_dir_end = '\0';
 
 			/* task_path contain: $path/tasks */
 			tasks_path = (char *)malloc(strlen(path) + 6 + 1);

--- a/src/api.c
+++ b/src/api.c
@@ -6718,7 +6718,7 @@ int cgroup_list_mount_points(const enum cg_version_t cgrp_version, char ***mount
 			goto err;
 		}
 	}
-	mnt_paths[i] = '\0';
+	mnt_paths[i] = NULL;
 
 	ret = 0;
 	*mount_paths = mnt_paths;

--- a/src/api.c
+++ b/src/api.c
@@ -5170,7 +5170,7 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller, char *
 		 * - controller-list is empty
 		 */
 		if (mode == CGROUP_MODE_UNIFIED || unified) {
-			ret = fscanf(pid_cgrp_fd, "%d::%4096s\n", &num, cgrp_path);
+			ret = fscanf(pid_cgrp_fd, "%d::%4095s\n", &num, cgrp_path);
 			if (ret != 2) {
 				/*
 				 * we are interested only in unified format
@@ -5212,10 +5212,10 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller, char *
 		}
 
 		/*
-		 * 4096 == FILENAME_MAX, keeping the coverity happy with precision
+		 * 4095 == FILENAME_MAX - 1, keeping coverity happy with precision
 		 * for the cgrp_path.
 		 */
-		ret = fscanf(pid_cgrp_fd, "%d:%[^:]:%4096s\n", &num, controllers, cgrp_path);
+		ret = fscanf(pid_cgrp_fd, "%d:%[^:]:%4095s\n", &num, controllers, cgrp_path);
 		/*
 		 * Magic numbers like "3" seem to be integrating into my daily
 		 * life, I need some magic to help make them disappear :)

--- a/src/api.c
+++ b/src/api.c
@@ -4229,8 +4229,8 @@ static bool cgroup_is_rt_task(const pid_t pid)
 STATIC bool cgroup_compare_ignore_rule(const struct cgroup_rule * const rule, pid_t pid,
 				       const char * const procname)
 {
-	char *controller_list[MAX_MNT_ELEMENTS] = { '\0' };
-	char *cgrp_list[MAX_MNT_ELEMENTS] = { '\0' };
+	char *controller_list[MAX_MNT_ELEMENTS] = { NULL };
+	char *cgrp_list[MAX_MNT_ELEMENTS] = { NULL };
 	int rule_matching_controller_idx;
 	int cgrp_list_matching_idx = 0;
 	bool found_match = false;

--- a/src/api.c
+++ b/src/api.c
@@ -3781,7 +3781,7 @@ int cgroup_fill_cgc(struct dirent *ctrl_dir, struct cgroup *cgrp, struct cgroup_
 	 * sort of a flag, but this is fine for now.
 	 */
 	cg_build_path_locked(cgrp->name, path, cg_mount_table[cg_index].name);
-	strncat(path, d_name, sizeof(path) - strlen(path));
+	strncat(path, d_name, sizeof(path) - strlen(path) - 1);
 
 	error = stat(path, &stat_buffer);
 	if (error) {

--- a/src/api.c
+++ b/src/api.c
@@ -3724,7 +3724,7 @@ static int cg_rd_ctrl_file(const char *subsys, const char *cgrp, const char *fil
 	if (!cg_build_path_locked(cgrp, path, subsys))
 		return ECGFAIL;
 
-	strncat(path, file, sizeof(path) - strlen(path));
+	strncat(path, file, sizeof(path) - strlen(path) - 1);
 	ctrl_file = fopen(path, "re");
 	if (!ctrl_file)
 		return ECGROUPVALUENOTEXIST;

--- a/src/tools/cgclassify.c
+++ b/src/tools/cgclassify.c
@@ -331,9 +331,9 @@ static pid_t find_scope_pid(pid_t pid, int capture)
 		/* read according to the cgroup mode */
 		if (strstr(buffer, "::")) {
 			snprintf(ctrl_name, CONTROL_NAMELEN_MAX, "unified");
-			ret = sscanf(buffer, "%d::%4096s\n", &idx, cgrp_name);
+			ret = sscanf(buffer, "%d::%4095s\n", &idx, cgrp_name);
 		} else {
-			ret = sscanf(buffer, "%d:%[^:]:%4096s\n", &idx, ctrl_name, cgrp_name);
+			ret = sscanf(buffer, "%d:%[^:]:%4095s\n", &idx, ctrl_name, cgrp_name);
 		}
 
 		if (ret != 2 && ret != 3) {
@@ -494,7 +494,7 @@ static void find_mnt_point(const char * const controller, char **mnt_point)
 				continue;
 		}
 
-		ret = sscanf(buffer, "%*s %4096s\n", cgrp_path);
+		ret = sscanf(buffer, "%*s %4095s\n", cgrp_path);
 		if (ret != 1) {
 			err("Failed during read of %s:%s\n", proc_mount, strerror(errno));
 			goto out;

--- a/src/tools/cgexec.c
+++ b/src/tools/cgexec.c
@@ -291,9 +291,9 @@ static pid_t find_scope_pid(pid_t pid)
 
 		/* read according to the cgroup mode */
 		if (strstr(buffer, "::"))
-			ret = sscanf(buffer, "%d::%4096s\n", &idx, cgrp_name);
+			ret = sscanf(buffer, "%d::%4095s\n", &idx, cgrp_name);
 		else
-			ret = sscanf(buffer, "%d:%[^:]:%4096s\n", &idx, ctrl_name, cgrp_name);
+			ret = sscanf(buffer, "%d:%[^:]:%4095s\n", &idx, ctrl_name, cgrp_name);
 
 		if (ret != 2 && ret != 3) {
 			err("Unrecognized cgroup file format: %s\n", buffer);
@@ -420,7 +420,7 @@ static void find_mnt_point(const char * const controller, char **mnt_point)
 		if (!strstr(buffer, controller))
 			continue;
 
-		ret = sscanf(buffer, "%*s %4096s\n", cgrp_path);
+		ret = sscanf(buffer, "%*s %4095s\n", cgrp_path);
 		if (ret != 1) {
 			err("Failed during read of %s:%s\n", proc_mount, strerror(errno));
 			goto out;

--- a/src/tools/cgxget.c
+++ b/src/tools/cgxget.c
@@ -897,7 +897,7 @@ err:
 #ifdef LIBCG_LIB
 int cgroup_cgxget(struct cgroup **cg, enum cg_version_t version, bool ignore_unmappable)
 {
-	struct cgroup *disk_cg, *out_cg;
+	struct cgroup *disk_cg = NULL, *out_cg;
 	int ret;
 
 	if (!cg || !(*cg)) {


### PR DESCRIPTION
Add a Github Actions job to build libcgroup using clang.  Since our Github Actions jobs set all warnings to errors, also fix the various errors that this build generated.