### PR TITLE
docs (cgcreate): update `-a` flag to match `uid:gid` order

### DIFF
--- a/doc/man/cgcreate.1
+++ b/doc/man/cgcreate.1
@@ -15,7 +15,7 @@ The command creates new cgroup(s) defined by the options
 \fB-g\fR.
 
 .TP
-.B -a <agid>:<auid>
+.B -a <auid>:<agid>
 defines the name of the user and the group which own the
 rest of the defined control group’s files. These users are
 allowed to set subsystem parameters and create subgroups.


### PR DESCRIPTION
Currently, `cgcreate`'s man page states that the order in which the `-a` flag receives its parameters is:
`-a <agid>:<auid>`.

However, when I passed the parameters like so, I got an error stating: "there's no user named 'users'" (which is the name of the group). 

Looking at the code, I believe the actual order is: `-a <agid>:<auid>`. That's the order the `-t` flag requires ([docs](https://github.com/libcgroup/libcgroup/blob/05ce62bca993c260af6478a1f2035bb0c73050a9/doc/man/cgcreate.1#L89-L93)) and they both use the same parsing function ([linked here](https://github.com/libcgroup/libcgroup/blob/05ce62bca993c260af6478a1f2035bb0c73050a9/src/tools/cgcreate.c#L204-L210)).

