### PR TITLE
src/api.c: prevent potential oom null derefs

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -5930,6 +5930,11 @@ STATIC int cg_get_cgroups_from_proc_cgroups(pid_t pid, char *cgrp_list[],
 		if (buff_len > 1) {
 			/* Strip off the leading '/' for every cgroup but the root cgroup */
 			cgrp_list[idx] = malloc(buff_len);
+			if (!cgrp_list[idx]) {
+				cgroup_err("malloc failed to allocate memory: %s\n", strerror(errno));
+				fclose(f);
+				return ECGOTHER;
+			}
 			snprintf(cgrp_list[idx], buff_len, "%s", &stok_buff[1]);
 		} else {
 			/* Retain the leading '/' since we're in the root cgroup */


### PR DESCRIPTION
Hello!

I used SAST tool Svace to analyze source code and encountered 2 potential null ptr dereference cases:

1) In function `cgroup_fill_cgc` there is an allocation of memory by calling `strdup(ctrl_dir->d_name)`. Result of this allocation is not checked and used in `strcmp` then;
2) In function `cg_get_cgroups_from_proc_cgroups` there is an allocation of memory by calling `malloc(buff_len)`. Result of this allocation is not checked and then used in `snprintf`.

This PR adds handling of such possible failed memory allocations.