### PR TITLE
systemd,cgcreate: use strchr() to find the slice/scope separator

### DIFF
--- a/src/systemd.c
+++ b/src/systemd.c
@@ -381,7 +381,7 @@ int cgroup_create_scope2(struct cgroup *cgroup, int ignore_ownership,
 		return ECGINVAL;
 	}
 
-	slash = strstr(slash + 1, "/");
+	slash = strchr(slash + 1, '/');
 	if (slash) {
 		cgroup_err("cgroup name contains more than one slash: %s\n", cgroup->name);
 		return ECGINVAL;

--- a/src/tools/cgcreate.c
+++ b/src/tools/cgcreate.c
@@ -70,7 +70,7 @@ static int create_systemd_scope(struct cgroup * const cgrp, const char * const p
 
 	ret = cgroup_create_scope2(cgrp, 0, &opts);
 	if (!ret && set_default) {
-		scope = strstr(cgrp->name, "/");
+		scope = strchr(cgrp->name, '/');
 		if (!scope) {
 			err("%s: Invalid scope name %s, expected <slice>/<scope>\n",
 			    prog_name, cgrp->name);


### PR DESCRIPTION
Both cgroup_create_scope2() and create_systemd_scope() used strstr() to
locate the '/' delimiter between slice and scope components. Since we
are matching a single character, use strchr() instead to express the
intent precisely and avoid the extra substring search semantics/overhead
implied by strstr().

No functional change expected. cgroup name that do not conform to
`<slice-name>.slice/<scope-name>.scope`, continue to be rejected.