### PR TITLE
src/config: harden cgroup table growth

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -146,25 +146,26 @@ int config_insert_cgroup(char *cg_name, int flag)
 	}
 
 	if (*table_index >= *max - 1) {
+		unsigned int oldlen = *max;
 		struct cgroup *newblk;
-		unsigned int oldlen;
+		unsigned int newlen;
 
-		if (*max >= INT_MAX) {
+		if (oldlen >= UINT_MAX / 2) {
 			last_errno = ENOMEM;
 			return 0;
 		}
-		oldlen = *max;
-		*max *= 2;
+		newlen = oldlen * 2;
 
-		newblk = realloc(config_table, (*max * sizeof(struct cgroup)));
+		newblk = realloc(config_table, ((size_t)newlen * sizeof(struct cgroup)));
 		if (!newblk) {
 			last_errno = ENOMEM;
 			return 0;
 		}
 
-		memset(newblk + oldlen, 0, (*max - oldlen) * sizeof(struct cgroup));
-		init_cgroup_table(newblk + oldlen, *max - oldlen);
+		memset(newblk + oldlen, 0, (newlen - oldlen) * sizeof(struct cgroup));
+		init_cgroup_table(newblk + oldlen, newlen - oldlen);
 		config_table = newblk;
+		*max = newlen;
 		switch (flag) {
 		case CGROUP:
 			config_cgrp_table = config_table;
@@ -175,7 +176,7 @@ int config_insert_cgroup(char *cg_name, int flag)
 		default:
 			return 0;
 		}
-		cgroup_dbg("maximum %d\n", *max);
+		cgroup_dbg("maximum %u\n", *max);
 		cgroup_dbg("reallocated config_table to %p\n", config_table);
 	}
 


### PR DESCRIPTION
config_insert_cgroup() doubles the parser table size whenever it hits
the limit, but it bumps *max before realloc() succeeds. If the allocation
fails we leave the global size counter inflated while the backing array
stays at the old length, so the next insert walks off the end. The expansion
logic also skipped reinitialising the new slots and printed the limit with
a signed format specifier.

Compute the new length up front, attempt realloc() with that size, and
only store it back into *max once the allocation succeeds. Zero and initialise
the newly created entries so subsequent inserts see a clean struct cgroup,
and log the size with %u to match the unsigned type. The growth path no
longer leaves stale state behind when memory is tight.