### PR TITLE
Fix grammar and typos across headers and sources

### DIFF
--- a/include/libcgroup/config.h
+++ b/include/libcgroup/config.h
@@ -46,7 +46,7 @@ int cgroup_unload_cgroups(void);
  * file.
  *
  * The groups are either removed recursively or only the empty ones, based
- * on given flags. Mount point are always umounted only if they are empty,
+ * on given flags. Mount points are always umounted only if they are empty,
  * regardless of any flags.
  *
  * The groups are sorted before they are removed, so the removal of empty ones
@@ -105,7 +105,7 @@ void cgroup_templates_cache_set_source_files(struct cgroup_string_list *tmpl_fil
 /**
  * Physically create a new control group in kernel, based on given control
  * group template and configuration file. If given template is not set in
- * configuration file, then the procedure works create the control group
+ * configuration file, then the procedure creates the control group
  * using  cgroup_create_cgroup() function
  *
  * Templates are loaded using cgroup_load_templates_cache_from_files

--- a/include/libcgroup/error.h
+++ b/include/libcgroup/error.h
@@ -108,4 +108,4 @@ int cgroup_get_last_errno(void);
 } /* extern "C" */
 #endif
 
-#endif /* _LIBCGROUP_INIT_H */
+#endif /* _LIBCGROUP_ERROR_H */

--- a/include/libcgroup/error.h
+++ b/include/libcgroup/error.h
@@ -20,7 +20,7 @@ extern "C" {
  *
  * @name Error handling
  * @{
- * Unless states otherwise in documentation of a function, all functions
+ * Unless stated otherwise in a function's documentation, all functions
  * return @c int, which is zero (0) when the function succeeds, and positive
  * number if the function fails.
  *
@@ -62,7 +62,7 @@ enum {
 	ECGROUPNORULES,			/* 50020 */
 	ECGMOUNTFAIL,			/* 50021 */
 	/**
-	 * Not an real error, it just indicates that iterator has come to end
+	 * Not a real error, it just indicates that the iterator has come to the end
 	 * of sequence and no more items are left.
 	 */
 	ECGEOF = 50023,

--- a/include/libcgroup/groups.h
+++ b/include/libcgroup/groups.h
@@ -151,7 +151,7 @@ struct cgroup_controller;
  *	for the root group itself and @c "/foo/bar/baz" or @c "foo/bar/baz" for
  *	subgroups.
  *	@todo suggest one preferred way, either "/foo" or "foo".
- * @returns Created group or NULL on error.
+ * @return Created group or NULL on error.
  */
 struct cgroup *cgroup_new_cgroup(const char *name);
 
@@ -215,7 +215,7 @@ void cgroup_free_controllers(struct cgroup *cgrp);
  * The created groups has owner which was set by cgroup_set_uid_gid() and
  * permissions set by cgroup_set_permissions.
  * @param cgrp
- * @param ignore_ownership When nozero, all errors are ignored when setting
+ * @param ignore_ownership When nonzero, all errors are ignored when setting
  *	owner of the group and/or its tasks file.
  *	@todo what is ignore_ownership good for?
  * @retval #ECGROUPNOTEQUAL if not all specified controller parameters
@@ -236,9 +236,9 @@ int cgroup_create_cgroup(struct cgroup *cgrp, int ignore_ownership);
  * cgroup_add_controller() is not used, like in cgroup_create_cgroup()? I can't
  * create subgroup of root group in just one hierarchy with this function!
  *
- * @param cgrp The cgroup to create. Only it's name is used, everything else
+ * @param cgrp The cgroup to create. Only its name is used, everything else
  *	is discarded.
- * @param ignore_ownership When nozero, all errors are ignored when setting
+ * @param ignore_ownership When nonzero, all errors are ignored when setting
  *	owner of the group and/or its tasks file.
  *	@todo what is ignore_ownership good for?
  * @retval #ECGROUPNOTEQUAL if not all inherited controller parameters
@@ -249,7 +249,7 @@ int cgroup_create_cgroup_from_parent(struct cgroup *cgrp, int ignore_ownership);
 /**
  * Physically modify a control group in kernel. All parameters added by
  * cgroup_add_value_ or cgroup_set_value_ are written.
- * Currently it's not possible to change and owner of a group.
+ * Currently it's not possible to change the owner of a group.
  *
  * @param cgrp
  */
@@ -265,7 +265,7 @@ int cgroup_modify_cgroup(struct cgroup *cgrp);
  * cgroup_delete_cgroup_ext() for recursive delete.
  *
  * @param cgrp
- * @param ignore_migration When nozero, all errors are ignored when migrating
+ * @param ignore_migration When nonzero, all errors are ignored when migrating
  *	tasks from the group to the parent group.
  *	@todo what is ignore_migration good for? rmdir() will fail if tasks were not moved.
  */
@@ -311,7 +311,7 @@ int cgroup_delete_cgroup_ext(struct cgroup *cgrp, int flags);
  * cgroup_get_uid_gid() if the group is in multiple hierarchies, each with
  * different owner of tasks file?
  *
- * @param cgrp The cgroup to load. Only it's name is used, everything else
+ * @param cgrp The cgroup to load. Only its name is used, everything else
  *	is replaced.
  */
 int cgroup_get_cgroup(struct cgroup *cgrp);

--- a/include/libcgroup/log.h
+++ b/include/libcgroup/log.h
@@ -134,14 +134,14 @@ extern void cgroup_set_loglevel(int loglevel);
 
 /**
  * Retrieve the current loglevel.
- * @return the current loglevel from with libcgroup
+ * @return The current loglevel from libcgroup.
  */
 extern int cgroup_get_loglevel(void);
 
 /**
  * Libcgroup log function. This is for applications which are too lazy to set
- * up their own complex logging and miss-use libcgroup for that purpose.
- * I.e. this function should be used only by simple command-line tools.
+ * up their own complex logging and misuse libcgroup for that purpose.
+ * i.e. this function should be used only by simple command-line tools.
  * This logging automatically benefits from CGROUP_LOGLEVEL env. variable.
  */
 extern void cgroup_log(int loglevel, const char *fmt, ...);

--- a/include/libcgroup/tasks.h
+++ b/include/libcgroup/tasks.h
@@ -29,7 +29,7 @@ enum cgflags {
 enum cgroup_daemon_type {
 	/**
 	 * The daemon must not touch the given task, i.e. it never moves it
-	 * to any controlgroup.
+	 * to any control group.
 	 */
 	CGROUP_DAEMON_UNCHANGE_CHILDREN       = 0x1,
 	CGROUP_DAEMON_CANCEL_UNCHANGE_PROCESS = 0x2,
@@ -41,8 +41,8 @@ enum cgroup_daemon_type {
  *
  * @name Simple task assignment
  * @{
- * Applications can use following functions to simply put a task into given
- * control group and find a groups where given tasks is.
+ * Applications can use the following functions to put a task into a given
+ * control group and find groups where a given task is.
  */
 
 /**
@@ -76,7 +76,7 @@ int cgroup_change_cgroup_path(const char *path, pid_t pid, const char * const co
  * @param pid The task to find.
  * @param controller The controller (hierarchy), where to find the task.
  * @param current_path The path to control group, where the task has been found.
- *	The patch is relative to the root of the hierarchy. The caller must
+ *	The path is relative to the root of the hierarchy. The caller must
  *	free this memory.
  */
 int cgroup_get_current_controller_path(pid_t pid, const char *controller, char **current_path);
@@ -92,7 +92,7 @@ int cgroup_get_current_controller_path(pid_t pid, const char *controller, char *
  */
 
 /**
- * Initializes the rules cache and load it from /etc/cgrules.conf.
+ * Initializes the rules cache and loads it from /etc/cgrules.conf.
  * @todo add parameter with the filename?
  */
 int cgroup_init_rules_cache(void);
@@ -123,7 +123,7 @@ void cgroup_print_rules_config(FILE *fp);
 
 /**
  * Changes the cgroup of all running PIDs based on the rules in the config
- * file. If a rules exists for a PID, then the PID is placed in the correct
+ * file. If a rule exists for a PID, then the PID is placed in the correct
  * group.
  *
  * This function may be called after creating new control groups to move
@@ -149,7 +149,7 @@ int cgroup_change_all_cgroups(void);
  * @param procname The PROCESS NAME to match.
  * @param pid The PID of the process to move.
  * @param flags Bit flags to change the behavior, as defined in enum #cgflags.
- * @todo Determine thread-safeness and fix of not safe.
+ * @todo Determine thread safety and fix if not safe.
  */
 int cgroup_change_cgroup_flags(uid_t uid, gid_t gid, const char *procname, pid_t pid, int flags);
 
@@ -164,7 +164,7 @@ int cgroup_change_cgroup_flags(uid_t uid, gid_t gid, const char *procname, pid_t
  * @param gid The GID to match.
  * @param pid The PID of the process to move.
  * @param flags Bit flags to change the behavior, as defined in enum #cgflags.
- * @todo Determine thread-safeness and fix if not safe.
+ * @todo Determine thread safety and fix if not safe.
  */
 int cgroup_change_cgroup_uid_gid_flags(uid_t uid, gid_t gid, pid_t pid, int flags);
 
@@ -192,7 +192,7 @@ int cgroup_change_cgroup_uid_gid(uid_t uid, gid_t gid, pid_t pid);
 /**
  * Register the unchanged process to a cgrulesengd daemon. This process
  * is never moved to another control group by the daemon.
- * If the daemon does not work, this function returns 0 as success.
+ * If the daemon does not work, this function returns 0 (success).
  * @param pid The task id.
  * @param flags Bit flags to change the behavior, as defined in
  *	#cgroup_daemon_type
@@ -200,7 +200,7 @@ int cgroup_change_cgroup_uid_gid(uid_t uid, gid_t gid, pid_t pid);
 int cgroup_register_unchanged_process(pid_t pid, int flags);
 
 /**
- * Move given threads (=thread) to given control group.
+ * Move a given thread (=task) to the given control group.
  * @param cgroup Destination control group.
  * @param tid The task to move.
  */

--- a/src/api.c
+++ b/src/api.c
@@ -54,13 +54,13 @@ const struct cgroup_library_version library_version = {
 };
 
 /*
- * The errno which happened the last time (have to be thread specific)
+ * The errno that occurred last time (has to be thread-specific)
  */
 __thread int last_errno;
 
 #define MAXLEN 256
 
-/* the value have to be thread specific */
+/* The value has to be thread-specific. */
 static __thread char errtext[MAXLEN];
 
 /* Task command name length */
@@ -998,8 +998,8 @@ finish:
 
 /**
  * Parse CGRULES_CONF_FILE and all files in CGRULES_CONF_FILE_DIR.
- * If CGRULES_CONF_FILE_DIR does not exists or can not be read, parse only
- * CGRULES_CONF_FILE. This way we keep the back compatibility.
+ * If CGRULES_CONF_FILE_DIR does not exist or cannot be read, parse only
+ * CGRULES_CONF_FILE. This way we keep backward compatibility.
  *
  * Original description of this function moved to cgroup_parse_rules_file.
  * Also cloned and all occurrences of file changed to files.
@@ -1016,7 +1016,7 @@ finish:
  * The remaining files are skipped. It will store this rule in trl, as well as
  * any children rules (rules that begin with a %) that it has.
  *
- * Files can be read in an random order so the first match must not be
+ * Files can be read in a random order so the first match must not be
  * dependent on it. Thus construct the rules the way not to break this
  * assumption.
  *
@@ -1053,7 +1053,7 @@ static int cgroup_parse_rules(bool cache, uid_t muid, gid_t mgid, const char *mp
 
 	pthread_rwlock_wrlock(&rl_lock);
 
-	/* Parse CGRULES_CONF_FILE configuration file (back compatibility). */
+	/* Parse CGRULES_CONF_FILE configuration file (backward compatibility). */
 	ret = cgroup_parse_rules_file(CGRULES_CONF_FILE, cache, muid, mgid, mprocname);
 
 	/*
@@ -1111,7 +1111,7 @@ static int cgroup_parse_rules(bool cache, uid_t muid, gid_t mgid, const char *mp
 			cgroup_warn("cannot read %s: %s\n", dirname, strerror(errno));
 			/*
 			 * Cannot read an item.
-			 * But continue for back compatibility as a success.
+			 * But continue for backward compatibility as a success.
 			 */
 			ret = 0;
 			goto unlock_list;
@@ -3426,7 +3426,7 @@ static int cg_move_task_files(FILE *input_tasks, FILE *output_tasks)
  *	processes should be moved.
  * @param flags Flag indicating whether the errors from task
  *	migration should be ignored (CGROUP_DELETE_IGNORE_MIGRATION) or not (0).
- * @returns 0 on success, >0 on error.
+ * @return 0 on success, >0 on error.
  */
 static int cg_delete_cgrp_controller(char *cgrp_name, char *controller, FILE *target_tasks,
 				     int flags)
@@ -4411,7 +4411,7 @@ static struct cgroup_rule *cgroup_find_matching_rule_uid_gid(uid_t uid, gid_t gi
  *	@param gid The GID to match
  *	@param procname The PROCESS NAME to match
  *	@return Pointer to the first matching rule, or NULL if no match
- * TODO: Determine thread-safeness and fix if not safe.
+ * TODO: Determine thread safety and fix if not safe.
  */
 static struct cgroup_rule *cgroup_find_matching_rule(uid_t uid, gid_t gid, pid_t pid,
 						     const char *procname)
@@ -4680,9 +4680,9 @@ int cgroup_change_cgroup_flags(uid_t uid, gid_t gid, const char *procname, pid_t
 	}
 
 	/*
-	 * User had asked to find the matching rule (if one exist) in the
+	 * The user asked to find the matching rule (if one exists) in the
 	 * cached rules but the list might be empty due to the inactive
-	 * cgrulesengd. Lets emulate its behaviour of caching the rules by
+	 * cgrulesengd. Let's emulate its behavior of caching the rules by
 	 * reloading the rules from the configuration file.
 	 */
 	if ((flags & CGFLAG_USECACHE) && (rl.head == NULL)) {
@@ -4954,7 +4954,7 @@ finished:
 
 /**
  * Changes the cgroup of all running PIDs based on the rules in the config file.
- * If a rules exists for a PID, then the PID is placed in the correct group.
+ * If a rule exists for a PID, then the PID is placed in the correct group.
  *
  * This function may be called after creating new control groups to move
  * running PIDs into the newly created control groups.
@@ -6184,7 +6184,7 @@ int cgroup_register_unchanged_process(pid_t pid, int flags)
 
 	if (connect(sk, (struct sockaddr *)&addr,
 	    sizeof(addr.sun_family) + strlen(CGRULE_CGRED_SOCKET_PATH)) < 0) {
-		/* If the daemon does not work, this function returns 0 as success. */
+		/* If the daemon does not work, this function returns 0 (success). */
 		ret = 0;
 		goto close;
 	}


### PR DESCRIPTION
This series cleans up spelling mistakes and grammar issues across
various headers and source files in the project. The changes are
purely cosmetic and improve readability and consistency of comments
and documentation. There are no functional changes.

The updates include:
  - Fixing typos in header guards and comments
  - Improving grammar in function descriptions and enum comments
  - General spelling and wording fixes across multiple files

Patches are grouped per file to keep the changes easy to review.