### PR TITLE
fix potential template_table realloc mem leak

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1809,13 +1809,16 @@ int cgroup_add_cgroup_templates(int offset)
  */
 int cgroup_expand_template_table(void)
 {
+	struct cgroup *new_template_table;
 	int i;
 
-	template_table = realloc(template_table,
+	new_template_table = realloc(template_table,
 				 (template_table_index + config_template_table_index)
 				 *sizeof(struct cgroup));
-	if (template_table == NULL)
+	if (new_template_table == NULL)
 		return -ECGOTHER;
+
+	template_table = new_template_table;
 
 	for (i = 0; i < config_template_table_index; i++)
 		template_table[i + template_table_index].index = 0;


### PR DESCRIPTION
Hello!

In `cgroup_expand_template_table` `realloc()` leaves the original allocation untouched on failure, but the current code overwrites the only pointer to the existing `template_table` with `NULL`. This leaks the old cache and leaves global template state in an inconsistent state.

Store the result in a temporary pointer and only update `template_table` after a successful reallocation.

Found by Linux Verification Center (linuxtesting.org) with SVACE.