### PR TITLE
src/libcgroup-internal: drop dirent/mntent includes

### DIFF
--- a/src/libcgroup-internal.h
+++ b/src/libcgroup-internal.h
@@ -18,14 +18,15 @@ extern "C" {
 #include <libcgroup.h>
 
 #include <pthread.h>
-#include <dirent.h>
 #include <limits.h>
-#include <mntent.h>
 #include <setjmp.h>
 #include <fts.h>
 
 #include <sys/stat.h>
 #include <sys/types.h>
+
+struct dirent;
+struct mntent;
 
 #define MAX_MNT_ELEMENTS	17	/* Maximum number of mount points/controllers */
 #define MAX_GROUP_ELEMENTS	128	/* Estimated number of groups created */


### PR DESCRIPTION
src/libcgroup-internal.h includes <dirent.h> and <mntent.h>, but only uses pointer
types in function declarations.

Replace the heavy includes with forward declarations:
- add struct dirent;
- add struct mntent;
- remove <dirent.h> and <mntent.h> from the internal header

This trims transitive header dependencies and reduces compile noise, with no
functional change.

Build tested with:
  make -j4