### PR TITLE
abstraction/tests: preserve cpu burst mappings across v1<->v2 conversion

### DIFF
--- a/src/abstraction-map.c
+++ b/src/abstraction-map.c
@@ -25,6 +25,8 @@ const struct cgroup_abstraction_map cgroup_v1_to_v2_map[] = {
 	{cgroup_convert_cpu_quota_to_max, "cpu.cfs_quota_us", NULL, "cpu.max", NULL},
 	{cgroup_convert_cpu_period_to_max, "cpu.cfs_period_us", NULL, "cpu.max", NULL},
 	{cgroup_convert_passthrough, "cpu.idle", NULL, "cpu.idle", NULL},
+	{cgroup_convert_passthrough, "cpu.uclamp.min", NULL, "cpu.uclamp.min", NULL},
+	{cgroup_convert_passthrough, "cpu.uclamp.max", NULL, "cpu.uclamp.max", NULL},
 	{cgroup_convert_unmappable, "cpu.stat", NULL, "cpu.stat", NULL},
 
 	/* cpuset controller */
@@ -59,6 +61,8 @@ const struct cgroup_abstraction_map cgroup_v2_to_v1_map[] = {
 	{cgroup_convert_cpu_max_to_quota, "cpu.max", NULL, "cpu.cfs_quota_us", NULL},
 	{cgroup_convert_cpu_max_to_period, "cpu.max", NULL, "cpu.cfs_period_us", NULL},
 	{cgroup_convert_passthrough, "cpu.idle", NULL, "cpu.idle", NULL},
+	{cgroup_convert_passthrough, "cpu.uclamp.min", NULL, "cpu.uclamp.min", NULL},
+	{cgroup_convert_passthrough, "cpu.uclamp.max", NULL, "cpu.uclamp.max", NULL},
 	{cgroup_convert_unmappable, "cpu.stat", NULL, "cpu.stat", NULL},
 
 	/* cpuset controller */

--- a/src/abstraction-map.c
+++ b/src/abstraction-map.c
@@ -24,6 +24,7 @@ const struct cgroup_abstraction_map cgroup_v1_to_v2_map[] = {
 	{cgroup_convert_name_only, "cpu.cfs_burst_us", NULL, "cpu.max.burst", NULL},
 	{cgroup_convert_cpu_quota_to_max, "cpu.cfs_quota_us", NULL, "cpu.max", NULL},
 	{cgroup_convert_cpu_period_to_max, "cpu.cfs_period_us", NULL, "cpu.max", NULL},
+	{cgroup_convert_passthrough, "cpu.idle", NULL, "cpu.idle", NULL},
 	{cgroup_convert_unmappable, "cpu.stat", NULL, "cpu.stat", NULL},
 
 	/* cpuset controller */
@@ -57,6 +58,7 @@ const struct cgroup_abstraction_map cgroup_v2_to_v1_map[] = {
 	{cgroup_convert_name_only, "cpu.max.burst", NULL, "cpu.cfs_burst_us", NULL},
 	{cgroup_convert_cpu_max_to_quota, "cpu.max", NULL, "cpu.cfs_quota_us", NULL},
 	{cgroup_convert_cpu_max_to_period, "cpu.max", NULL, "cpu.cfs_period_us", NULL},
+	{cgroup_convert_passthrough, "cpu.idle", NULL, "cpu.idle", NULL},
 	{cgroup_convert_unmappable, "cpu.stat", NULL, "cpu.stat", NULL},
 
 	/* cpuset controller */

--- a/src/abstraction-map.c
+++ b/src/abstraction-map.c
@@ -21,6 +21,7 @@
 const struct cgroup_abstraction_map cgroup_v1_to_v2_map[] = {
 	/* cpu controller */
 	{cgroup_convert_int, "cpu.shares", (void *)1024, "cpu.weight", (void *)100},
+	{cgroup_convert_name_only, "cpu.cfs_burst_us", NULL, "cpu.max.burst", NULL},
 	{cgroup_convert_cpu_quota_to_max, "cpu.cfs_quota_us", NULL, "cpu.max", NULL},
 	{cgroup_convert_cpu_period_to_max, "cpu.cfs_period_us", NULL, "cpu.max", NULL},
 	{cgroup_convert_unmappable, "cpu.stat", NULL, "cpu.stat", NULL},
@@ -53,6 +54,7 @@ const int cgroup_v1_to_v2_map_sz = ARRAY_SIZE(cgroup_v1_to_v2_map);
 const struct cgroup_abstraction_map cgroup_v2_to_v1_map[] = {
 	/* cpu controller */
 	{cgroup_convert_int, "cpu.weight", (void *)100, "cpu.shares", (void *)1024},
+	{cgroup_convert_name_only, "cpu.max.burst", NULL, "cpu.cfs_burst_us", NULL},
 	{cgroup_convert_cpu_max_to_quota, "cpu.max", NULL, "cpu.cfs_quota_us", NULL},
 	{cgroup_convert_cpu_max_to_period, "cpu.max", NULL, "cpu.cfs_period_us", NULL},
 	{cgroup_convert_unmappable, "cpu.stat", NULL, "cpu.stat", NULL},

--- a/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
+++ b/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
@@ -29,7 +29,7 @@ CGRP_VER_V1 = CgroupVersion.CGROUP_V1
 CGRP_VER_V2 = CgroupVersion.CGROUP_V2
 
 TABLE = [
-    # writesetting, writeval, writever, readsetting, readval, readver
+    # writesetting, writeval, writever, readsetting, readval, readver, optional
     ['cpu.shares', '512', CGRP_VER_V1, 'cpu.shares', '512', CGRP_VER_V1],
     ['cpu.shares', '512', CGRP_VER_V1, 'cpu.weight', '50',  CGRP_VER_V2],
 
@@ -59,7 +59,27 @@ TABLE = [
      'cpu.max',          'max 40000', CGRP_VER_V2],
     ['cpu.max',          'max 41000', CGRP_VER_V2,
      'cpu.cfs_quota_us', '-1',        CGRP_VER_V1],
+
+    ['cpu.cfs_burst_us', '5000', CGRP_VER_V1,
+     'cpu.cfs_burst_us', '5000', CGRP_VER_V1, True],
+    ['cpu.cfs_burst_us', '6000', CGRP_VER_V1,
+     'cpu.max.burst',    '6000', CGRP_VER_V2, True],
+    ['cpu.max.burst',    '7000', CGRP_VER_V2,
+     'cpu.max.burst',    '7000', CGRP_VER_V2, True],
+    ['cpu.max.burst',    '8000', CGRP_VER_V2,
+     'cpu.cfs_burst_us', '8000', CGRP_VER_V1, True],
 ]
+
+
+def _is_optional_unsupported(error):
+    unsupported_tokens = [
+        'requested group parameter does not exist',
+        'No such file or directory',
+        'Invalid argument',
+    ]
+
+    stderr = error.stderr or ''
+    return any(token in stderr for token in unsupported_tokens)
 
 
 def prereqs(config):
@@ -117,12 +137,19 @@ def test(config):
     cgrps = {SYSTEMD_CGNAME: False, OTHER_CGNAME: True}
     for i in cgrps:
         for entry in TABLE:
-            Cgroup.xset(config, cgname=i, setting=entry[0], value=entry[1],
-                        version=entry[2], ignore_systemd=cgrps[i])
+            optional = len(entry) > 6 and entry[6]
+            try:
+                Cgroup.xset(config, cgname=i, setting=entry[0], value=entry[1],
+                            version=entry[2], ignore_systemd=cgrps[i])
 
-            out = Cgroup.xget(config, cgname=i, setting=entry[3],
-                              version=entry[5], values_only=True,
-                              print_headers=False, ignore_systemd=cgrps[i])
+                out = Cgroup.xget(config, cgname=i, setting=entry[3],
+                                  version=entry[5], values_only=True,
+                                  print_headers=False, ignore_systemd=cgrps[i])
+            except RunError as re:
+                if optional and _is_optional_unsupported(re):
+                    continue
+                raise
+
             if out != entry[4]:
                 result = consts.TEST_FAILED
                 tmp_cause = (

--- a/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
+++ b/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
@@ -68,6 +68,15 @@ TABLE = [
      'cpu.max.burst',    '7000', CGRP_VER_V2, True],
     ['cpu.max.burst',    '8000', CGRP_VER_V2,
      'cpu.cfs_burst_us', '8000', CGRP_VER_V1, True],
+
+    ['cpu.idle', '1', CGRP_VER_V1,
+     'cpu.idle', '1', CGRP_VER_V1, True],
+    ['cpu.idle', '0', CGRP_VER_V1,
+     'cpu.idle', '0', CGRP_VER_V2, True],
+    ['cpu.idle', '1', CGRP_VER_V2,
+     'cpu.idle', '1', CGRP_VER_V2, True],
+    ['cpu.idle', '0', CGRP_VER_V2,
+     'cpu.idle', '0', CGRP_VER_V1, True],
 ]
 
 

--- a/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
+++ b/tests/ftests/069-sudo-systemd_cgxget-cpu-settings-v1.py
@@ -77,6 +77,19 @@ TABLE = [
      'cpu.idle', '1', CGRP_VER_V2, True],
     ['cpu.idle', '0', CGRP_VER_V2,
      'cpu.idle', '0', CGRP_VER_V1, True],
+
+    ['cpu.uclamp.min', '50.00', CGRP_VER_V1,
+     'cpu.uclamp.min', '50.00', CGRP_VER_V1, True],
+    ['cpu.uclamp.min', '60.00', CGRP_VER_V1,
+     'cpu.uclamp.min', '60.00', CGRP_VER_V2, True],
+    ['cpu.uclamp.min', '70.00', CGRP_VER_V2,
+     'cpu.uclamp.min', '70.00', CGRP_VER_V1, True],
+    ['cpu.uclamp.max', '90.00', CGRP_VER_V1,
+     'cpu.uclamp.max', '90.00', CGRP_VER_V1, True],
+    ['cpu.uclamp.max', '80.00', CGRP_VER_V1,
+     'cpu.uclamp.max', '80.00', CGRP_VER_V2, True],
+    ['cpu.uclamp.max', '70.00', CGRP_VER_V2,
+     'cpu.uclamp.max', '70.00', CGRP_VER_V1, True],
 ]
 
 

--- a/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
+++ b/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
@@ -68,6 +68,15 @@ TABLE = [
      'cpu.max.burst',    '7000', CGRP_VER_V2, True],
     ['cpu.max.burst',    '8000', CGRP_VER_V2,
      'cpu.cfs_burst_us', '8000', CGRP_VER_V1, True],
+
+    ['cpu.idle', '1', CGRP_VER_V1,
+     'cpu.idle', '1', CGRP_VER_V1, True],
+    ['cpu.idle', '0', CGRP_VER_V1,
+     'cpu.idle', '0', CGRP_VER_V2, True],
+    ['cpu.idle', '1', CGRP_VER_V2,
+     'cpu.idle', '1', CGRP_VER_V2, True],
+    ['cpu.idle', '0', CGRP_VER_V2,
+     'cpu.idle', '0', CGRP_VER_V1, True],
 ]
 
 

--- a/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
+++ b/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
@@ -77,6 +77,19 @@ TABLE = [
      'cpu.idle', '1', CGRP_VER_V2, True],
     ['cpu.idle', '0', CGRP_VER_V2,
      'cpu.idle', '0', CGRP_VER_V1, True],
+
+    ['cpu.uclamp.min', '50.00', CGRP_VER_V1,
+     'cpu.uclamp.min', '50.00', CGRP_VER_V1, True],
+    ['cpu.uclamp.min', '60.00', CGRP_VER_V1,
+     'cpu.uclamp.min', '60.00', CGRP_VER_V2, True],
+    ['cpu.uclamp.min', '70.00', CGRP_VER_V2,
+     'cpu.uclamp.min', '70.00', CGRP_VER_V1, True],
+    ['cpu.uclamp.max', '90.00', CGRP_VER_V1,
+     'cpu.uclamp.max', '90.00', CGRP_VER_V1, True],
+    ['cpu.uclamp.max', '80.00', CGRP_VER_V1,
+     'cpu.uclamp.max', '80.00', CGRP_VER_V2, True],
+    ['cpu.uclamp.max', '70.00', CGRP_VER_V2,
+     'cpu.uclamp.max', '70.00', CGRP_VER_V1, True],
 ]
 
 

--- a/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
+++ b/tests/ftests/070-sudo-systemd_cgxget-cpu-settings-v2.py
@@ -29,7 +29,7 @@ CGRP_VER_V1 = CgroupVersion.CGROUP_V1
 CGRP_VER_V2 = CgroupVersion.CGROUP_V2
 
 TABLE = [
-    # writesetting, writeval, writever, readsetting, readval, readver
+    # writesetting, writeval, writever, readsetting, readval, readver, optional
     ['cpu.shares', '512', CGRP_VER_V1, 'cpu.shares', '512', CGRP_VER_V1],
     ['cpu.shares', '512', CGRP_VER_V1, 'cpu.weight', '50',  CGRP_VER_V2],
 
@@ -59,7 +59,27 @@ TABLE = [
      'cpu.max',          'max 40000', CGRP_VER_V2],
     ['cpu.max',          'max 41000', CGRP_VER_V2,
      'cpu.cfs_quota_us', '-1',        CGRP_VER_V1],
+
+    ['cpu.cfs_burst_us', '5000', CGRP_VER_V1,
+     'cpu.cfs_burst_us', '5000', CGRP_VER_V1, True],
+    ['cpu.cfs_burst_us', '6000', CGRP_VER_V1,
+     'cpu.max.burst',    '6000', CGRP_VER_V2, True],
+    ['cpu.max.burst',    '7000', CGRP_VER_V2,
+     'cpu.max.burst',    '7000', CGRP_VER_V2, True],
+    ['cpu.max.burst',    '8000', CGRP_VER_V2,
+     'cpu.cfs_burst_us', '8000', CGRP_VER_V1, True],
 ]
+
+
+def _is_optional_unsupported(error):
+    unsupported_tokens = [
+        'requested group parameter does not exist',
+        'No such file or directory',
+        'Invalid argument',
+    ]
+
+    stderr = error.stderr or ''
+    return any(token in stderr for token in unsupported_tokens)
 
 
 def prereqs(config):
@@ -128,12 +148,19 @@ def test(config):
     cgrps = {SYSTEMD_CGNAME: False, OTHER_CGNAME: True}
     for i in cgrps:
         for entry in TABLE:
-            Cgroup.xset(config, cgname=i, setting=entry[0], value=entry[1],
-                        version=entry[2], ignore_systemd=cgrps[i])
+            optional = len(entry) > 6 and entry[6]
+            try:
+                Cgroup.xset(config, cgname=i, setting=entry[0], value=entry[1],
+                            version=entry[2], ignore_systemd=cgrps[i])
 
-            out = Cgroup.xget(config, cgname=i, setting=entry[3],
-                              version=entry[5], values_only=True,
-                              print_headers=False, ignore_systemd=cgrps[i])
+                out = Cgroup.xget(config, cgname=i, setting=entry[3],
+                                  version=entry[5], values_only=True,
+                                  print_headers=False, ignore_systemd=cgrps[i])
+            except RunError as re:
+                if optional and _is_optional_unsupported(re):
+                    continue
+                raise
+
             if out != entry[4]:
                 result = consts.TEST_FAILED
                 tmp_cause = (


### PR DESCRIPTION
This series preserves CPU burst settings across cgroup v1<->v2 conversion.

Patch 1 adds symmetric abstraction mappings:
```
cpu.cfs_burst_us -> cpu.max.burst
cpu.max.burst -> cpu.cfs_burst_us
```
Patch 2 extends ftests `069/070` to validate both directions. The mapping
is name-only (no scaling), since both settings represent CFS burst runtime
in microseconds. Tests mark burst rows optional so older kernels without
burst files are skipped cleanly.